### PR TITLE
feat(component): Add `imgAlt` attribute to `Card`s 

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -2,13 +2,13 @@ import { FC, PropsWithChildren } from 'react';
 import classNames from 'classnames';
 
 export type CardProps = PropsWithChildren<{
-  alt?: string;
   className?: string;
   horizontal?: boolean;
+  imgAlt?: string;
   imgSrc?: string;
 }>;
 
-export const Card: FC<CardProps> = ({ alt, children, className, horizontal, imgSrc }) => {
+export const Card: FC<CardProps> = ({ imgAlt, children, className, horizontal, imgSrc }) => {
   return (
     <div
       className={classNames(
@@ -27,7 +27,7 @@ export const Card: FC<CardProps> = ({ alt, children, className, horizontal, imgS
             'h-96 w-full rounded-t-lg object-cover md:h-auto md:w-48 md:rounded-none md:rounded-l-lg': horizontal,
           })}
           src={imgSrc}
-          alt={alt ?? ''}
+          alt={imgAlt ?? ''}
         />
       )}
       <div className="flex h-full flex-col justify-center gap-4 p-6">{children}</div>

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -8,7 +8,7 @@ export type CardProps = PropsWithChildren<{
   imgSrc?: string;
 }>;
 
-export const Card: FC<CardProps> = ({ imgAlt, children, className, horizontal, imgSrc }) => {
+export const Card: FC<CardProps> = ({ children, className, horizontal, imgAlt, imgSrc }) => {
   return (
     <div
       className={classNames(

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -2,12 +2,13 @@ import { FC, PropsWithChildren } from 'react';
 import classNames from 'classnames';
 
 export type CardProps = PropsWithChildren<{
+  alt?: string;
   className?: string;
   horizontal?: boolean;
   imgSrc?: string;
 }>;
 
-export const Card: FC<CardProps> = ({ children, className, horizontal, imgSrc }) => {
+export const Card: FC<CardProps> = ({ alt, children, className, horizontal, imgSrc }) => {
   return (
     <div
       className={classNames(
@@ -26,7 +27,7 @@ export const Card: FC<CardProps> = ({ children, className, horizontal, imgSrc })
             'h-96 w-full rounded-t-lg object-cover md:h-auto md:w-48 md:rounded-none md:rounded-l-lg': horizontal,
           })}
           src={imgSrc}
-          alt=""
+          alt={alt ?? ''}
         />
       )}
       <div className="flex h-full flex-col justify-center gap-4 p-6">{children}</div>

--- a/src/pages/CardPage.tsx
+++ b/src/pages/CardPage.tsx
@@ -20,9 +20,27 @@ const CardPage: FC = () => {
       codeClassName: 'dark:!bg-gray-900',
     },
     {
-      title: 'Card with image',
+      title: 'Card with decorative image',
       code: (
         <Card className="max-w-sm" imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg">
+          <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+            Noteworthy technology acquisitions 2021
+          </h5>
+          <p className="font-normal text-gray-700 dark:text-gray-400">
+            Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
+          </p>
+        </Card>
+      ),
+      codeClassName: 'dark:!bg-gray-900',
+    },
+    {
+      title: 'Card with image with alt text',
+      code: (
+        <Card
+          className="max-w-sm"
+          imgAlt="Meaningful alt text for an image that is not purely decorative"
+          imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg"
+        >
           <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
             Noteworthy technology acquisitions 2021
           </h5>


### PR DESCRIPTION
Allows `Card`s to pass `imgAlt` to provide `alt` text to the underlying `<img/>`, when an `imgSrc` has also been provided.

Now, by default, `Card`s with an image will have `alt=""`, which browsers interpret appropriately as [decorative images](https://www.w3.org/WAI/tutorials/images/decorative/).

To add `alt` text to your `Card` with an image:

```js
<Card
  imgAlt="Meaningful alt text for an image that is not purely decorative"
  imgSrc="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
>
  ..
</Card>
```

Also renames the existing `Card with image` example to `Card with decorative image` to more clearly indicate `alt` text *should* be provided if the image is *not* purely decorative.