### PR TITLE
feat(route): Add `Sidebar` examples page & stories, resolving #53 #56

### DIFF
--- a/src/docs/pages/SidebarPage.tsx
+++ b/src/docs/pages/SidebarPage.tsx
@@ -1,0 +1,219 @@
+import { FC } from 'react';
+import { BiBuoy } from 'react-icons/bi';
+import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, HiViewBoards } from 'react-icons/hi';
+import { Sidebar } from '../components';
+import { CodeExample, DemoPage } from './DemoPage';
+
+const SidebarPage: FC = () => {
+  const examples: CodeExample[] = [
+    {
+      title: 'Default sidebar',
+      code: (
+        <Sidebar collapsed={false}>
+          <Sidebar.Items>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Dashboard
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="gray">
+                Kanban
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiInbox} label="3">
+                Inbox
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiUser}>
+                Users
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiShoppingBag}>
+                Products
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                Sign In
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiTable}>
+                Sign Up
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+          </Sidebar.Items>
+        </Sidebar>
+      ),
+    },
+    {
+      title: 'Multi-level dropdown',
+      code: (
+        <Sidebar collapsed={false}>
+          <Sidebar.Items>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Dashboard
+              </Sidebar.Item>
+              <Sidebar.Collapse icon={HiShoppingBag} label="E-commerce">
+                <Sidebar.Item href="#">Products</Sidebar.Item>
+              </Sidebar.Collapse>
+              <Sidebar.Item href="#" icon={HiInbox}>
+                Inbox
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiUser}>
+                Users
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiShoppingBag}>
+                Products
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                Sign In
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiTable}>
+                Sign Up
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+          </Sidebar.Items>
+        </Sidebar>
+      ),
+    },
+    {
+      title: 'Content separator',
+      code: (
+        <Sidebar collapsed={false}>
+          <Sidebar.Items>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Dashboard
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiViewBoards}>
+                Kanban
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiInbox}>
+                Inbox
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiUser}>
+                Users
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiShoppingBag}>
+                Products
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                Sign In
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiTable}>
+                Sign Up
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Upgrade to Pro
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiViewBoards}>
+                Documentation
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={BiBuoy}>
+                Help
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+          </Sidebar.Items>
+        </Sidebar>
+      ),
+    },
+    {
+      title: 'CTA button',
+      code: (
+        <Sidebar collapsed={false}>
+          <Sidebar.Items>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Dashboard
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiViewBoards}>
+                Kanban
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiInbox}>
+                Inbox
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiUser}>
+                Users
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiShoppingBag}>
+                Products
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                Sign In
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiTable}>
+                Sign Up
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+          </Sidebar.Items>
+          <Sidebar.CTA>
+            <div className="mb-3 flex items-center">
+              <span className="mr-2 rounded bg-orange-100 px-2.5 py-0.5 text-sm font-semibold text-orange-800 dark:bg-orange-200 dark:text-orange-900">
+                Beta
+              </span>
+              <button
+                type="button"
+                className="-mx-1.5 -my-1.5 ml-auto inline-flex h-6 w-6 rounded-lg bg-blue-50 p-1 text-blue-900 hover:bg-blue-200 focus:ring-2 focus:ring-blue-400 dark:bg-blue-900 dark:text-blue-400 dark:hover:bg-blue-800"
+                data-collapse-toggle="dropdown-cta"
+                aria-label="Close"
+              >
+                <span className="sr-only">Close</span>
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    fillRule="evenodd"
+                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  ></path>
+                </svg>
+              </button>
+            </div>
+            <p className="mb-3 text-sm text-blue-900 dark:text-blue-400">
+              Preview the new Flowbite dashboard navigation! You can turn the new navigation off for a limited time in
+              your profile.
+            </p>
+            <a
+              className="text-sm text-blue-900 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+              href="#"
+            >
+              Turn new navigation off
+            </a>
+          </Sidebar.CTA>
+        </Sidebar>
+      ),
+    },
+    {
+      title: 'Logo branding',
+      code: (
+        <Sidebar collapsed={false}>
+          <Sidebar.Logo href="#" img="logo192.png" imgAlt="Flowbite logo">
+            Flowbite
+          </Sidebar.Logo>
+          <Sidebar.Items>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Dashboard
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiViewBoards}>
+                Kanban
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiInbox}>
+                Inbox
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiUser}>
+                Users
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiShoppingBag}>
+                Products
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                Sign In
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiTable}>
+                Sign Up
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+          </Sidebar.Items>
+        </Sidebar>
+      ),
+    },
+  ];
+  return <DemoPage examples={examples} />;
+};
+
+export default SidebarPage;

--- a/src/docs/pages/SidebarPage.tsx
+++ b/src/docs/pages/SidebarPage.tsx
@@ -4,223 +4,213 @@ import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, Hi
 import { Sidebar } from '../components';
 import { CodeExample, DemoPage } from './DemoPage';
 
