### PR TITLE
feature(component): Rewrite Breadcrumb in composable form

### DIFF
--- a/src/docs/pages/BreadcrumbPage.tsx
+++ b/src/docs/pages/BreadcrumbPage.tsx
@@ -14,7 +14,7 @@ const BreadcrumbPage: FC = () => {
             Home
           </Breadcrumb.Item>
           <Breadcrumb.Item href="#">Projects</Breadcrumb.Item>
-          <Breadcrumb.Item icon={HiHome}>Flowbite React</Breadcrumb.Item>
+          <Breadcrumb.Item>Flowbite React</Breadcrumb.Item>
         </Breadcrumb>
       ),
     },
@@ -26,7 +26,7 @@ const BreadcrumbPage: FC = () => {
             Home
           </Breadcrumb.Item>
           <Breadcrumb.Item href="#">Projects</Breadcrumb.Item>
-          <Breadcrumb.Item icon={HiHome}>Flowbite React</Breadcrumb.Item>
+          <Breadcrumb.Item>Flowbite React</Breadcrumb.Item>
         </Breadcrumb>
       ),
     },

--- a/src/docs/pages/BreadcrumbPage.tsx
+++ b/src/docs/pages/BreadcrumbPage.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { HiHome } from 'react-icons/hi';
+import Breadcrumb from '../../lib/components/Breadcrumb';
 
