### PR TITLE
feature(component): Rewrite `Alert`s to use themes, resolves #126

### DIFF
--- a/src/docs/pages/ThemePage.tsx
+++ b/src/docs/pages/ThemePage.tsx
@@ -4,10 +4,10 @@ import { HiInformationCircle } from 'react-icons/hi';
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { dracula } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Alert, Card, DarkThemeToggle } from '../../lib';
-import { Flowbite } from '../../lib/components';
+import { DeepPartial, Flowbite, FlowbiteTheme } from '../../lib/components';
 
 const ThemePage: FC = () => {
-  const theme = { config: { button: { base: 'py-5 px-5' } } };
+  const theme: DeepPartial<FlowbiteTheme> = { alert: { color: { primary: 'bg-primary' } } };
 
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 dark:text-white">
@@ -26,7 +26,7 @@ const ThemePage: FC = () => {
         </div>
         <Card>
           <SyntaxHighlighter language="tsx" style={dracula}>
-            {reactElementToJSXString(<Flowbite theme={theme}>...</Flowbite>, {
+            {reactElementToJSXString(<Flowbite theme={{ theme }}>...</Flowbite>, {
               showFunctions: true,
               functionValue: (fn) => fn.name,
               sortProps: false,

--- a/src/lib/components/Alert/index.tsx
+++ b/src/lib/components/Alert/index.tsx
@@ -39,14 +39,13 @@ export const Alert: FC<AlertProps> = ({
         <div>{children}</div>
         {typeof onDismiss === 'function' && (
           <button
-            aria-label="Close"
             className={classNames(theme.closeButton.base, theme.closeButton.color[color])}
             data-testid="alert-dismiss"
             onClick={onDismiss}
             type="button"
           >
             <span className="sr-only">Close</span>
-            <HiX className="h-5 w-5" />
+            <HiX aria-hidden="true" className="h-5 w-5" />
           </button>
         )}
       </div>

--- a/src/lib/components/Alert/index.tsx
+++ b/src/lib/components/Alert/index.tsx
@@ -1,59 +1,45 @@
 import { ComponentProps, FC, PropsWithChildren, ReactNode } from 'react';
 import classNames from 'classnames';
 import { HiX } from 'react-icons/hi';
+import { useTheme } from '../Flowbite/ThemeContext';
 
 export type AlertProps = PropsWithChildren<{
-  color?: 'blue' | 'red' | 'green' | 'yellow' | 'gray';
+  additionalContent?: ReactNode;
+  color?: string;
   icon?: FC<ComponentProps<'svg'>>;
+  onDismiss?: boolean | (() => void);
   rounded?: boolean;
   withBorderAccent?: boolean;
-  additionalContent?: ReactNode;
-  onDismiss?: boolean | (() => void);
 }>;
 
-const colorClasses: Record<AlertProps['color'] & string, string> = {
-  blue: 'text-blue-700 bg-blue-100 border-blue-500 dark:bg-blue-200 dark:text-blue-800',
-  red: 'text-red-700 bg-red-100 border-red-500 dark:bg-red-200 dark:text-red-800',
-  green: 'text-green-700 bg-green-100 border-green-500 dark:bg-green-200 dark:text-green-800',
-  yellow: 'text-yellow-700 bg-yellow-100 border-yellow-500 dark:bg-yellow-200 dark:text-yellow-800',
-  gray: 'text-gray-700 bg-gray-100 border-gray-500 dark:bg-gray-700 dark:text-gray-300',
-};
-
 export const Alert: FC<AlertProps> = ({
+  additionalContent,
   children,
   color = 'blue',
   icon: Icon,
+  onDismiss,
   rounded = true,
   withBorderAccent,
-  additionalContent,
-  onDismiss,
 }) => {
+  const theme = useTheme().theme.alert;
+
   return (
     <div
-      className={classNames('flex flex-col gap-2 p-4 text-sm', colorClasses[color], {
-        'rounded-lg': rounded,
-        'border-t-4': withBorderAccent,
-      })}
+      className={classNames(
+        theme.base,
+        theme.color[color],
+        rounded && theme.rounded,
+        withBorderAccent && theme.borderAccent,
+      )}
       role="alert"
     >
       <div className="flex items-center">
-        {Icon && <Icon className="mr-3 inline h-5 w-5 flex-shrink-0" />}
+        {Icon && <Icon className={theme.icon} />}
         <div>{children}</div>
         {typeof onDismiss === 'function' && (
           <button
             aria-label="Close"
-            className={classNames('-mx-1.5 -my-1.5 ml-auto inline-flex h-8 w-8 rounded-lg p-1.5 focus:ring-2', {
-              'bg-blue-100 text-blue-500 hover:bg-blue-200 focus:ring-blue-400 dark:bg-blue-200 dark:text-blue-600 dark:hover:bg-blue-300':
-                color === 'blue',
-              'bg-red-100 text-red-500 hover:bg-red-200 focus:ring-red-400 dark:bg-red-200 dark:text-red-600 dark:hover:bg-red-300':
-                color === 'red',
-              'bg-green-100 text-green-500 hover:bg-green-200 focus:ring-green-400 dark:bg-green-200 dark:text-green-600 dark:hover:bg-green-300':
-                color === 'green',
-              'bg-yellow-100 text-yellow-500 hover:bg-yellow-200 focus:ring-yellow-400 dark:bg-yellow-200 dark:text-yellow-600 dark:hover:bg-yellow-300':
-                color === 'yellow',
-              'bg-gray-100 text-gray-500 hover:bg-gray-200 focus:ring-gray-400 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white':
-                color === 'gray',
-            })}
+            className={classNames(theme.closeButton.base, theme.closeButton.color[color])}
             data-testid="alert-dismiss"
             onClick={onDismiss}
             type="button"

--- a/src/lib/components/Alert/index.tsx
+++ b/src/lib/components/Alert/index.tsx
@@ -2,10 +2,11 @@ import { ComponentProps, FC, PropsWithChildren, ReactNode } from 'react';
 import classNames from 'classnames';
 import { HiX } from 'react-icons/hi';
 import { useTheme } from '../Flowbite/ThemeContext';
+import { Colors } from '../Flowbite/FlowbiteTheme';
 
 export type AlertProps = PropsWithChildren<{
   additionalContent?: ReactNode;
-  color?: string;
+  color?: keyof Colors;
   icon?: FC<ComponentProps<'svg'>>;
   onDismiss?: boolean | (() => void);
   rounded?: boolean;
@@ -15,7 +16,7 @@ export type AlertProps = PropsWithChildren<{
 export const Alert: FC<AlertProps> = ({
   additionalContent,
   children,
-  color = 'blue',
+  color = 'info',
   icon: Icon,
   onDismiss,
   rounded = true,

--- a/src/lib/components/Flowbite/FlowbiteTheme.d.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.d.ts
@@ -1,0 +1,37 @@
+export interface FlowbiteTheme {
+  accordion: {
+    base: string;
+    title: {
+      base: string;
+      isOpen: string;
+      isOpenNotFlushed: string;
+      notFlushed: string;
+    };
+    content: {
+      base: string;
+    };
+  };
+  alert: {
+    base: string;
+    borderAccent: string;
+    closeButton: {
+      base: string;
+      color: Colors;
+    };
+    color: Colors;
+    icon: string;
+    rounded: string;
+  };
+}
+
+export type Colors = FlowbiteColors & {
+  [key in string]: string;
+};
+
+export interface FlowbiteColors {
+  failure: string;
+  gray: string;
+  info: string;
+  success: string;
+  warning: string;
+}

--- a/src/lib/components/Flowbite/ThemeContext.tsx
+++ b/src/lib/components/Flowbite/ThemeContext.tsx
@@ -6,9 +6,39 @@ import defaultTheme from '../../theme/default';
 export type Mode = string | undefined | 'light' | 'dark';
 
 interface ThemeContextProps {
-  theme: any;
+  theme: FlowbiteTheme;
   mode?: Mode;
   toggleMode?: () => void | null;
+}
+
+export interface FlowbiteTheme {
+  accordion: {
+    base: string;
+    title: {
+      base: string;
+      isOpen: string;
+      isOpenNotFlushed: string;
+      notFlushed: string;
+    };
+    content: {
+      base: string;
+    };
+  };
+  alert: {
+    base: string;
+    borderAccent: string;
+    closeButton: {
+      base: string;
+      color: {
+        [key in string]: string;
+      };
+    };
+    color: {
+      [key in string]: string;
+    };
+    icon: string;
+    rounded: string;
+  };
 }
 
 export const ThemeContext = createContext<ThemeContextProps>({

--- a/src/lib/components/Flowbite/ThemeContext.tsx
+++ b/src/lib/components/Flowbite/ThemeContext.tsx
@@ -2,6 +2,7 @@
 import { FC, ReactNode, createContext, useContext, useState, useEffect } from 'react';
 import windowExists from '../../helpers/window-exists';
 import defaultTheme from '../../theme/default';
+import { FlowbiteTheme } from './FlowbiteTheme';
 
 export type Mode = string | undefined | 'light' | 'dark';
 
@@ -9,36 +10,6 @@ interface ThemeContextProps {
   theme: FlowbiteTheme;
   mode?: Mode;
   toggleMode?: () => void | null;
-}
-
-export interface FlowbiteTheme {
-  accordion: {
-    base: string;
-    title: {
-      base: string;
-      isOpen: string;
-      isOpenNotFlushed: string;
-      notFlushed: string;
-    };
-    content: {
-      base: string;
-    };
-  };
-  alert: {
-    base: string;
-    borderAccent: string;
-    closeButton: {
-      base: string;
-      color: {
-        [key in string]: string;
-      };
-    };
-    color: {
-      [key in string]: string;
-    };
-    icon: string;
-    rounded: string;
-  };
 }
 
 export const ThemeContext = createContext<ThemeContextProps>({

--- a/src/lib/components/Flowbite/index.tsx
+++ b/src/lib/components/Flowbite/index.tsx
@@ -3,12 +3,19 @@ import { ThemeContext, useThemeMode } from './ThemeContext';
 import { mergeDeep } from '../../helpers/mergeDeep';
 import defaultTheme from '../../theme/default';
 import windowExists from '../../helpers/window-exists';
+import { FlowbiteTheme } from './FlowbiteTheme';
 
 export interface ThemeProps {
-  config?: object;
   dark?: boolean;
+  theme?: DeepPartial<FlowbiteTheme>;
   usePreferences?: boolean;
 }
+
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;
 
 interface FlowbiteProps extends HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
@@ -16,7 +23,7 @@ interface FlowbiteProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export const Flowbite: FC<FlowbiteProps> = ({ children, theme = {} }) => {
-  const { config: customTheme, dark, usePreferences = true } = theme;
+  const { theme: customTheme, dark, usePreferences = true } = theme;
   const [mode, setMode, toggleMode] = useThemeMode(usePreferences);
 
   const mergedTheme = mergeDeep(defaultTheme, customTheme);
@@ -44,3 +51,5 @@ export const Flowbite: FC<FlowbiteProps> = ({ children, theme = {} }) => {
 
   return <ThemeContext.Provider value={themeContextValue}>{children}</ThemeContext.Provider>;
 };
+
+export type { FlowbiteTheme } from './FlowbiteTheme';

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -17,21 +17,22 @@ export default {
     closeButton: {
       base: '-mx-1.5 -my-1.5 ml-auto inline-flex h-8 w-8 rounded-lg p-1.5 focus:ring-2',
       color: {
-        blue: 'bg-blue-100 text-blue-500 hover:bg-blue-200 focus:ring-blue-400 dark:bg-blue-200 dark:text-blue-600 dark:hover:bg-blue-300',
-        red: 'bg-red-100 text-red-500 hover:bg-red-200 focus:ring-red-400 dark:bg-red-200 dark:text-red-600 dark:hover:bg-red-300',
-        green:
-          'bg-green-100 text-green-500 hover:bg-green-200 focus:ring-green-400 dark:bg-green-200 dark:text-green-600 dark:hover:bg-green-300',
-        yellow:
-          'bg-yellow-100 text-yellow-500 hover:bg-yellow-200 focus:ring-yellow-400 dark:bg-yellow-200 dark:text-yellow-600 dark:hover:bg-yellow-300',
+        info: 'bg-blue-100 text-blue-500 hover:bg-blue-200 focus:ring-blue-400 dark:bg-blue-200 dark:text-blue-600 dark:hover:bg-blue-300',
+        failure:
+          'bg-red-100 text-red-500 hover:bg-red-200 focus:ring-red-400 dark:bg-red-200 dark:text-red-600 dark:hover:bg-red-300',
         gray: 'bg-gray-100 text-gray-500 hover:bg-gray-200 focus:ring-gray-400 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white',
+        success:
+          'bg-green-100 text-green-500 hover:bg-green-200 focus:ring-green-400 dark:bg-green-200 dark:text-green-600 dark:hover:bg-green-300',
+        warning:
+          'bg-yellow-100 text-yellow-500 hover:bg-yellow-200 focus:ring-yellow-400 dark:bg-yellow-200 dark:text-yellow-600 dark:hover:bg-yellow-300',
       },
     },
     color: {
-      blue: 'text-blue-700 bg-blue-100 border-blue-500 dark:bg-blue-200 dark:text-blue-800',
-      red: 'text-red-700 bg-red-100 border-red-500 dark:bg-red-200 dark:text-red-800',
-      green: 'text-green-700 bg-green-100 border-green-500 dark:bg-green-200 dark:text-green-800',
-      yellow: 'text-yellow-700 bg-yellow-100 border-yellow-500 dark:bg-yellow-200 dark:text-yellow-800',
+      info: 'text-blue-700 bg-blue-100 border-blue-500 dark:bg-blue-200 dark:text-blue-800',
+      failure: 'text-red-700 bg-red-100 border-red-500 dark:bg-red-200 dark:text-red-800',
       gray: 'text-gray-700 bg-gray-100 border-gray-500 dark:bg-gray-700 dark:text-gray-300',
+      success: 'text-green-700 bg-green-100 border-green-500 dark:bg-green-200 dark:text-green-800',
+      warning: 'text-yellow-700 bg-yellow-100 border-yellow-500 dark:bg-yellow-200 dark:text-yellow-800',
     },
     icon: 'mr-3 inline h-5 w-5 flex-shrink-0',
     rounded: 'rounded-lg',

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -11,4 +11,29 @@ export default {
       base: 'py-5 px-5 last:rounded-b-lg dark:bg-gray-900',
     },
   },
+  alert: {
+    base: 'flex flex-col gap-2 p-4 text-sm',
+    borderAccent: 'border-t-4',
+    closeButton: {
+      base: '-mx-1.5 -my-1.5 ml-auto inline-flex h-8 w-8 rounded-lg p-1.5 focus:ring-2',
+      color: {
+        blue: 'bg-blue-100 text-blue-500 hover:bg-blue-200 focus:ring-blue-400 dark:bg-blue-200 dark:text-blue-600 dark:hover:bg-blue-300',
+        red: 'bg-red-100 text-red-500 hover:bg-red-200 focus:ring-red-400 dark:bg-red-200 dark:text-red-600 dark:hover:bg-red-300',
+        green:
+          'bg-green-100 text-green-500 hover:bg-green-200 focus:ring-green-400 dark:bg-green-200 dark:text-green-600 dark:hover:bg-green-300',
+        yellow:
+          'bg-yellow-100 text-yellow-500 hover:bg-yellow-200 focus:ring-yellow-400 dark:bg-yellow-200 dark:text-yellow-600 dark:hover:bg-yellow-300',
+        gray: 'bg-gray-100 text-gray-500 hover:bg-gray-200 focus:ring-gray-400 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white',
+      },
+    },
+    color: {
+      blue: 'text-blue-700 bg-blue-100 border-blue-500 dark:bg-blue-200 dark:text-blue-800',
+      red: 'text-red-700 bg-red-100 border-red-500 dark:bg-red-200 dark:text-red-800',
+      green: 'text-green-700 bg-green-100 border-green-500 dark:bg-green-200 dark:text-green-800',
+      yellow: 'text-yellow-700 bg-yellow-100 border-yellow-500 dark:bg-yellow-200 dark:text-yellow-800',
+      gray: 'text-gray-700 bg-gray-100 border-gray-500 dark:bg-gray-700 dark:text-gray-300',
+    },
+    icon: 'mr-3 inline h-5 w-5 flex-shrink-0',
+    rounded: 'rounded-lg',
+  },
 };


### PR DESCRIPTION
## Breaking changes

None.

## Features

- [x] [Explicitly type <Flowbite theme={}>](https://github.com/themesberg/flowbite-react/pull/151/commits/433f2925f8328dbd4ee6a1fa6cc703aa6425546f)
- [x] [Add Accordion theme defaults](https://github.com/themesberg/flowbite-react/commit/af30327cb0b6a99ee9527b31f9ad9c0328b2ebfc)
- [x] [Rewrite](https://github.com/themesberg/flowbite-react/pull/151/commits/de4e6408ea3f6652b7c4e4ea320eb74e49c21cec) [Alert](https://github.com/themesberg/flowbite-react/pull/151/commits/de4e6408ea3f6652b7c4e4ea320eb74e49c21cec)[s to use themes,](https://github.com/themesberg/flowbite-react/pull/151/commits/de4e6408ea3f6652b7c4e4ea320eb74e49c21cec) [resolves](https://github.com/themesberg/flowbite-react/pull/151/commits/de4e6408ea3f6652b7c4e4ea320eb74e49c21cec) https://github.com/themesberg/flowbite-react/issues/126
- [x] [Check type on <Flowbite theme={..}>](https://github.com/themesberg/flowbite-react/pull/151/commits/b756acd3db323f8a1c0d0899ec019e48a621e6ad)
- [x] [Use semantic colors in <Flowbite theme>](https://github.com/themesberg/flowbite-react/pull/151/commits/a1b48addf128f9f904d30a334667d085b2e5c097)

## Bug fixes

- [x] [Remove redundant a11y label from Alert close button](https://github.com/themesberg/flowbite-react/pull/151/commits/649143bb444d5bb4089b82387509d432da780704)