-export const DefaultSidebarComponent = () => (
-  <Sidebar collapsed={false}>
-    <Sidebar.Items>
-      <Sidebar.ItemGroup>
-        <Sidebar.Item href="#" icon={HiChartPie}>
-          Dashboard
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="gray">
-          Kanban
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiInbox} label="3">
-          Inbox
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiUser}>
-          Users
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiShoppingBag}>
-          Products
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiArrowSmRight}>
-          Sign In
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiTable}>
-          Sign Up
-        </Sidebar.Item>
-      </Sidebar.ItemGroup>
-    </Sidebar.Items>
-  </Sidebar>
-);
-
-export const DropdownSidebarComponent = () => (
-  <Sidebar collapsed={false}>
-    <Sidebar.Items>
-      <Sidebar.ItemGroup>
-        <Sidebar.Item href="#" icon={HiChartPie}>
-          Dashboard
-        </Sidebar.Item>
-        <Sidebar.Collapse icon={HiShoppingBag} label="E-commerce">
-          <Sidebar.Item href="#">Products</Sidebar.Item>
-        </Sidebar.Collapse>
-        <Sidebar.Item href="#" icon={HiInbox}>
-          Inbox
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiUser}>
-          Users
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiShoppingBag}>
-          Products
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiArrowSmRight}>
-          Sign In
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiTable}>
-          Sign Up
-        </Sidebar.Item>
-      </Sidebar.ItemGroup>
-    </Sidebar.Items>
-  </Sidebar>
-);
-
-export const SeparatorSidebarComponent = () => (
-  <Sidebar collapsed={false}>
-    <Sidebar.Items>
-      <Sidebar.ItemGroup>
-        <Sidebar.Item href="#" icon={HiChartPie}>
-          Dashboard
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiViewBoards}>
-          Kanban
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiInbox}>
-          Inbox
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiUser}>
-          Users
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiShoppingBag}>
-          Products
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiArrowSmRight}>
-          Sign In
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiTable}>
-          Sign Up
-        </Sidebar.Item>
-      </Sidebar.ItemGroup>
-      <Sidebar.ItemGroup>
-        <Sidebar.Item href="#" icon={HiChartPie}>
-          Upgrade to Pro
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiViewBoards}>
-          Documentation
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={BiBuoy}>
-          Help
-        </Sidebar.Item>
-      </Sidebar.ItemGroup>
-    </Sidebar.Items>
-  </Sidebar>
-);
-
-export const CTASidebarComponent = () => (
-  <Sidebar collapsed={false}>
-    <Sidebar.Items>
-      <Sidebar.ItemGroup>
-        <Sidebar.Item href="#" icon={HiChartPie}>
-          Dashboard
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiViewBoards}>
-          Kanban
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiInbox}>
-          Inbox
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiUser}>
-          Users
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiShoppingBag}>
-          Products
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiArrowSmRight}>
-          Sign In
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiTable}>
-          Sign Up
-        </Sidebar.Item>
-      </Sidebar.ItemGroup>
-    </Sidebar.Items>
-    <Sidebar.CTA>
-      <div className="mb-3 flex items-center">
-        <span className="mr-2 rounded bg-orange-100 px-2.5 py-0.5 text-sm font-semibold text-orange-800 dark:bg-orange-200 dark:text-orange-900">
-          Beta
-        </span>
-        <button
-          type="button"
-          className="-mx-1.5 -my-1.5 ml-auto inline-flex h-6 w-6 rounded-lg bg-blue-50 p-1 text-blue-900 hover:bg-blue-200 focus:ring-2 focus:ring-blue-400 dark:bg-blue-900 dark:text-blue-400 dark:hover:bg-blue-800"
-          data-collapse-toggle="dropdown-cta"
-          aria-label="Close"
-        >
-          <span className="sr-only">Close</span>
-          <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-            <path
-              fillRule="evenodd"
-              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-              clipRule="evenodd"
-            ></path>
-          </svg>
-        </button>
-      </div>
-      <p className="mb-3 text-sm text-blue-900 dark:text-blue-400">
-        Preview the new Flowbite dashboard navigation! You can turn the new navigation off for a limited time in your
-        profile.
-      </p>
-      <a
-        className="text-sm text-blue-900 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-        href="#"
-      >
-        Turn new navigation off
-      </a>
-    </Sidebar.CTA>
-  </Sidebar>
-);
-
-export const LogoSidebarComponent = () => (
-  <Sidebar collapsed={false}>
-    <Sidebar.Logo href="#" img="logo192.png" imgAlt="Flowbite logo">
-      Flowbite
-    </Sidebar.Logo>
-    <Sidebar.Items>
-      <Sidebar.ItemGroup>
-        <Sidebar.Item href="#" icon={HiChartPie}>
-          Dashboard
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiViewBoards}>
-          Kanban
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiInbox}>
-          Inbox
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiUser}>
-          Users
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiShoppingBag}>
-          Products
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiArrowSmRight}>
-          Sign In
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiTable}>
-          Sign Up
-        </Sidebar.Item>
-      </Sidebar.ItemGroup>
-    </Sidebar.Items>
-  </Sidebar>
-);
-
 const SidebarPage: FC = () => {
   const examples: CodeExample[] = [
     {
       title: 'Default sidebar',
-      code: <DefaultSidebarComponent />,
+      code: (
+        <Sidebar collapsed={false}>
+          <Sidebar.Items>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Dashboard
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="gray">
+                Kanban
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiInbox} label="3">
+                Inbox
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiUser}>
+                Users
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiShoppingBag}>
+                Products
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                Sign In
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiTable}>
+                Sign Up
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+          </Sidebar.Items>
+        </Sidebar>
+      ),
     },
     {
       title: 'Multi-level dropdown',
-      code: <DropdownSidebarComponent />,
+      code: (
+        <Sidebar collapsed={false}>
+          <Sidebar.Items>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Dashboard
+              </Sidebar.Item>
+              <Sidebar.Collapse icon={HiShoppingBag} label="E-commerce">
+                <Sidebar.Item href="#">Products</Sidebar.Item>
+              </Sidebar.Collapse>
+              <Sidebar.Item href="#" icon={HiInbox}>
+                Inbox
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiUser}>
+                Users
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiShoppingBag}>
+                Products
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                Sign In
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiTable}>
+                Sign Up
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+          </Sidebar.Items>
+        </Sidebar>
+      ),
     },
     {
       title: 'Content separator',
-      code: <SeparatorSidebarComponent />,
+      code: (
+        <Sidebar collapsed={false}>
+          <Sidebar.Items>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Dashboard
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiViewBoards}>
+                Kanban
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiInbox}>
+                Inbox
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiUser}>
+                Users
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiShoppingBag}>
+                Products
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                Sign In
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiTable}>
+                Sign Up
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Upgrade to Pro
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiViewBoards}>
+                Documentation
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={BiBuoy}>
+                Help
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+          </Sidebar.Items>
+        </Sidebar>
+      ),
     },
     {
       title: 'CTA button',
-      code: <CTASidebarComponent />,
+      code: (
+        <Sidebar collapsed={false}>
+          <Sidebar.Items>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Dashboard
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiViewBoards}>
+                Kanban
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiInbox}>
+                Inbox
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiUser}>
+                Users
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiShoppingBag}>
+                Products
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                Sign In
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiTable}>
+                Sign Up
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+          </Sidebar.Items>
+          <Sidebar.CTA>
+            <div className="mb-3 flex items-center">
+              <span className="mr-2 rounded bg-orange-100 px-2.5 py-0.5 text-sm font-semibold text-orange-800 dark:bg-orange-200 dark:text-orange-900">
+                Beta
+              </span>
+              <button
+                type="button"
+                className="-mx-1.5 -my-1.5 ml-auto inline-flex h-6 w-6 rounded-lg bg-blue-50 p-1 text-blue-900 hover:bg-blue-200 focus:ring-2 focus:ring-blue-400 dark:bg-blue-900 dark:text-blue-400 dark:hover:bg-blue-800"
+                data-collapse-toggle="dropdown-cta"
+                aria-label="Close"
+              >
+                <span className="sr-only">Close</span>
+                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    fillRule="evenodd"
+                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  ></path>
+                </svg>
+              </button>
+            </div>
+            <p className="mb-3 text-sm text-blue-900 dark:text-blue-400">
+              Preview the new Flowbite dashboard navigation! You can turn the new navigation off for a limited time in
+              your profile.
+            </p>
+            <a
+              className="text-sm text-blue-900 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+              href="#"
+            >
+              Turn new navigation off
+            </a>
+          </Sidebar.CTA>
+        </Sidebar>
+      ),
     },
     {
       title: 'Logo branding',
-      code: <LogoSidebarComponent />,
+      code: (
+        <Sidebar collapsed={false}>
+          <Sidebar.Logo href="#" img="logo192.png" imgAlt="Flowbite logo">
+            Flowbite
+          </Sidebar.Logo>
+          <Sidebar.Items>
+            <Sidebar.ItemGroup>
+              <Sidebar.Item href="#" icon={HiChartPie}>
+                Dashboard
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiViewBoards}>
+                Kanban
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiInbox}>
+                Inbox
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiUser}>
+                Users
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiShoppingBag}>
+                Products
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                Sign In
+              </Sidebar.Item>
+              <Sidebar.Item href="#" icon={HiTable}>
+                Sign Up
+              </Sidebar.Item>
+            </Sidebar.ItemGroup>
+          </Sidebar.Items>
+        </Sidebar>
+      ),
     },
   ];
   return <DemoPage examples={examples} />;

