### PR TITLE
feature(component): Add keyboard controls to `ToggleSwitch`

### DIFF
--- a/src/docs/pages/FormsPage.tsx
+++ b/src/docs/pages/FormsPage.tsx
@@ -11,16 +11,16 @@ const FormsPage: FC = () => {
       code: (
         <form className="flex flex-col gap-4">
           <div>
-            <Label className="mb-2 block" htmlFor="email">
+            <Label className="mb-2 block" htmlFor="email1">
               Your email
             </Label>
-            <TextInput id="email" type="email" placeholder="name@flowbite.com" required />
+            <TextInput id="email1" type="email" placeholder="name@flowbite.com" required />
           </div>
           <div>
-            <Label className="mb-2 block" htmlFor="password">
+            <Label className="mb-2 block" htmlFor="password1">
               Your password
             </Label>
-            <TextInput id="password" type="password" required />
+            <TextInput id="password1" type="password" required />
           </div>
           <div className="flex items-center gap-2">
             <Checkbox id="remember" />
@@ -59,8 +59,10 @@ const FormsPage: FC = () => {
       title: 'Disabled inputs',
       code: (
         <div className="flex flex-col gap-4">
-          <TextInput type="text" placeholder="Disabled input" disabled />
-          <TextInput type="text" placeholder="Disabled readonly input" disabled readOnly />
+          <Label htmlFor="disabledInput1">API token</Label>
+          <TextInput type="text" id="disabledInput1" placeholder="Disabled input" disabled />
+          <Label htmlFor="disabledInput2">Personal access token</Label>
+          <TextInput type="text" id="disabledInput2" placeholder="Disabled readonly input" disabled readOnly />
         </div>
       ),
     },
@@ -69,16 +71,16 @@ const FormsPage: FC = () => {
       code: (
         <form className="flex flex-col gap-4">
           <div>
-            <Label className="mb-2 block" htmlFor="email">
+            <Label className="mb-2 block" htmlFor="email2">
               Your email
             </Label>
-            <TextInput id="email" type="email" placeholder="name@flowbite.com" required shadow />
+            <TextInput id="email2" type="email" placeholder="name@flowbite.com" required shadow />
           </div>
           <div>
-            <Label className="mb-2 block" htmlFor="password">
+            <Label className="mb-2 block" htmlFor="password2">
               Your password
             </Label>
-            <TextInput id="password" type="password" required shadow />
+            <TextInput id="password2" type="password" required shadow />
           </div>
           <div>
             <Label className="mb-2 block" htmlFor="repeat-password">
@@ -103,11 +105,11 @@ const FormsPage: FC = () => {
       title: 'Helper text',
       code: (
         <div>
-          <Label className="mb-2 block" htmlFor="email">
+          <Label className="mb-2 block" htmlFor="email3">
             Your email
           </Label>
           <TextInput
-            id="email"
+            id="email3"
             type="email"
             placeholder="name@flowbite.com"
             required
@@ -128,10 +130,10 @@ const FormsPage: FC = () => {
       title: 'Input element with icon',
       code: (
         <div>
-          <Label className="mb-2 block" htmlFor="email">
+          <Label className="mb-2 block" htmlFor="email4">
             Your email
           </Label>
-          <TextInput id="email" type="email" placeholder="name@flowbite.com" required icon={HiMail} />
+          <TextInput id="email4" type="email" placeholder="name@flowbite.com" required icon={HiMail} />
         </div>
       ),
     },
@@ -142,7 +144,7 @@ const FormsPage: FC = () => {
           <Label className="mb-2 block" htmlFor="username">
             Username
           </Label>
-          <TextInput id="username" placeholder="Bonnie Green" required addon="@" />
+          <TextInput id="username3" placeholder="Bonnie Green" required addon="@" />
         </div>
       ),
     },
@@ -151,7 +153,7 @@ const FormsPage: FC = () => {
       code: (
         <div className="flex flex-col gap-4">
           <div>
-            <Label className="mb-2 block" htmlFor="username" color="green">
+            <Label className="mb-2 block" htmlFor="username3" color="green">
               Your name
             </Label>
             <TextInput
@@ -167,11 +169,11 @@ const FormsPage: FC = () => {
             />
           </div>
           <div>
-            <Label className="mb-2 block" htmlFor="username" color="red">
+            <Label className="mb-2 block" htmlFor="username4" color="red">
               Your name
             </Label>
             <TextInput
-              id="username"
+              id="username4"
               placeholder="Bonnie Green"
               required
               color="red"
@@ -260,6 +262,7 @@ const FormsPage: FC = () => {
       title: 'Radio',
       code: (
         <fieldset className="flex flex-col gap-4" id="radio">
+          <legend>Choose your favorite country</legend>
           <div className="flex items-center gap-2">
             <Radio id="united-state" name="countries" value="USA" defaultChecked />
             <Label htmlFor="united-state">United States</Label>

--- a/src/docs/pages/FormsPage.tsx
+++ b/src/docs/pages/FormsPage.tsx
@@ -1,10 +1,13 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { HiMail } from 'react-icons/hi';
 
 import { CodeExample, DemoPage } from './DemoPage';
 import { Button, Checkbox, FileInput, Label, Radio, Select, Textarea, TextInput, ToggleSwitch } from '../../lib';
 
 const FormsPage: FC = () => {
+  const [switch1, setSwitch1] = useState(false);
+  const [switch2, setSwitch2] = useState(true);
+
   const examples: CodeExample[] = [
     {
       title: 'Form example',
@@ -303,9 +306,9 @@ const FormsPage: FC = () => {
       title: 'Toggle Switch',
       code: (
         <div className="flex flex-col gap-4" id="toggle">
-          <ToggleSwitch label="Toggle me" />
-          <ToggleSwitch label="Toggle me (checked)" defaultChecked />
-          <ToggleSwitch label="Toggle me (disabled)" disabled />
+          <ToggleSwitch checked={switch1} label="Toggle me" onChange={setSwitch1} />
+          <ToggleSwitch checked={switch2} label="Toggle me (checked)" onChange={setSwitch2} />
+          <ToggleSwitch checked={false} disabled label="Toggle me (disabled)" onChange={() => undefined} />
         </div>
       ),
     },

--- a/src/lib/components/FormControls/Checkbox.spec.tsx
+++ b/src/lib/components/FormControls/Checkbox.spec.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import { Checkbox } from './Checkbox';
+
+describe('Components / Form controls / Checkbox', () => {
+  it('should render', () => {
+    render(<Checkbox />);
+  });
+
+  describe('A11y', () => {
+    it('should have role="checkbox" by default', () => {
+      const checkbox = render(<Checkbox />).getByRole('checkbox');
+
+      expect(checkbox).toBeInTheDocument();
+    });
+  });
+});

--- a/src/lib/components/FormControls/FileInput.spec.tsx
+++ b/src/lib/components/FormControls/FileInput.spec.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { FileInput } from './FileInput';
+
+describe('Components / Form controls / File input', () => {
+  it('should render', () => {
+    render(<FileInput />);
+  });
+});

--- a/src/lib/components/FormControls/Label.spec.tsx
+++ b/src/lib/components/FormControls/Label.spec.tsx
@@ -1,0 +1,107 @@
+import { render } from '@testing-library/react';
+import { HiGlobe, HiLockClosed } from 'react-icons/hi';
+import { Button } from '../Button';
+import { Checkbox } from './Checkbox';
+import { FileInput } from './FileInput';
+import { Label } from './Label';
+import { Radio } from './Radio';
+import { Select } from './Select';
+import { Textarea } from './Textarea';
+import { TextInput } from './TextInput';
+import { ToggleSwitch } from './ToggleSwitch';
+
+describe('Components / Form controls / Label', () => {
+  it('should render', () => {
+    render(<Label>Hello</Label>);
+  });
+
+  describe('A11y', () => {
+    it('should provide accessible name to any form control associated by `htmlFor`', () => {
+      const { getByLabelText } = render(<TestForm />);
+
+      const inputLabels = [
+        'Your email',
+        'Your password',
+        'Remember me',
+        'Enable notifications',
+        'Upload file',
+        'United States',
+        'Your message',
+      ];
+
+      inputLabels.forEach((label) => expect(getByLabelText(label)).toHaveAccessibleName(label));
+    });
+  });
+});
+
+const TestForm = (): JSX.Element => (
+  <form>
+    <div>
+      <ToggleSwitch checked={false} label="Enable notifications" onChange={console.log} />
+    </div>
+    <div>
+      <Label htmlFor="email">Your email</Label>
+      <TextInput id="email" type="email" placeholder="name@flowbite.com" required />
+    </div>
+    <div>
+      <Label htmlFor="password">Your password</Label>
+      <TextInput
+        addon="Make sure it is at least 12 characters!"
+        icon={HiLockClosed}
+        id="password"
+        type="password"
+        required
+      />
+    </div>
+    <div>
+      <Checkbox id="remember" />
+      <Label htmlFor="remember">Remember me</Label>
+    </div>
+    <div>
+      <Label htmlFor="countries">Select your country</Label>
+      <Select
+        addon={<span>Or just pick any country</span>}
+        helperText="Or just pick any country"
+        icon={HiGlobe}
+        id="countries"
+      >
+        <option>United States</option>
+        <option>Canada</option>
+        <option>France</option>
+        <option>Germany</option>
+      </Select>
+    </div>
+    <div>
+      <Label htmlFor="file">Upload file</Label>
+      <FileInput id="file" helperText="A profile picture is useful to confirm your are logged into your account" />
+    </div>
+    <fieldset>
+      <legend>Choose your favorite country</legend>
+      <div>
+        <Radio id="united-state" name="countries" value="USA" defaultChecked />
+        <Label htmlFor="united-state">United States</Label>
+      </div>
+      <div>
+        <Radio id="germany" name="countries" value="Germany" />
+        <Label htmlFor="germany">Germany</Label>
+      </div>
+      <div>
+        <Radio id="spain" name="countries" value="Spain" />
+        <Label htmlFor="spain">Spain</Label>
+      </div>
+      <div>
+        <Radio id="uk" name="countries" value="United Kingdom" />
+        <Label htmlFor="uk">United Kingdom</Label>
+      </div>
+      <div>
+        <Radio id="china" name="countries" value="China" disabled />
+        <Label>China (disabled)</Label>
+      </div>
+      <div>
+        <Label htmlFor="comment">Your message</Label>
+        <Textarea id="comment" helperText="Leave a comment..." required rows={4} />
+      </div>
+    </fieldset>
+    <Button type="submit">Submit</Button>
+  </form>
+);

--- a/src/lib/components/FormControls/Radio.spec.tsx
+++ b/src/lib/components/FormControls/Radio.spec.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import { Radio } from './Radio';
+
+describe('Components / Form controls / Radio', () => {
+  it('should render', () => {
+    render(<Radio />);
+  });
+
+  describe('A11y', () => {
+    it('should have role="radio" by default', () => {
+      const radio = render(<Radio />).getByRole('radio');
+
+      expect(radio).toBeInTheDocument();
+    });
+  });
+});

--- a/src/lib/components/FormControls/Select.spec.tsx
+++ b/src/lib/components/FormControls/Select.spec.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import { Select } from './Select';
+
+describe('Components / Form controls / Select', () => {
+  it('should render', () => {
+    render(<Select />);
+  });
+
+  describe('A11y', () => {
+    it('should have role="combobox" by default', () => {
+      const select = render(<Select />).getByRole('combobox');
+
+      expect(select).toBeInTheDocument();
+    });
+  });
+});

--- a/src/lib/components/FormControls/TextInput.spec.tsx
+++ b/src/lib/components/FormControls/TextInput.spec.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import { TextInput } from './TextInput';
+
+describe('Components / Form controls / Text input', () => {
+  it('should render', () => {
+    render(<TextInput />);
+  });
+
+  describe('A11y', () => {
+    it('should have role="textbox" by default', () => {
+      const textInput = render(<TextInput />).getByRole('textbox');
+
+      expect(textInput).toBeInTheDocument();
+    });
+  });
+});

--- a/src/lib/components/FormControls/TextInput.stories.tsx
+++ b/src/lib/components/FormControls/TextInput.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 const Template: Story<TextInputProps> = (args) => <TextInput {...args} />;
 
-export const DefaultTextInput = Template.bind({});
-DefaultTextInput.storyName = 'TextInput';
-DefaultTextInput.args = {};
+export const Default = Template.bind({});
+Default.storyName = 'Text input';
+Default.args = {};

--- a/src/lib/components/FormControls/Textarea.spec.tsx
+++ b/src/lib/components/FormControls/Textarea.spec.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import { Select } from './Select';
+import { Textarea } from './Textarea';
+
+describe('Components / Form controls / Select', () => {
+  it('should render', () => {
+    render(<Textarea rows={3} />);
+  });
+
+  describe('A11y', () => {
+    it('should have role="combobox" by default', () => {
+      const select = render(<Select />).getByRole('combobox');
+
+      expect(select).toBeInTheDocument();
+    });
+  });
+});

--- a/src/lib/components/FormControls/ToggleSwitch.spec.tsx
+++ b/src/lib/components/FormControls/ToggleSwitch.spec.tsx
@@ -1,0 +1,224 @@
+import { render, RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { TextInput } from './TextInput';
+import { ToggleSwitch } from './ToggleSwitch';
+
+describe('Components / Form controls / Toggle switch', () => {
+  it('should render', () => {
+    render(<ToggleSwitch checked={false} label="Enable" onChange={console.log} />);
+  });
+
+  describe('Props', () => {
+    describe('`type`', () => {
+      it('should be "button" by default', () => {
+        const switchElement = getSwitch(render(<ToggleSwitch checked={false} label="Enable" onChange={console.log} />));
+
+        assertSwitch({ switchElement });
+        expect(switchElement).toHaveAttribute('type', 'button');
+      });
+
+      it('should use the supplied `type`, if there is one', () => {
+        const switchElement = getSwitch(
+          render(<ToggleSwitch checked={false} label="Enable" onChange={console.log} type="submit" />),
+        );
+
+        assertSwitch({ switchElement });
+        expect(switchElement).toHaveAttribute('type', 'submit');
+      });
+    });
+  });
+
+  describe('A11y', () => {
+    it('should have accessible name', () => {
+      const switchElement = getSwitch(
+        render(
+          <ToggleSwitch checked={false} label="Enable notifications" name="notifications" onChange={console.log} />,
+        ),
+      );
+
+      assertSwitch({ switchElement });
+      expect(switchElement).toHaveAccessibleName('Enable notifications');
+    });
+  });
+
+  describe('Keyboard interaction', () => {
+    describe('`Enter`', () => {
+      it("shouldn't toggle", () => {
+        const handleChange = jest.fn();
+        const switchElement = getSwitch(
+          render(
+            <ToggleSwitch checked={false} label="Enable notifications" name="notifications" onChange={handleChange} />,
+          ),
+        );
+
+        assertSwitch({ switchElement });
+
+        userEvent.tab();
+
+        expect(switchElement).toHaveFocus();
+
+        userEvent.keyboard('[Enter]');
+
+        expect(handleChange).not.toHaveBeenCalled();
+      });
+
+      it("shouldn't submit surrounding form", () => {
+        const handleSubmit = jest.fn();
+        const switchElement = getSwitch(
+          render(
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                handleSubmit();
+              }}
+            >
+              <ToggleSwitch checked={false} label="Enable notifications" name="notifications" onChange={console.log} />
+            </form>,
+          ),
+        );
+
+        userEvent.tab();
+
+        assertSwitch({ switchElement });
+        expect(switchElement).toHaveFocus();
+
+        userEvent.keyboard('[Enter]');
+
+        expect(handleSubmit).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('`Space`', () => {
+      it('should toggle', () => {
+        const handleChange = jest.fn();
+
+        const TestToggleSwitch = (): JSX.Element => {
+          const [state, setState] = useState(false);
+
+          return (
+            <ToggleSwitch
+              checked={state}
+              label="Enable notifications"
+              name="notifications"
+              onChange={(value) => {
+                setState(value);
+                handleChange(value);
+              }}
+            />
+          );
+        };
+
+        const switchElement = getSwitch(render(<TestToggleSwitch />));
+
+        assertSwitch({ switchElement, props: { checked: false } });
+
+        userEvent.tab();
+
+        expect(switchElement).toHaveFocus();
+
+        userEvent.keyboard('[Space]');
+
+        assertSwitch({ switchElement, props: { checked: true } });
+
+        userEvent.keyboard('[Space]');
+
+        assertSwitch({ switchElement, props: { checked: false } });
+      });
+    });
+
+    describe('`Tab`', () => {
+      it('should focus', () => {
+        const switchElement = getSwitch(
+          render(
+            <ToggleSwitch checked={false} label="Enable notifications" name="notifications" onChange={console.log} />,
+          ),
+        );
+
+        userEvent.tab();
+
+        assertSwitch({ switchElement });
+        expect(switchElement).toHaveFocus();
+      });
+
+      it('should allow the user to `Tab` away', () => {
+        const TestToggleSwitch = (): JSX.Element => (
+          <form>
+            <ToggleSwitch checked={false} label="Enable notifications" name="notifications" onChange={console.log} />
+            <TextInput type="text" />
+          </form>
+        );
+
+        const view = render(<TestToggleSwitch />);
+        const switchElement = getSwitch(view);
+        const nextItemInTabOrder = view.getByRole('textbox');
+
+        userEvent.tab();
+        userEvent.tab();
+
+        assertSwitch({ switchElement });
+        expect(switchElement).not.toHaveFocus();
+        expect(nextItemInTabOrder).toHaveFocus();
+      });
+    });
+  });
+
+  describe('Mouse interaction', () => {
+    describe('Click button', () => {
+      it('should toggle', () => {
+        const handleChange = jest.fn();
+        const switchElement = getSwitch(
+          render(
+            <ToggleSwitch checked={false} label="Enable notifications" name="notifications" onChange={handleChange} />,
+          ),
+        );
+
+        userEvent.click(switchElement);
+
+        assertSwitch({ switchElement });
+        expect(handleChange).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('Click label', () => {
+      it('should toggle', () => {
+        const handleChange = jest.fn();
+        const view = render(
+          <ToggleSwitch checked={false} label="Enable notifications" name="notifications" onChange={handleChange} />,
+        );
+
+        const switchElement = getSwitch(view);
+        const switchLabel = view.getByTestId('flowbite-toggleswitch-label');
+
+        userEvent.click(switchLabel);
+
+        assertSwitch({ switchElement });
+        expect(handleChange).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});
+
+const getSwitch = ({ getByRole }: RenderResult): HTMLElement => getByRole('switch');
+
+const assertSwitch = ({
+  switchElement,
+  props,
+}: {
+  switchElement: HTMLElement;
+  props?: {
+    checked?: boolean;
+    label?: string;
+  };
+}): void => {
+  expect(switchElement).toBeInstanceOf(HTMLButtonElement);
+  expect(switchElement).toHaveAttribute('tabindex', '0');
+
+  if (props?.checked) {
+    expect(switchElement).toHaveAttribute('aria-checked', props.checked ? 'true' : 'false');
+  }
+
+  if (props?.label) {
+    expect(switchElement).toHaveTextContent(props.label);
+  }
+};

--- a/src/lib/components/FormControls/ToggleSwitch.stories.tsx
+++ b/src/lib/components/FormControls/ToggleSwitch.stories.tsx
@@ -10,5 +10,5 @@ export default {
 const Template: Story<ToggleSwitchProps> = (args) => <ToggleSwitch {...args} />;
 
 export const DefaultToggleSwitch = Template.bind({});
-DefaultToggleSwitch.storyName = 'ToggleSwitch';
+DefaultToggleSwitch.storyName = 'Toggle switch';
 DefaultToggleSwitch.args = {};

--- a/src/lib/components/FormControls/ToggleSwitch.tsx
+++ b/src/lib/components/FormControls/ToggleSwitch.tsx
@@ -1,24 +1,82 @@
-import { ComponentProps, FC } from 'react';
+import { ComponentProps, FC, KeyboardEvent, MouseEvent, useMemo } from 'react';
 import classNames from 'classnames';
+import * as nanoid from 'nanoid';
 
-export type ToggleSwitchProps = ComponentProps<'input'> & {
+export type ToggleSwitchProps = Omit<ComponentProps<'button'>, 'onChange'> & {
+  checked: boolean;
   label: string;
+  onChange: (checked: boolean) => void;
 };
 
-export const ToggleSwitch: FC<ToggleSwitchProps> = ({ className, label, id, disabled, ...props }) => (
-  <label
-    htmlFor={id}
-    className={classNames(
-      'relative flex items-center',
-      {
-        'cursor-not-allowed opacity-50': disabled,
-        'cursor-pointer': !disabled,
-      },
-      className,
-    )}
-  >
-    <input type="checkbox" id={id} className="sr-only" disabled={disabled} {...props} />
-    <div className="toggle-bg h-6 w-11 rounded-full border border-gray-200 bg-gray-200 dark:border-gray-600 dark:bg-gray-700" />
-    <span className="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300">{label}</span>
-  </label>
-);
+export const ToggleSwitch: FC<ToggleSwitchProps> = ({
+  checked,
+  className,
+  disabled,
+  label,
+  name,
+  onChange,
+  ...props
+}) => {
+  const id = useMemo(() => nanoid.nanoid(), []);
+
+  const toggle = (): void => onChange(!checked);
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>): void => {
+    event.preventDefault();
+    toggle();
+  };
+
+  const handleKeyUp = (event: KeyboardEvent<HTMLButtonElement>): void => {
+    if (event.key === 'Space') {
+      event.preventDefault();
+      toggle();
+    }
+  };
+
+  const handleKeyPress = (event: KeyboardEvent<HTMLButtonElement>): void => {
+    event.preventDefault();
+  };
+
+  return (
+    <>
+      {name && checked && <input checked={checked} hidden name={name} readOnly type="checkbox" className="sr-only" />}
+      <button
+        aria-checked={checked}
+        aria-labelledby={`${id}-flowbite-toggleswitch-label`}
+        disabled={disabled}
+        id={`${id}-flowbite-toggleswitch`}
+        onClick={handleClick}
+        onKeyDown={handleKeyUp}
+        onKeyPress={handleKeyPress}
+        role="switch"
+        tabIndex={0}
+        type="button"
+        className={classNames(
+          'group relative flex items-center rounded-lg focus:outline-none',
+          {
+            'cursor-not-allowed opacity-50': disabled,
+            'cursor-pointer': !disabled,
+          },
+          className,
+        )}
+        {...props}
+      >
+        <div
+          className={classNames(
+            'toggle-bg h-6 w-11 rounded-full border group-focus:ring-4 group-focus:ring-blue-500/25',
+            checked
+              ? 'border-blue-700 bg-blue-700 after:translate-x-full after:border-white'
+              : 'border-gray-200 bg-gray-200 dark:border-gray-600 dark:bg-gray-700',
+          )}
+        />
+        <span
+          data-testid="flowbite-toggleswitch-label"
+          id={`${id}-flowbite-toggleswitch-label`}
+          className="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300"
+        >
+          {label}
+        </span>
+      </button>
+    </>
+  );
+};

--- a/src/lib/components/FormControls/ToggleSwitch.tsx
+++ b/src/lib/components/FormControls/ToggleSwitch.tsx
@@ -26,13 +26,6 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
     toggle();
   };
 
-  const handleKeyUp = (event: KeyboardEvent<HTMLButtonElement>): void => {
-    if (event.key === 'Space') {
-      event.preventDefault();
-      toggle();
-    }
-  };
-
   const handleKeyPress = (event: KeyboardEvent<HTMLButtonElement>): void => {
     event.preventDefault();
   };
@@ -46,7 +39,6 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
         disabled={disabled}
         id={`${id}-flowbite-toggleswitch`}
         onClick={handleClick}
-        onKeyDown={handleKeyUp}
         onKeyPress={handleKeyPress}
         role="switch"
         tabIndex={0}


### PR DESCRIPTION
## Breaking changes

`ToggleSwitch` now requires:

- `checked` (`boolean`)
- `onChange` (`(checked: boolean) => void`)

You can now use Tab to navigate into a `ToggleSwitch`, and use Space to toggle its state.

### Example

```js
const [state, setState] = useState(false);

return <ToggleSwitch checked={state} label="Enable notifications" onChange={setState} />
```

## Features

- [x] [Add keyboard controls to ToggleSwitch](https://github.com/themesberg/flowbite-react/pull/120/commits/1844ca84e51ca0b20f570c9d19a4ef00509b3829)

## Bug fixes

- [x] [Move incorrect file name](https://github.com/themesberg/flowbite-react/pull/120/commits/c1b3b4d52eaea9a242211965b479ea306ad47f81)
- [x] [Resolve missing accessible label on Forms docs](https://github.com/themesberg/flowbite-react/pull/120/commits/353cc1808acc5933de581cca17994c8874f2d715)

## Tests

### Unit

- [x] [Add unit tests for form controls,](https://github.com/themesberg/flowbite-react/pull/120/commits/ba85ec4c46d8201a77bb259461e575f27bda91e4) [resolves](https://github.com/themesberg/flowbite-react/pull/120/commits/ba85ec4c46d8201a77bb259461e575f27bda91e4) https://github.com/themesberg/flowbite-react/issues/38