### PR TITLE
fix(component): Remove default export from `Breadcrumb`

### DIFF
--- a/src/docs/pages/BreadcrumbPage.tsx
+++ b/src/docs/pages/BreadcrumbPage.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { HiHome } from 'react-icons/hi';
-import Breadcrumb from '../../lib/components/Breadcrumb';
+import { Breadcrumb } from '../../lib';
 
 import { CodeExample, DemoPage } from './DemoPage';
 

--- a/src/lib/components/Breadcrumb/Breadcrumb.spec.tsx
+++ b/src/lib/components/Breadcrumb/Breadcrumb.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import { HiHome } from 'react-icons/hi';
-import Breadcrumb from '.';
+import { Breadcrumb } from '.';
 
 describe('Breadcrumb', () => {
   describe('given an aria-label', () => {

--- a/src/lib/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/lib/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/react/types-6-0';
 import { HiHome } from 'react-icons/hi';
 
-import Breadcrumb from '.';
+import { Breadcrumb } from '.';
 
 export default {
   title: 'Components/Breadcrumb',

--- a/src/lib/components/Breadcrumb/index.tsx
+++ b/src/lib/components/Breadcrumb/index.tsx
@@ -10,4 +10,4 @@ const BreadcrumbComponent: FC<ComponentProps<'nav'>> = ({ children, ...rest }): 
 };
 
 BreadcrumbComponent.displayName = 'Breadcrumb';
-export default Object.assign(BreadcrumbComponent, { Item: BreadcrumbItem });
+export const Breadcrumb = Object.assign(BreadcrumbComponent, { Item: BreadcrumbItem });


### PR DESCRIPTION
`Breadcrumb` is uncallable right now in the standard convention:

```js
import {Breadcrumb} from "flowbite-react";
```

Since I `export default`'d. This changes that to a named export so the module can be imported like above.