### PR TITLE
set tab item button type to "button"

### DIFF
--- a/src/lib/components/Tab/index.tsx
+++ b/src/lib/components/Tab/index.tsx
@@ -122,6 +122,7 @@ export const TabsComponent: FC<TabsProps> = ({ children, className, style = 'def
         {tabs.map((tab, index) => (
           <button
             key={index}
+            type="button"
             aria-controls={`${id}-tabpanel-${index}`}
             aria-selected={index === activeTab}
             className={classNames(


### PR DESCRIPTION
The tab items buttons should have a type of button. In case the tabs are used inside a form element, Clicking tabs won't submit the form.