### PR TITLE
feature(component): Rewrite `Badge` to use themes, resolves #128

### DIFF
--- a/src/docs/pages/BadgesPage.tsx
+++ b/src/docs/pages/BadgesPage.tsx
@@ -10,11 +10,11 @@ const BadgesPage: FC = () => {
       title: 'Default badge',
       code: (
         <div className="flex flex-wrap gap-2">
-          <Badge color="blue">Default</Badge>
+          <Badge color="info">Default</Badge>
           <Badge color="gray">Dark</Badge>
-          <Badge color="red">Red</Badge>
-          <Badge color="green">Green</Badge>
-          <Badge color="yellow">Yellow</Badge>
+          <Badge color="failure">Failure</Badge>
+          <Badge color="success">Success</Badge>
+          <Badge color="warning">Warning</Badge>
           <Badge color="indigo">Indigo</Badge>
           <Badge color="purple">Purple</Badge>
           <Badge color="pink">Pink</Badge>
@@ -25,20 +25,20 @@ const BadgesPage: FC = () => {
       title: 'Large badge',
       code: (
         <div className="flex flex-wrap gap-2">
-          <Badge color="blue" size="sm">
+          <Badge color="info" size="sm">
             Default
           </Badge>
           <Badge color="gray" size="sm">
             Dark
           </Badge>
-          <Badge color="red" size="sm">
-            Red
+          <Badge color="failure" size="sm">
+            Failure
           </Badge>
-          <Badge color="green" size="sm">
-            Green
+          <Badge color="success" size="sm">
+            Success
           </Badge>
-          <Badge color="yellow" size="sm">
-            Yellow
+          <Badge color="warning" size="sm">
+            Warning
           </Badge>
           <Badge color="indigo" size="sm">
             Indigo

--- a/src/lib/components/Badge/Badge.spec.tsx
+++ b/src/lib/components/Badge/Badge.spec.tsx
@@ -4,6 +4,20 @@ import { Badge } from '.';
 import { Flowbite } from '../Flowbite';
 
 describe('Components / Badge', () => {
+  describe('Props', () => {
+    it('should ignore `className`', () => {
+      const { getByTestId } = render(
+        <Badge className="test testing" color="success">
+          A badge
+        </Badge>,
+      );
+
+      const badge = getByTestId('flowbite-badge');
+
+      expect(badge).not.toHaveClass('test testing');
+    });
+  });
+
   describe('Rendering', () => {
     describe('"href" provided', () => {
       it('should wrap itself in anchor', () => {
@@ -30,6 +44,7 @@ describe('Components / Badge', () => {
           },
         },
       };
+
       const { getByTestId } = render(
         <Flowbite theme={{ theme }}>
           <Badge color="primary" href="/" icon={HiCheck}>
@@ -37,6 +52,7 @@ describe('Components / Badge', () => {
           </Badge>
         </Flowbite>,
       );
+
       const badge = getByTestId('flowbite-badge');
 
       expect(badge).toHaveClass(
@@ -59,20 +75,26 @@ describe('Components / Badge', () => {
           },
         },
       };
+
       const { getAllByTestId, getByTestId } = render(
         <Flowbite theme={{ theme }}>
           <Badge size="xxl">A badge</Badge>
           <Badge icon={HiCheck} size="xxl" />
         </Flowbite>,
       );
+
       const badges = getAllByTestId('flowbite-badge');
-      const icon = getByTestId('flowbite-badge-icon');
       const regularBadge = badges[0];
-      const emptyBadge = badges[1];
 
       expect(regularBadge).toHaveClass('text-2xl');
       expect(regularBadge).toHaveClass('rounded-lg p-1');
+
+      const emptyBadge = badges[1];
+
       expect(emptyBadge).toHaveClass('rounded-full p-5');
+
+      const icon = getByTestId('flowbite-badge-icon');
+
       expect(icon).toHaveClass('w-6 h-6');
     });
   });

--- a/src/lib/components/Badge/Badge.spec.tsx
+++ b/src/lib/components/Badge/Badge.spec.tsx
@@ -1,19 +1,79 @@
 import { render } from '@testing-library/react';
 import { HiCheck } from 'react-icons/hi';
 import { Badge } from '.';
+import { Flowbite } from '../Flowbite';
 
-describe('Badge', () => {
-  describe('with link', () => {
-    it('should wrap Badge in anchor', () => {
+describe('Components / Badge', () => {
+  describe('Rendering', () => {
+    describe('"href" provided', () => {
+      it('should wrap itself in anchor', () => {
+        const { getByRole } = render(
+          <Badge href="/" icon={HiCheck}>
+            A badge with a link
+          </Badge>,
+        );
+        const badgeLink = getByRole('link');
+
+        expect(badgeLink).toBeInTheDocument();
+        expect(badgeLink).toHaveAttribute('href', '/');
+      });
+    });
+  });
+
+  describe('Theme', () => {
+    it('should use custom colors', () => {
+      const theme = {
+        badge: {
+          color: {
+            primary:
+              'bg-blue-100 text-blue-800 dark:bg-blue-200 dark:text-blue-800 group-hover:bg-blue-200 dark:group-hover:bg-blue-300',
+          },
+        },
+      };
       const { getByTestId } = render(
-        <Badge href="/" icon={HiCheck}>
-          A badge with a link
-        </Badge>,
+        <Flowbite theme={{ theme }}>
+          <Badge color="primary" href="/" icon={HiCheck}>
+            A badge
+          </Badge>
+        </Flowbite>,
       );
+      const badge = getByTestId('flowbite-badge');
 
-      const badgeLink = getByTestId('badge-link');
-      expect(badgeLink).toBeInTheDocument();
-      expect(badgeLink).toHaveAttribute('href', '/');
+      expect(badge).toHaveClass(
+        'bg-blue-100 text-blue-800 dark:bg-blue-200 dark:text-blue-800 group-hover:bg-blue-200 dark:group-hover:bg-blue-300',
+      );
+    });
+
+    it('should use custom sizes', () => {
+      const theme = {
+        badge: {
+          icon: {
+            disabled: 'rounded-lg p-1',
+            enabled: 'rounded-full p-5',
+            size: {
+              xxl: 'w-6 h-6',
+            },
+          },
+          size: {
+            xxl: 'text-2xl',
+          },
+        },
+      };
+      const { getAllByTestId, getByTestId } = render(
+        <Flowbite theme={{ theme }}>
+          <Badge size="xxl">A badge</Badge>
+          <Badge icon={HiCheck} size="xxl" />
+        </Flowbite>,
+      );
+      const badges = getAllByTestId('flowbite-badge');
+      const icon = getByTestId('flowbite-badge-icon');
+      const regularBadge = badges[0];
+      const emptyBadge = badges[1];
+
+      expect(regularBadge).toHaveClass('text-2xl');
+      expect(regularBadge).toHaveClass('rounded-lg p-1');
+      expect(emptyBadge).toHaveClass('rounded-full p-5');
+      expect(icon).toHaveClass('w-6 h-6');
     });
   });
 });

--- a/src/lib/components/Badge/index.tsx
+++ b/src/lib/components/Badge/index.tsx
@@ -2,6 +2,7 @@ import { ComponentProps, FC, PropsWithChildren } from 'react';
 import classNames from 'classnames';
 import { useTheme } from '../Flowbite/ThemeContext';
 import { Colors, BadgeSizes } from '../Flowbite/FlowbiteTheme';
+import { excludeClassName } from '../../helpers/exclude';
 
 export interface BadgeProps extends PropsWithChildren<ComponentProps<'span'>> {
   color?: keyof Colors;
@@ -10,7 +11,15 @@ export interface BadgeProps extends PropsWithChildren<ComponentProps<'span'>> {
   size?: keyof BadgeSizes;
 }
 
-export const Badge: FC<BadgeProps> = ({ children, color = 'info', href, icon: Icon, size = 'xs', ...props }) => {
+export const Badge: FC<BadgeProps> = ({
+  children,
+  color = 'info',
+  href,
+  icon: Icon,
+  size = 'xs',
+  ...props
+}): JSX.Element => {
+  const theirProps = excludeClassName(props);
   const theme = useTheme().theme.badge;
 
   const Content = (): JSX.Element => (
@@ -22,7 +31,7 @@ export const Badge: FC<BadgeProps> = ({ children, color = 'info', href, icon: Ic
         theme.size[size],
       )}
       data-testid="flowbite-badge"
-      {...props}
+      {...theirProps}
     >
       {Icon && <Icon aria-hidden className={theme.icon.size[size]} data-testid="flowbite-badge-icon" />}
       {children && <span>{children}</span>}

--- a/src/lib/components/Badge/index.tsx
+++ b/src/lib/components/Badge/index.tsx
@@ -1,61 +1,39 @@
 import { ComponentProps, FC, PropsWithChildren } from 'react';
 import classNames from 'classnames';
+import { useTheme } from '../Flowbite/ThemeContext';
+import { Colors, BadgeSizes } from '../Flowbite/FlowbiteTheme';
 
-export type BadgeColor = 'blue' | 'red' | 'green' | 'yellow' | 'gray' | 'indigo' | 'purple' | 'pink';
-
-export type BadgeProps = PropsWithChildren<{
-  color?: BadgeColor;
-  size?: 'xs' | 'sm';
+export interface BadgeProps extends PropsWithChildren<ComponentProps<'span'>> {
+  color?: keyof Colors;
   href?: string;
   icon?: FC<ComponentProps<'svg'>>;
-}>;
+  size?: keyof BadgeSizes;
+}
 
-const colorClasses: Record<BadgeProps['color'] & string, string> = {
-  blue: 'bg-blue-100 text-blue-800 dark:bg-blue-200 dark:text-blue-800 group-hover:bg-blue-200 dark:group-hover:bg-blue-300',
-  gray: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300 group-hover:bg-gray-200 dark:group-hover:bg-gray-600',
-  red: 'bg-red-100 text-red-800 dark:bg-red-200 dark:text-red-900 group-hover:bg-red-200 dark:group-hover:bg-red-300',
-  green:
-    'bg-green-100 text-green-800 dark:bg-green-200 dark:text-green-900 group-hover:bg-green-200 dark:group-hover:bg-green-300',
-  yellow:
-    'bg-yellow-100 text-yellow-800 dark:bg-yellow-200 dark:text-yellow-900 group-hover:bg-yellow-200 dark:group-hover:bg-yellow-300',
-  indigo:
-    'bg-indigo-100 text-indigo-800 dark:bg-indigo-200 dark:text-indigo-900 group-hover:bg-indigo-200 dark:group-hover:bg-indigo-300',
-  purple:
-    'bg-purple-100 text-purple-800 dark:bg-purple-200 dark:text-purple-900 group-hover:bg-purple-200 dark:group-hover:bg-purple-300',
-  pink: 'bg-pink-100 text-pink-800 dark:bg-pink-200 dark:text-pink-900 group-hover:bg-pink-200 dark:group-hover:bg-pink-300',
-};
+export const Badge: FC<BadgeProps> = ({ children, color = 'info', href, icon: Icon, size = 'xs', ...props }) => {
+  const theme = useTheme().theme.badge;
 
-const sizeClasses: Record<BadgeProps['size'] & string, string> = {
-  xs: 'text-xs',
-  sm: 'text-sm',
-};
-
-const iconSizeClasses: Record<BadgeProps['size'] & string, string> = {
-  xs: 'w-3 h-3',
-  sm: 'w-3.5 h-3.5',
-};
-
-export const Badge: FC<BadgeProps> = ({ children, color = 'blue', size = 'xs', href, icon: Icon }) => {
-  const span = (
-    <>
-      <span
-        className={classNames('flex h-fit items-center gap-1 font-semibold', colorClasses[color], sizeClasses[size], {
-          'rounded px-2 py-0.5': !!children,
-          'rounded-full p-1': !children && size === 'xs',
-          'rounded-full p-1.5': !children && size === 'sm',
-        })}
-      >
-        {Icon && <Icon className={classNames(iconSizeClasses[size])} />}
-        {children && <span>{children}</span>}
-      </span>
-    </>
+  const Content = (): JSX.Element => (
+    <span
+      className={classNames(
+        Icon ? theme.icon.enabled : theme.icon.disabled,
+        theme.base,
+        theme.color[color],
+        theme.size[size],
+      )}
+      data-testid="flowbite-badge"
+      {...props}
+    >
+      {Icon && <Icon aria-hidden className={theme.icon.size[size]} data-testid="flowbite-badge-icon" />}
+      {children && <span>{children}</span>}
+    </span>
   );
 
   return href ? (
-    <a className="group" data-testid="badge-link" href={href}>
-      {span}
+    <a className={theme.href} href={href}>
+      <Content />
     </a>
   ) : (
-    span
+    <Content />
   );
 };

--- a/src/lib/components/Flowbite/FlowbiteTheme.d.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.d.ts
@@ -48,6 +48,17 @@ export interface FlowbiteTheme {
       'top-right': string;
     };
   };
+  badge: {
+    base: string;
+    color: Colors;
+    href: string;
+    icon: {
+      disabled: string;
+      enabled: string;
+      size: BadgeSizes;
+    };
+    size: BadgeSizes;
+  };
 }
 
 export type Colors = FlowbiteColors & {
@@ -73,3 +84,9 @@ export interface FlowbiteSizes {
   lg: string;
   xl: string;
 }
+
+export type BadgeSizes = FlowbiteBadgeSizes & {
+  [key in string]: string;
+};
+
+export type FlowbiteBadgeSizes = Pick<FlowbiteSizes, 'xs' | 'sm'>;

--- a/src/lib/components/Sidebar/SidebarItem.tsx
+++ b/src/lib/components/Sidebar/SidebarItem.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { ComponentProps, ElementType, FC, PropsWithChildren } from 'react';
-import { Badge, BadgeColor } from '../Badge';
+import { Badge } from '../Badge';
+import { Colors } from '../Flowbite/FlowbiteTheme';
 import { Tooltip } from '../Tooltip';
 import { useSidebarContext } from './SidebarContext';
 import { useSidebarItemContext } from './SidebarItemContext';
@@ -9,7 +10,7 @@ export interface SidebarItem {
   className?: string;
   icon?: FC<ComponentProps<'svg'>>;
   label?: string;
-  labelColor?: BadgeColor;
+  labelColor?: keyof Colors;
 }
 
 export interface SidebarItemProps extends PropsWithChildren<SidebarItem & Record<string, unknown>> {

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -18,9 +18,9 @@ export default {
       base: '-mx-1.5 -my-1.5 ml-auto inline-flex h-8 w-8 rounded-lg p-1.5 focus:ring-2',
       color: {
         info: 'bg-blue-100 text-blue-500 hover:bg-blue-200 focus:ring-blue-400 dark:bg-blue-200 dark:text-blue-600 dark:hover:bg-blue-300',
+        gray: 'bg-gray-100 text-gray-500 hover:bg-gray-200 focus:ring-gray-400 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white',
         failure:
           'bg-red-100 text-red-500 hover:bg-red-200 focus:ring-red-400 dark:bg-red-200 dark:text-red-600 dark:hover:bg-red-300',
-        gray: 'bg-gray-100 text-gray-500 hover:bg-gray-200 focus:ring-gray-400 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white',
         success:
           'bg-green-100 text-green-500 hover:bg-green-200 focus:ring-green-400 dark:bg-green-200 dark:text-green-600 dark:hover:bg-green-300',
         warning:
@@ -29,8 +29,8 @@ export default {
     },
     color: {
       info: 'text-blue-700 bg-blue-100 border-blue-500 dark:bg-blue-200 dark:text-blue-800',
-      failure: 'text-red-700 bg-red-100 border-red-500 dark:bg-red-200 dark:text-red-800',
       gray: 'text-gray-700 bg-gray-100 border-gray-500 dark:bg-gray-700 dark:text-gray-300',
+      failure: 'text-red-700 bg-red-100 border-red-500 dark:bg-red-200 dark:text-red-800',
       success: 'text-green-700 bg-green-100 border-green-500 dark:bg-green-200 dark:text-green-800',
       warning: 'text-yellow-700 bg-yellow-100 border-yellow-500 dark:bg-yellow-200 dark:text-yellow-800',
     },
@@ -65,6 +65,37 @@ export default {
       'bottom-right': '-bottom-1 -right-1',
       'top-left': '-top-1 -left-1',
       'top-right': '-top-1 -right-1',
+    },
+  },
+  badge: {
+    base: 'flex h-fit items-center gap-1 font-semibold',
+    color: {
+      info: 'bg-blue-100 text-blue-800 dark:bg-blue-200 dark:text-blue-800 group-hover:bg-blue-200 dark:group-hover:bg-blue-300',
+      gray: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300 group-hover:bg-gray-200 dark:group-hover:bg-gray-600',
+      failure:
+        'bg-red-100 text-red-800 dark:bg-red-200 dark:text-red-900 group-hover:bg-red-200 dark:group-hover:bg-red-300',
+      success:
+        'bg-green-100 text-green-800 dark:bg-green-200 dark:text-green-900 group-hover:bg-green-200 dark:group-hover:bg-green-300',
+      warning:
+        'bg-yellow-100 text-yellow-800 dark:bg-yellow-200 dark:text-yellow-900 group-hover:bg-yellow-200 dark:group-hover:bg-yellow-300',
+      indigo:
+        'bg-indigo-100 text-indigo-800 dark:bg-indigo-200 dark:text-indigo-900 group-hover:bg-indigo-200 dark:group-hover:bg-indigo-300',
+      purple:
+        'bg-purple-100 text-purple-800 dark:bg-purple-200 dark:text-purple-900 group-hover:bg-purple-200 dark:group-hover:bg-purple-300',
+      pink: 'bg-pink-100 text-pink-800 dark:bg-pink-200 dark:text-pink-900 group-hover:bg-pink-200 dark:group-hover:bg-pink-300',
+    },
+    href: 'group',
+    icon: {
+      disabled: 'rounded px-2 py-0.5',
+      enabled: 'rounded-full p-1.5',
+      size: {
+        xs: 'w-3 h-3',
+        sm: 'w-3.5 h-3.5',
+      },
+    },
+    size: {
+      xs: 'p-1 text-xs',
+      sm: 'p-1.5 text-sm',
     },
   },
 };


### PR DESCRIPTION
## Breaking changes

`Badge`s can now be customized using `<Flowbite theme={..}>`.

```js
badge: {
  base: string;
  color: Colors;
  href: string;
  icon: {
    disabled: string;
    enabled: string;
    size: BadgeSizes;
  };
  size: BadgeSizes;
};
```

- `badge.color` will respect any additional colors you provide, e.g., `<Badge color="primary" />`
- `badge.size` will respect any additional sizes you provide, e.g., `<Badge size="xxl" .../>`
  - `badge.icon.size` can also be scaled as needed

## Features

- [x] [feature(component): Allow props on Badge, excluding className](https://github.com/themesberg/flowbite-react/pull/154/commits/bc738fcbca24517775b2c146754891816fce714c)
- [x] [feature(component): Rewrite](https://github.com/themesberg/flowbite-react/pull/154/commits/1790d36b8a7e5449c69993b314e6de585d578b2d) [Badge](https://github.com/themesberg/flowbite-react/pull/154/commits/1790d36b8a7e5449c69993b314e6de585d578b2d) [t use themes,](https://github.com/themesberg/flowbite-react/pull/154/commits/1790d36b8a7e5449c69993b314e6de585d578b2d) [resolves](https://github.com/themesberg/flowbite-react/pull/154/commits/1790d36b8a7e5449c69993b314e6de585d578b2d) https://github.com/themesberg/flowbite-react/issues/128
- [x] [feature(type): Add theme for Badges](https://github.com/themesberg/flowbite-react/pull/154/commits/ef1cd7431472973adbb880a05619bb9c66c40723)

## Tests

### Unit

- [x] [test(component): Add theme unit tests for Badges](https://github.com/themesberg/flowbite-react/pull/154/commits/9ff69d269c7d9797b177b4ae9a05c500fe90f6c5)