--- a/src/docs/pages/SidebarPage.tsx
+++ b/src/docs/pages/SidebarPage.tsx
@@ -4,213 +4,223 @@ import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, Hi
 import { Sidebar } from '../components';
 import { CodeExample, DemoPage } from './DemoPage';
 
+export const DefaultSidebarComponent = () => (
+  <Sidebar collapsed={false}>
+    <Sidebar.Items>
+      <Sidebar.ItemGroup>
+        <Sidebar.Item href="#" icon={HiChartPie}>
+          Dashboard
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="gray">
+          Kanban
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiInbox} label="3">
+          Inbox
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiUser}>
+          Users
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiShoppingBag}>
+          Products
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiArrowSmRight}>
+          Sign In
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiTable}>
+          Sign Up
+        </Sidebar.Item>
+      </Sidebar.ItemGroup>
+    </Sidebar.Items>
+  </Sidebar>
+);
+
+export const DropdownSidebarComponent = () => (
+  <Sidebar collapsed={false}>
+    <Sidebar.Items>
+      <Sidebar.ItemGroup>
+        <Sidebar.Item href="#" icon={HiChartPie}>
+          Dashboard
+        </Sidebar.Item>
+        <Sidebar.Collapse icon={HiShoppingBag} label="E-commerce">
+          <Sidebar.Item href="#">Products</Sidebar.Item>
+        </Sidebar.Collapse>
+        <Sidebar.Item href="#" icon={HiInbox}>
+          Inbox
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiUser}>
+          Users
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiShoppingBag}>
+          Products
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiArrowSmRight}>
+          Sign In
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiTable}>
+          Sign Up
+        </Sidebar.Item>
+      </Sidebar.ItemGroup>
+    </Sidebar.Items>
+  </Sidebar>
+);
+
+export const SeparatorSidebarComponent = () => (
+  <Sidebar collapsed={false}>
+    <Sidebar.Items>
+      <Sidebar.ItemGroup>
+        <Sidebar.Item href="#" icon={HiChartPie}>
+          Dashboard
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiViewBoards}>
+          Kanban
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiInbox}>
+          Inbox
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiUser}>
+          Users
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiShoppingBag}>
+          Products
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiArrowSmRight}>
+          Sign In
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiTable}>
+          Sign Up
+        </Sidebar.Item>
+      </Sidebar.ItemGroup>
+      <Sidebar.ItemGroup>
+        <Sidebar.Item href="#" icon={HiChartPie}>
+          Upgrade to Pro
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiViewBoards}>
+          Documentation
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={BiBuoy}>
+          Help
+        </Sidebar.Item>
+      </Sidebar.ItemGroup>
+    </Sidebar.Items>
+  </Sidebar>
+);
+
+export const CTASidebarComponent = () => (
+  <Sidebar collapsed={false}>
+    <Sidebar.Items>
+      <Sidebar.ItemGroup>
+        <Sidebar.Item href="#" icon={HiChartPie}>
+          Dashboard
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiViewBoards}>
+          Kanban
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiInbox}>
+          Inbox
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiUser}>
+          Users
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiShoppingBag}>
+          Products
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiArrowSmRight}>
+          Sign In
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiTable}>
+          Sign Up
+        </Sidebar.Item>
+      </Sidebar.ItemGroup>
+    </Sidebar.Items>
+    <Sidebar.CTA>
+      <div className="mb-3 flex items-center">
+        <span className="mr-2 rounded bg-orange-100 px-2.5 py-0.5 text-sm font-semibold text-orange-800 dark:bg-orange-200 dark:text-orange-900">
+          Beta
+        </span>
+        <button
+          type="button"
+          className="-mx-1.5 -my-1.5 ml-auto inline-flex h-6 w-6 rounded-lg bg-blue-50 p-1 text-blue-900 hover:bg-blue-200 focus:ring-2 focus:ring-blue-400 dark:bg-blue-900 dark:text-blue-400 dark:hover:bg-blue-800"
+          data-collapse-toggle="dropdown-cta"
+          aria-label="Close"
+        >
+          <span className="sr-only">Close</span>
+          <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+            <path
+              fillRule="evenodd"
+              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+              clipRule="evenodd"
+            ></path>
+          </svg>
+        </button>
+      </div>
+      <p className="mb-3 text-sm text-blue-900 dark:text-blue-400">
+        Preview the new Flowbite dashboard navigation! You can turn the new navigation off for a limited time in your
+        profile.
+      </p>
+      <a
+        className="text-sm text-blue-900 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+        href="#"
+      >
+        Turn new navigation off
+      </a>
+    </Sidebar.CTA>
+  </Sidebar>
+);
+
+export const LogoSidebarComponent = () => (
+  <Sidebar collapsed={false}>
+    <Sidebar.Logo href="#" img="logo192.png" imgAlt="Flowbite logo">
+      Flowbite
+    </Sidebar.Logo>
+    <Sidebar.Items>
+      <Sidebar.ItemGroup>
+        <Sidebar.Item href="#" icon={HiChartPie}>
+          Dashboard
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiViewBoards}>
+          Kanban
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiInbox}>
+          Inbox
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiUser}>
+          Users
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiShoppingBag}>
+          Products
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiArrowSmRight}>
+          Sign In
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiTable}>
+          Sign Up
+        </Sidebar.Item>
+      </Sidebar.ItemGroup>
+    </Sidebar.Items>
+  </Sidebar>
+);
+
 const SidebarPage: FC = () => {
   const examples: CodeExample[] = [
     {
       title: 'Default sidebar',
-      code: (
-        <Sidebar collapsed={false}>
-          <Sidebar.Items>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="gray">
-                Kanban
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiInbox} label="3">
-                Inbox
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiUser}>
-                Users
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiShoppingBag}>
-                Products
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiArrowSmRight}>
-                Sign In
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiTable}>
-                Sign Up
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-          </Sidebar.Items>
-        </Sidebar>
-      ),
+      code: <DefaultSidebarComponent />,
     },
     {
       title: 'Multi-level dropdown',
-      code: (
-        <Sidebar collapsed={false}>
-          <Sidebar.Items>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Collapse icon={HiShoppingBag} label="E-commerce">
-                <Sidebar.Item href="#">Products</Sidebar.Item>
-              </Sidebar.Collapse>
-              <Sidebar.Item href="#" icon={HiInbox}>
-                Inbox
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiUser}>
-                Users
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiShoppingBag}>
-                Products
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiArrowSmRight}>
-                Sign In
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiTable}>
-                Sign Up
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-          </Sidebar.Items>
-        </Sidebar>
-      ),
+      code: <DropdownSidebarComponent />,
     },
     {
       title: 'Content separator',
-      code: (
-        <Sidebar collapsed={false}>
-          <Sidebar.Items>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiViewBoards}>
-                Kanban
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiInbox}>
-                Inbox
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiUser}>
-                Users
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiShoppingBag}>
-                Products
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiArrowSmRight}>
-                Sign In
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiTable}>
-                Sign Up
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Upgrade to Pro
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiViewBoards}>
-                Documentation
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={BiBuoy}>
-                Help
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-          </Sidebar.Items>
-        </Sidebar>
-      ),
+      code: <SeparatorSidebarComponent />,
     },
     {
       title: 'CTA button',
-      code: (
-        <Sidebar collapsed={false}>
-          <Sidebar.Items>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiViewBoards}>
-                Kanban
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiInbox}>
-                Inbox
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiUser}>
-                Users
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiShoppingBag}>
-                Products
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiArrowSmRight}>
-                Sign In
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiTable}>
-                Sign Up
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-          </Sidebar.Items>
-          <Sidebar.CTA>
-            <div className="mb-3 flex items-center">
-              <span className="mr-2 rounded bg-orange-100 px-2.5 py-0.5 text-sm font-semibold text-orange-800 dark:bg-orange-200 dark:text-orange-900">
-                Beta
-              </span>
-              <button
-                type="button"
-                className="-mx-1.5 -my-1.5 ml-auto inline-flex h-6 w-6 rounded-lg bg-blue-50 p-1 text-blue-900 hover:bg-blue-200 focus:ring-2 focus:ring-blue-400 dark:bg-blue-900 dark:text-blue-400 dark:hover:bg-blue-800"
-                data-collapse-toggle="dropdown-cta"
-                aria-label="Close"
-              >
-                <span className="sr-only">Close</span>
-                <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    fillRule="evenodd"
-                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-                    clipRule="evenodd"
-                  ></path>
-                </svg>
-              </button>
-            </div>
-            <p className="mb-3 text-sm text-blue-900 dark:text-blue-400">
-              Preview the new Flowbite dashboard navigation! You can turn the new navigation off for a limited time in
-              your profile.
-            </p>
-            <a
-              className="text-sm text-blue-900 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-              href="#"
-            >
-              Turn new navigation off
-            </a>
-          </Sidebar.CTA>
-        </Sidebar>
-      ),
+      code: <CTASidebarComponent />,
     },
     {
       title: 'Logo branding',
-      code: (
-        <Sidebar collapsed={false}>
-          <Sidebar.Logo href="#" img="logo192.png" imgAlt="Flowbite logo">
-            Flowbite
-          </Sidebar.Logo>
-          <Sidebar.Items>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiViewBoards}>
-                Kanban
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiInbox}>
-                Inbox
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiUser}>
-                Users
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiShoppingBag}>
-                Products
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiArrowSmRight}>
-                Sign In
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiTable}>
-                Sign Up
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-          </Sidebar.Items>
-        </Sidebar>
-      ),
+      code: <LogoSidebarComponent />,
     },
   ];
   return <DemoPage examples={examples} />;