-import { Breadcrumb } from '../../lib';
 import { CodeExample, DemoPage } from './DemoPage';
 
 const BreadcrumbPage: FC = () => {
@@ -9,22 +9,25 @@ const BreadcrumbPage: FC = () => {
     {
       title: 'Default breadcrumb',
       code: (
-        <Breadcrumb
-          items={[
-            {
-              icon: HiHome,
-              label: 'Home',
-              href: '/breadcrumb',
-            },
-            {
-              label: 'Projects',
-              href: '/breadcrumb',
-            },
-            {
-              label: 'Flowbite React',
-            },
-          ]}
-        />
+        <Breadcrumb>
+          <Breadcrumb.Item href="#" icon={HiHome}>
+            Home
+          </Breadcrumb.Item>
+          <Breadcrumb.Item href="#">Projects</Breadcrumb.Item>
+          <Breadcrumb.Item icon={HiHome}>Flowbite React</Breadcrumb.Item>
+        </Breadcrumb>
+      ),
+    },
+    {
+      title: 'Solid background',
+      code: (
+        <Breadcrumb className="bg-gray-50 py-3 px-5 dark:bg-gray-900">
+          <Breadcrumb.Item href="#" icon={HiHome}>
+            Home
+          </Breadcrumb.Item>
+          <Breadcrumb.Item href="#">Projects</Breadcrumb.Item>
+          <Breadcrumb.Item icon={HiHome}>Flowbite React</Breadcrumb.Item>
+        </Breadcrumb>
       ),
     },
   ];

--- a/src/docs/pages/BreadcrumbPage.tsx
+++ b/src/docs/pages/BreadcrumbPage.tsx
@@ -9,7 +9,7 @@ const BreadcrumbPage: FC = () => {
     {
       title: 'Default breadcrumb',
       code: (
-        <Breadcrumb>
+        <Breadcrumb aria-label="Default breadcrumb example">
           <Breadcrumb.Item href="#" icon={HiHome}>
             Home
           </Breadcrumb.Item>
@@ -21,7 +21,7 @@ const BreadcrumbPage: FC = () => {
     {
       title: 'Solid background',
       code: (
-        <Breadcrumb className="bg-gray-50 py-3 px-5 dark:bg-gray-900">
+        <Breadcrumb aria-label="Solid background breadcrumb example" className="bg-gray-50 py-3 px-5 dark:bg-gray-900">
           <Breadcrumb.Item href="#" icon={HiHome}>
             Home
           </Breadcrumb.Item>

--- a/src/lib/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/src/lib/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react';
+import { HiHome } from 'react-icons/hi';
+import Breadcrumb from '.';
+
+describe('Breadcrumb', () => {
+  describe('its first item', () => {
+    it("shouldn't have a chevron", () => {
+      const { getAllByTestId } = render(<BreadcrumbTest />);
+
+      const firstSeparator = getAllByTestId('breadcrumb-separator')[0];
+      expect(firstSeparator.nextElementSibling).not.toHaveTextContent('Home');
+      expect(firstSeparator.nextElementSibling).toHaveTextContent('Projects');
+    });
+  });
+
+  describe('its last item', () => {
+    it("shouldn't be an anchor", () => {
+      const { getAllByTestId } = render(<BreadcrumbTest />);
+
+      const items = getAllByTestId('breadcrumb-item');
+      const lastItem = items[items.length - 1];
+      expect(lastItem).not.toBeInstanceOf(HTMLAnchorElement);
+    });
+  });
+});
+
+const BreadcrumbTest = (): JSX.Element => (
+  <Breadcrumb>
+    <Breadcrumb.Item href="#" icon={HiHome}>
+      Home
+    </Breadcrumb.Item>
+    <Breadcrumb.Item href="#">Projects</Breadcrumb.Item>
+    <Breadcrumb.Item icon={HiHome}>Flowbite React</Breadcrumb.Item>
+  </Breadcrumb>
+);

--- a/src/lib/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/src/lib/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -3,29 +3,18 @@ import { HiHome } from 'react-icons/hi';
 import Breadcrumb from '.';
 
 describe('Breadcrumb', () => {
-  describe('its first item', () => {
-    it("shouldn't have a chevron", () => {
-      const { getAllByTestId } = render(<BreadcrumbTest />);
+  describe('given an aria-label', () => {
+    it('should override default aria-label', () => {
+      const { getByRole } = render(<BreadcrumbTest />);
 
-      const firstSeparator = getAllByTestId('breadcrumb-separator')[0];
-      expect(firstSeparator.nextElementSibling).not.toHaveTextContent('Home');
-      expect(firstSeparator.nextElementSibling).toHaveTextContent('Projects');
-    });
-  });
-
-  describe('its last item', () => {
-    it("shouldn't be an anchor", () => {
-      const { getAllByTestId } = render(<BreadcrumbTest />);
-
-      const items = getAllByTestId('breadcrumb-item');
-      const lastItem = items[items.length - 1];
-      expect(lastItem).not.toBeInstanceOf(HTMLAnchorElement);
+      const breadcrumb = getByRole('navigation');
+      expect(breadcrumb).toHaveAccessibleName('test label');
     });
   });
 });
 
 const BreadcrumbTest = (): JSX.Element => (
-  <Breadcrumb>
+  <Breadcrumb aria-label="test label">
     <Breadcrumb.Item href="#" icon={HiHome}>
       Home
     </Breadcrumb.Item>

--- a/src/lib/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/lib/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -14,7 +14,7 @@ export const Default = (): JSX.Element => (
       Home
     </Breadcrumb.Item>
     <Breadcrumb.Item href="#">Projects</Breadcrumb.Item>
-    <Breadcrumb.Item icon={HiHome}>Flowbite React</Breadcrumb.Item>
+    <Breadcrumb.Item>Flowbite React</Breadcrumb.Item>
   </Breadcrumb>
 );
 
@@ -24,7 +24,7 @@ export const SolidBackground = (): JSX.Element => (
       Home
     </Breadcrumb.Item>
     <Breadcrumb.Item href="#">Projects</Breadcrumb.Item>
-    <Breadcrumb.Item icon={HiHome}>Flowbite React</Breadcrumb.Item>
+    <Breadcrumb.Item>Flowbite React</Breadcrumb.Item>
   </Breadcrumb>
 );
 SolidBackground.storyName = 'Solid background';

--- a/src/lib/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/lib/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,29 +1,30 @@
-import { Meta, Story } from '@storybook/react/types-6-0';
+import { Meta } from '@storybook/react/types-6-0';
 import { HiHome } from 'react-icons/hi';
 
-import { Breadcrumb, BreadcrumbProps } from '.';
+import Breadcrumb from '.';
 
 export default {
   title: 'Components/Breadcrumb',
   component: Breadcrumb,
 } as Meta;
 
-const Template: Story<BreadcrumbProps> = (args) => <Breadcrumb {...args} />;
-export const DefaultBreadcrumb = Template.bind({});
-DefaultBreadcrumb.storyName = 'Default';
-DefaultBreadcrumb.args = {
-  items: [
-    {
-      icon: HiHome,
-      label: 'Home',
-      href: '/breadcrumb',
-    },
-    {
-      label: 'Projects',
-      href: '/breadcrumb',
-    },
-    {
-      label: 'Flowbite React',
-    },
-  ],
-};
+export const Default = (): JSX.Element => (
+  <Breadcrumb>
+    <Breadcrumb.Item href="#" icon={HiHome}>
+      Home
+    </Breadcrumb.Item>
+    <Breadcrumb.Item href="#">Projects</Breadcrumb.Item>
+    <Breadcrumb.Item icon={HiHome}>Flowbite React</Breadcrumb.Item>
+  </Breadcrumb>
+);
+
+export const SolidBackground = (): JSX.Element => (
+  <Breadcrumb className="bg-gray-50 py-3 px-5 dark:bg-gray-800">
+    <Breadcrumb.Item href="#" icon={HiHome}>
+      Home
+    </Breadcrumb.Item>
+    <Breadcrumb.Item href="#">Projects</Breadcrumb.Item>
+    <Breadcrumb.Item icon={HiHome}>Flowbite React</Breadcrumb.Item>
+  </Breadcrumb>
+);
+SolidBackground.storyName = 'Solid background';

--- a/src/lib/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/lib/components/Breadcrumb/BreadcrumbItem.tsx
@@ -4,24 +4,16 @@ import { HiOutlineChevronRight } from 'react-icons/hi';
 export interface BreadcrumbItemProps extends ComponentProps<'li'> {
   href?: string;
   icon?: FC<ComponentProps<'svg'>>;
-  isFirst?: boolean;
 }
 
-const BreadcrumbItem: FC<PropsWithChildren<BreadcrumbItemProps>> = ({
-  children,
-  href,
-  icon: Icon,
-  isFirst,
-}): JSX.Element => {
+const BreadcrumbItem: FC<PropsWithChildren<BreadcrumbItemProps>> = ({ children, href, icon: Icon }): JSX.Element => {
   return (
-    <li className="flex items-center">
-      {!isFirst && (
-        <HiOutlineChevronRight
-          aria-hidden="true"
-          className="mx-1 h-6 w-6 text-gray-400 md:mx-2"
-          data-testid="breadcrumb-separator"
-        />
-      )}
+    <li className="group flex items-center">
+      <HiOutlineChevronRight
+        aria-hidden="true"
+        className="mx-1 h-6 w-6 text-gray-400 group-first:hidden md:mx-2"
+        data-testid="breadcrumb-separator"
+      />
       {typeof href !== 'undefined' ? (
         <a
           className="flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"

--- a/src/lib/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/lib/components/Breadcrumb/BreadcrumbItem.tsx
@@ -1,0 +1,50 @@
+import { FC, ComponentProps, PropsWithChildren } from 'react';
+import { HiOutlineChevronRight } from 'react-icons/hi';
+
+export interface BreadcrumbItemProps extends ComponentProps<'li'> {
+  href?: string;
+  icon?: FC<ComponentProps<'svg'>>;
+  isFirst?: boolean;
+  isLast?: boolean;
+}
+
+const BreadcrumbItem: FC<PropsWithChildren<BreadcrumbItemProps>> = ({
+  children,
+  href,
+  icon: Icon,
+  isFirst,
+  isLast,
+}): JSX.Element => {
+  return (
+    <li className="flex items-center">
+      {!isFirst && (
+        <HiOutlineChevronRight
+          aria-hidden="true"
+          className="mx-1 h-6 w-6 text-gray-400 md:mx-2"
+          data-testid="breadcrumb-separator"
+        />
+      )}
+      {!isLast ? (
+        <a
+          className="flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+          data-testid="breadcrumb-item"
+          href={href}
+        >
+          {Icon && <Icon aria-hidden="true" className="mr-2 h-4 w-4" />}
+          {children}
+        </a>
+      ) : (
+        <span
+          className="flex items-center text-sm font-medium text-gray-400 dark:text-gray-500"
+          data-testid="breadcrumb-item"
+        >
+          {Icon && <Icon aria-hidden="true" className="mr-2 h-4 w-4" />}
+          {children}
+        </span>
+      )}
+    </li>
+  );
+};
+
+BreadcrumbItem.displayName = 'Breadcrumb.Item';
+export default BreadcrumbItem;

--- a/src/lib/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/lib/components/Breadcrumb/BreadcrumbItem.tsx
@@ -6,9 +6,14 @@ export interface BreadcrumbItemProps extends ComponentProps<'li'> {
   icon?: FC<ComponentProps<'svg'>>;
 }
 
-const BreadcrumbItem: FC<PropsWithChildren<BreadcrumbItemProps>> = ({ children, href, icon: Icon }): JSX.Element => {
+const BreadcrumbItem: FC<PropsWithChildren<BreadcrumbItemProps>> = ({
+  children,
+  href,
+  icon: Icon,
+  ...rest
+}): JSX.Element => {
   return (
-    <li className="group flex items-center">
+    <li className="group flex items-center" {...rest}>
       <HiOutlineChevronRight
         aria-hidden="true"
         className="mx-1 h-6 w-6 text-gray-400 group-first:hidden md:mx-2"

--- a/src/lib/components/Breadcrumb/BreadcrumbItem.tsx
+++ b/src/lib/components/Breadcrumb/BreadcrumbItem.tsx
@@ -5,7 +5,6 @@ export interface BreadcrumbItemProps extends ComponentProps<'li'> {
   href?: string;
   icon?: FC<ComponentProps<'svg'>>;
   isFirst?: boolean;
-  isLast?: boolean;
 }
 
 const BreadcrumbItem: FC<PropsWithChildren<BreadcrumbItemProps>> = ({
@@ -13,7 +12,6 @@ const BreadcrumbItem: FC<PropsWithChildren<BreadcrumbItemProps>> = ({
   href,
   icon: Icon,
   isFirst,
-  isLast,
 }): JSX.Element => {
   return (
     <li className="flex items-center">
@@ -24,7 +22,7 @@ const BreadcrumbItem: FC<PropsWithChildren<BreadcrumbItemProps>> = ({
           data-testid="breadcrumb-separator"
         />
       )}
-      {!isLast ? (
+      {typeof href !== 'undefined' ? (
         <a
           className="flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
           data-testid="breadcrumb-item"

--- a/src/lib/components/Breadcrumb/index.tsx
+++ b/src/lib/components/Breadcrumb/index.tsx
@@ -1,40 +1,21 @@
-import { ComponentProps, FC } from 'react';
-import { HiOutlineChevronRight } from 'react-icons/hi';
+import { cloneElement, ComponentProps, FC, ReactElement, ReactNode } from 'react';
+import BreadcrumbItem from './BreadcrumbItem';
 
-export type BreadcrumbItem = {
-  icon?: FC<ComponentProps<'svg'>>;
-  label: string;
-  href?: string;
-};
+export interface BreadcrumbProps extends ComponentProps<'nav'> {
+  children: ReactNode[];
+}
 
-export type BreadcrumbProps = {
-  items: BreadcrumbItem[];
-};
-
-export const Breadcrumb: FC<BreadcrumbProps> = ({ items }) => {
+const BreadcrumbComponent: FC<BreadcrumbProps> = ({ children, ...rest }): JSX.Element => {
   return (
-    <nav className="flex" aria-label="Breadcrumb">
+    <nav aria-label="Breadcrumb" {...rest}>
       <ol className="flex items-center">
-        {items.map((item, index) => (
-          <li key={index} className="flex items-center">
-            {index > 0 && <HiOutlineChevronRight className="mx-1 h-6 w-6 text-gray-400 md:mx-2" />}
-            {index < items.length - 1 ? (
-              <a
-                className="flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-                href={item.href}
-              >
-                {item.icon && <item.icon className="mr-2 h-4 w-4" />}
-                {item.label}
-              </a>
-            ) : (
-              <span className="flex items-center text-sm font-medium text-gray-400 dark:text-gray-500">
-                {item.icon && <item.icon className="mr-2 h-4 w-4" />}
-                {item.label}
-              </span>
-            )}
-          </li>
-        ))}
+        {children.map((child, key) =>
+          cloneElement(child as ReactElement, { isFirst: key === 0, isLast: key === children.length - 1, key }),
+        )}
       </ol>
     </nav>
   );
 };
+
+BreadcrumbComponent.displayName = 'Breadcrumb';
+export default Object.assign(BreadcrumbComponent, { Item: BreadcrumbItem });

--- a/src/lib/components/Breadcrumb/index.tsx
+++ b/src/lib/components/Breadcrumb/index.tsx
@@ -9,9 +9,7 @@ const BreadcrumbComponent: FC<BreadcrumbProps> = ({ children, ...rest }): JSX.El
   return (
     <nav aria-label="Breadcrumb" {...rest}>
       <ol className="flex items-center">
-        {children.map((child, key) =>
-          cloneElement(child as ReactElement, { isFirst: key === 0, isLast: key === children.length - 1, key }),
-        )}
+        {children.map((child, key) => cloneElement(child as ReactElement, { isFirst: key === 0, key }))}
       </ol>
     </nav>
   );

--- a/src/lib/components/Breadcrumb/index.tsx
+++ b/src/lib/components/Breadcrumb/index.tsx
@@ -1,16 +1,10 @@
-import { cloneElement, ComponentProps, FC, ReactElement, ReactNode } from 'react';
+import { ComponentProps, FC } from 'react';
 import BreadcrumbItem from './BreadcrumbItem';
 
-export interface BreadcrumbProps extends ComponentProps<'nav'> {
-  children: ReactNode[];
-}
-
-const BreadcrumbComponent: FC<BreadcrumbProps> = ({ children, ...rest }): JSX.Element => {
+const BreadcrumbComponent: FC<ComponentProps<'nav'>> = ({ children, ...rest }): JSX.Element => {
   return (
     <nav aria-label="Breadcrumb" {...rest}>
-      <ol className="flex items-center">
-        {children.map((child, key) => cloneElement(child as ReactElement, { isFirst: key === 0, key }))}
-      </ol>
+      <ol className="flex items-center">{children}</ol>
     </nav>
   );
 };


### PR DESCRIPTION
## Breaking changes

This is a substantial API change. Previously, `Breadcrumb`s looked like:

```js
<Breadcrumb
  items={[
    {
      href: '/breadcrumb',
      icon: HiHome,
      label: 'Home'
    },
    {
      href: '/breadcrumb',
      label: 'Projects'
    },
    {
      label: 'Flowbite React'
    }
  ]}
 />
```

Now, you can write instead:

```js
<Breadcrumb>
  <Breadcrumb.Item href="#" icon={HiHome}>
    Home
  </Breadcrumb.Item>
  <Breadcrumb.Item href="#">Projects</Breadcrumb.Item>
  <Breadcrumb.Item icon={HiHome}>Flowbite React</Breadcrumb.Item>
</Breadcrumb>
```

## Features

- [x] [Rewrite Breadcrumb in composable form](https://github.com/themesberg/flowbite-react/commit/ec5e4fb96a97d3d7361c1c554176c23d81156810)
- [x] [Add missing example to Breadcrumb page](https://github.com/themesberg/flowbite-react/commit/38de48efc76de96d9aeacc3dbf14f5ec810ceb0c)
- [x] [Add missing story to Breadcrumb](https://github.com/themesberg/flowbite-react/commit/d44caae6698a7aa2ee6aca4cfd0d988be09f9175)

## Tests

### Unit

- [x] [Add unit tests for](https://github.com/themesberg/flowbite-react/commit/f7c04fae1e041ede9fbeefba9f1e548fbd62288d) [Breadcrumb](https://github.com/themesberg/flowbite-react/commit/f7c04fae1e041ede9fbeefba9f1e548fbd62288d)[s,](https://github.com/themesberg/flowbite-react/commit/f7c04fae1e041ede9fbeefba9f1e548fbd62288d) [resolves](https://github.com/themesberg/flowbite-react/commit/f7c04fae1e041ede9fbeefba9f1e548fbd62288d) https://github.com/themesberg/flowbite-react/issues/46