### PR TITLE
feat(component): Add `alt` attribute to `Avatar`s

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -12,5 +12,6 @@ const Template: Story<AvatarProps> = (args) => <Avatar {...args} />;
 export const DefaultAvatar = Template.bind({});
 DefaultAvatar.storyName = 'Default';
 DefaultAvatar.args = {
+  alt: 'Your avatar',
   img: 'https://flowbite.com/docs/images/people/profile-picture-5.jpg',
 };

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -4,6 +4,7 @@ import { AvatarGroup } from './AvatarGroup';
 import { AvatarGroupCounter } from './AvatarGroupCounter';
 
 export type AvatarProps = PropsWithChildren<{
+  alt?: string;
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   rounded?: boolean;
   bordered?: boolean;
@@ -36,6 +37,7 @@ const statusPositionClasses: Record<AvatarProps['statusPosition'] & string, stri
 };
 
 const AvatarComponent: FC<AvatarProps> = ({
+  alt = '',
   img,
   status,
   children,
@@ -57,7 +59,7 @@ const AvatarComponent: FC<AvatarProps> = ({
               'p-1': bordered,
             })}
             src={img}
-            alt="Rounded avatar"
+            alt={alt}
           />
         ) : (
           <div

--- a/src/pages/AvatarPage.tsx
+++ b/src/pages/AvatarPage.tsx
@@ -121,6 +121,16 @@ const AvatarPage: FC = () => {
         </div>
       ),
     },
+    {
+      title: 'Alternative text',
+      code: (
+        <Avatar
+          alt="Default avatar with alt text"
+          img="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
+          rounded
+        />
+      ),
+    },
   ];
 
   return <DemoPage examples={examples} />;


### PR DESCRIPTION
Allows `Avatar`s to pass `alt` text to the underlying `<img/>`.

Now, by default, `Avatar`s will have `alt=""`, which browsers interpret appropriately as
[decorative images](https://www.w3.org/WAI/tutorials/images/decorative/).

To add `alt` text to your `Avatar`:

```js
<AvatarComponent
  alt="Default avatar with alt text"
  img="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
/>
```