--- a/src/docs/pages/SidebarPage.tsx
+++ b/src/docs/pages/SidebarPage.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { BiBuoy } from 'react-icons/bi';
 import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, HiViewBoards } from 'react-icons/hi';
-import { Sidebar } from '../components';
+import { Sidebar, Badge, Button } from '../../lib';
 import { CodeExample, DemoPage } from './DemoPage';
 
 const SidebarPage: FC = () => {
@@ -144,14 +144,11 @@ const SidebarPage: FC = () => {
           </Sidebar.Items>
           <Sidebar.CTA>
             <div className="mb-3 flex items-center">
-              <span className="mr-2 rounded bg-orange-100 px-2.5 py-0.5 text-sm font-semibold text-orange-800 dark:bg-orange-200 dark:text-orange-900">
-                Beta
-              </span>
-              <button
-                type="button"
-                className="-mx-1.5 -my-1.5 ml-auto inline-flex h-6 w-6 rounded-lg bg-blue-50 p-1 text-blue-900 hover:bg-blue-200 focus:ring-2 focus:ring-blue-400 dark:bg-blue-900 dark:text-blue-400 dark:hover:bg-blue-800"
-                data-collapse-toggle="dropdown-cta"
+              <Badge color="yellow">Beta</Badge>
+              <Button
                 aria-label="Close"
+                className="-mx-1.5 -my-1.5 ml-auto !h-6 !w-6 bg-transparent !p-1 text-blue-900 hover:bg-blue-200"
+                data-collapse-toggle="dropdown-cta"
               >
                 <span className="sr-only">Close</span>
                 <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
@@ -161,7 +158,7 @@ const SidebarPage: FC = () => {
                     clipRule="evenodd"
                   ></path>
                 </svg>
-              </button>
+              </Button>
             </div>
             <p className="mb-3 text-sm text-blue-900 dark:text-blue-400">
               Preview the new Flowbite dashboard navigation! You can turn the new navigation off for a limited time in

--- a/src/docs/routes.tsx
+++ b/src/docs/routes.tsx
@@ -2,7 +2,7 @@ import { ComponentProps, FC, ReactNode } from 'react';
 
 import { BiNotification } from 'react-icons/bi';
 import { BsCreditCard2FrontFill, BsImages } from 'react-icons/bs';
-import { FaSpinner } from 'react-icons/fa';
+import { FaBars, FaSpinner } from 'react-icons/fa';
 import { FiNavigation } from 'react-icons/fi';
 import {
   HiAnnotation,
@@ -46,6 +46,7 @@ import SpinnersPage from './pages/SpinnersPage';
 import TablePage from './pages/TablePage';
 import ToastPage from './pages/ToastPage';
 import TooltipsPage from './pages/TooltipsPage';
+import SidebarPage from './pages/SidebarPage';
 
 export type ComponentCardItem = {
   className: string;
@@ -255,6 +256,13 @@ export const routes: RouteProps[] = [
       className: 'w-40',
       images: { light: 'rating-light.svg', dark: 'rating-dark.svg' },
     },
+  },
+  {
+    title: 'Sidebar',
+    icon: FaBars,
+    href: '/sidebar',
+    component: <SidebarPage />,
+    group: false,
   },
   {
     title: 'Spinners',

--- a/src/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/src/lib/components/Sidebar/Sidebar.stories.tsx
@@ -45,7 +45,7 @@ CTAButton.args = {
 };
 
 export const LogoBranding = Template.bind({});
-LogoBranding.storyName = 'CTA button';
+LogoBranding.storyName = 'Logo branding';
 LogoBranding.args = {
   children: <LogoSidebarComponent />,
   collapsed: false,

--- a/src/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/src/lib/components/Sidebar/Sidebar.stories.tsx
@@ -1,0 +1,52 @@
+import { Meta, Story } from '@storybook/react/types-6-0';
+
+import { Sidebar } from '.';
+import {
+  CTASidebarComponent,
+  DefaultSidebarComponent,
+  DropdownSidebarComponent,
+  LogoSidebarComponent,
+  SeparatorSidebarComponent,
+} from '../../pages/SidebarPage';
+
+export default {
+  title: 'Components/Sidebar',
+  component: Sidebar,
+} as Meta;
+
+const Template: Story = (args) => <Sidebar {...args} />;
+
+export const DefaultSidebar = Template.bind({});
+DefaultSidebar.storyName = 'Default';
+DefaultSidebar.args = {
+  children: <DefaultSidebarComponent />,
+  collapsed: false,
+};
+
+export const MultiLevelDropdown = Template.bind({});
+MultiLevelDropdown.storyName = 'Multi-level dropdown';
+MultiLevelDropdown.args = {
+  children: <DropdownSidebarComponent />,
+  collapsed: false,
+};
+
+export const ContentSeparator = Template.bind({});
+ContentSeparator.storyName = 'Content separator';
+ContentSeparator.args = {
+  children: <SeparatorSidebarComponent />,
+  collapsed: false,
+};
+
+export const CTAButton = Template.bind({});
+CTAButton.storyName = 'CTA button';
+CTAButton.args = {
+  children: <CTASidebarComponent />,
+  collapsed: false,
+};
+
+export const LogoBranding = Template.bind({});
+LogoBranding.storyName = 'CTA button';
+LogoBranding.args = {
+  children: <LogoSidebarComponent />,
+  collapsed: false,
+};

--- a/src/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/src/lib/components/Sidebar/Sidebar.stories.tsx
@@ -1,13 +1,8 @@
 import { Meta, Story } from '@storybook/react/types-6-0';
+import { BiBuoy } from 'react-icons/bi';
+import { HiChartPie, HiViewBoards, HiInbox, HiUser, HiShoppingBag, HiArrowSmRight, HiTable } from 'react-icons/hi';
 
 import { Sidebar } from '.';
-import {
-  CTASidebarComponent,
-  DefaultSidebarComponent,
-  DropdownSidebarComponent,
-  LogoSidebarComponent,
-  SeparatorSidebarComponent,
-} from '../../pages/SidebarPage';
 
 export default {
   title: 'Components/Sidebar',
@@ -19,34 +14,220 @@ const Template: Story = (args) => <Sidebar {...args} />;
 export const DefaultSidebar = Template.bind({});
 DefaultSidebar.storyName = 'Default';
 DefaultSidebar.args = {
-  children: <DefaultSidebarComponent />,
+  children: (
+    <Sidebar collapsed={false}>
+      <Sidebar.Items>
+        <Sidebar.ItemGroup>
+          <Sidebar.Item href="#" icon={HiChartPie}>
+            Dashboard
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="gray">
+            Kanban
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiInbox} label="3">
+            Inbox
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiUser}>
+            Users
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiShoppingBag}>
+            Products
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiArrowSmRight}>
+            Sign In
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiTable}>
+            Sign Up
+          </Sidebar.Item>
+        </Sidebar.ItemGroup>
+      </Sidebar.Items>
+    </Sidebar>
+  ),
   collapsed: false,
 };
 
 export const MultiLevelDropdown = Template.bind({});
 MultiLevelDropdown.storyName = 'Multi-level dropdown';
 MultiLevelDropdown.args = {
-  children: <DropdownSidebarComponent />,
+  children: (
+    <Sidebar collapsed={false}>
+      <Sidebar.Items>
+        <Sidebar.ItemGroup>
+          <Sidebar.Item href="#" icon={HiChartPie}>
+            Dashboard
+          </Sidebar.Item>
+          <Sidebar.Collapse icon={HiShoppingBag} label="E-commerce">
+            <Sidebar.Item href="#">Products</Sidebar.Item>
+          </Sidebar.Collapse>
+          <Sidebar.Item href="#" icon={HiInbox}>
+            Inbox
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiUser}>
+            Users
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiShoppingBag}>
+            Products
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiArrowSmRight}>
+            Sign In
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiTable}>
+            Sign Up
+          </Sidebar.Item>
+        </Sidebar.ItemGroup>
+      </Sidebar.Items>
+    </Sidebar>
+  ),
   collapsed: false,
 };
 
 export const ContentSeparator = Template.bind({});
 ContentSeparator.storyName = 'Content separator';
 ContentSeparator.args = {
-  children: <SeparatorSidebarComponent />,
+  children: (
+    <Sidebar collapsed={false}>
+      <Sidebar.Items>
+        <Sidebar.ItemGroup>
+          <Sidebar.Item href="#" icon={HiChartPie}>
+            Dashboard
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiViewBoards}>
+            Kanban
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiInbox}>
+            Inbox
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiUser}>
+            Users
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiShoppingBag}>
+            Products
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiArrowSmRight}>
+            Sign In
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiTable}>
+            Sign Up
+          </Sidebar.Item>
+        </Sidebar.ItemGroup>
+        <Sidebar.ItemGroup>
+          <Sidebar.Item href="#" icon={HiChartPie}>
+            Upgrade to Pro
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiViewBoards}>
+            Documentation
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={BiBuoy}>
+            Help
+          </Sidebar.Item>
+        </Sidebar.ItemGroup>
+      </Sidebar.Items>
+    </Sidebar>
+  ),
   collapsed: false,
 };
 
 export const CTAButton = Template.bind({});
 CTAButton.storyName = 'CTA button';
 CTAButton.args = {
-  children: <CTASidebarComponent />,
+  children: (
+    <Sidebar collapsed={false}>
+      <Sidebar.Items>
+        <Sidebar.ItemGroup>
+          <Sidebar.Item href="#" icon={HiChartPie}>
+            Dashboard
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiViewBoards}>
+            Kanban
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiInbox}>
+            Inbox
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiUser}>
+            Users
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiShoppingBag}>
+            Products
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiArrowSmRight}>
+            Sign In
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiTable}>
+            Sign Up
+          </Sidebar.Item>
+        </Sidebar.ItemGroup>
+      </Sidebar.Items>
+      <Sidebar.CTA>
+        <div className="mb-3 flex items-center">
+          <span className="mr-2 rounded bg-orange-100 px-2.5 py-0.5 text-sm font-semibold text-orange-800 dark:bg-orange-200 dark:text-orange-900">
+            Beta
+          </span>
+          <button
+            type="button"
+            className="-mx-1.5 -my-1.5 ml-auto inline-flex h-6 w-6 rounded-lg bg-blue-50 p-1 text-blue-900 hover:bg-blue-200 focus:ring-2 focus:ring-blue-400 dark:bg-blue-900 dark:text-blue-400 dark:hover:bg-blue-800"
+            data-collapse-toggle="dropdown-cta"
+            aria-label="Close"
+          >
+            <span className="sr-only">Close</span>
+            <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+              <path
+                fillRule="evenodd"
+                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                clipRule="evenodd"
+              ></path>
+            </svg>
+          </button>
+        </div>
+        <p className="mb-3 text-sm text-blue-900 dark:text-blue-400">
+          Preview the new Flowbite dashboard navigation! You can turn the new navigation off for a limited time in your
+          profile.
+        </p>
+        <a
+          className="text-sm text-blue-900 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+          href="#"
+        >
+          Turn new navigation off
+        </a>
+      </Sidebar.CTA>
+    </Sidebar>
+  ),
   collapsed: false,
 };
 
 export const LogoBranding = Template.bind({});
 LogoBranding.storyName = 'Logo branding';
 LogoBranding.args = {
-  children: <LogoSidebarComponent />,
+  children: (
+    <Sidebar collapsed={false}>
+      <Sidebar.Logo href="#" img="logo192.png" imgAlt="Flowbite logo">
+        Flowbite
+      </Sidebar.Logo>
+      <Sidebar.Items>
+        <Sidebar.ItemGroup>
+          <Sidebar.Item href="#" icon={HiChartPie}>
+            Dashboard
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiViewBoards}>
+            Kanban
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiInbox}>
+            Inbox
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiUser}>
+            Users
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiShoppingBag}>
+            Products
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiArrowSmRight}>
+            Sign In
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiTable}>
+            Sign Up
+          </Sidebar.Item>
+        </Sidebar.ItemGroup>
+      </Sidebar.Items>
+    </Sidebar>
+  ),
   collapsed: false,
 };

--- a/src/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/src/lib/components/Sidebar/Sidebar.stories.tsx
@@ -3,6 +3,8 @@ import { BiBuoy } from 'react-icons/bi';
 import { HiChartPie, HiViewBoards, HiInbox, HiUser, HiShoppingBag, HiArrowSmRight, HiTable } from 'react-icons/hi';
 
 import { Sidebar } from '.';
+import { Badge } from '../Badge';
+import { Button } from '../Button';
 
 export default {
   title: 'Components/Sidebar',
@@ -159,14 +161,11 @@ CTAButton.args = {
       </Sidebar.Items>
       <Sidebar.CTA>
         <div className="mb-3 flex items-center">
-          <span className="mr-2 rounded bg-orange-100 px-2.5 py-0.5 text-sm font-semibold text-orange-800 dark:bg-orange-200 dark:text-orange-900">
-            Beta
-          </span>
-          <button
-            type="button"
-            className="-mx-1.5 -my-1.5 ml-auto inline-flex h-6 w-6 rounded-lg bg-blue-50 p-1 text-blue-900 hover:bg-blue-200 focus:ring-2 focus:ring-blue-400 dark:bg-blue-900 dark:text-blue-400 dark:hover:bg-blue-800"
-            data-collapse-toggle="dropdown-cta"
+          <Badge color="yellow">Beta</Badge>
+          <Button
             aria-label="Close"
+            className="-mx-1.5 -my-1.5 ml-auto !h-6 !w-6 bg-transparent !p-1 text-blue-900 hover:bg-blue-200"
+            data-collapse-toggle="dropdown-cta"
           >
             <span className="sr-only">Close</span>
             <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
@@ -176,7 +175,7 @@ CTAButton.args = {
                 clipRule="evenodd"
               ></path>
             </svg>
-          </button>
+          </Button>
         </div>
         <p className="mb-3 text-sm text-blue-900 dark:text-blue-400">
           Preview the new Flowbite dashboard navigation! You can turn the new navigation off for a limited time in your


### PR DESCRIPTION
Adds the following examples for `Sidebar`s:

- [x] Default sidebar
- [x] Multi-level dropdown
- [x] Content separator

~~The following can't be finished yet, because the
component needs work:~~

- [x] CTA button
- [x] Logo branding

Once #72 is accepted I can finalize this PR. 

This resolves #53.

Also adds Storybook stories for Sidebar, resolving #56.