### PR TITLE
feature(component): Rewrite `Accordion` to use `FlowbiteTheme`, resolves #125

### DIFF
--- a/src/docs/pages/SidebarPage.tsx
+++ b/src/docs/pages/SidebarPage.tsx
@@ -15,7 +15,7 @@ const SidebarPage: FC = () => {
               <Sidebar.Item href="#" icon={HiChartPie}>
                 Dashboard
               </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="gray">
+              <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="alternative">
                 Kanban
               </Sidebar.Item>
               <Sidebar.Item href="#" icon={HiInbox} label="3">

--- a/src/lib/components/Accordion/Accordion.spec.tsx
+++ b/src/lib/components/Accordion/Accordion.spec.tsx
@@ -1,98 +1,216 @@
-import { cleanup, render } from '@testing-library/react';
+import { render, RenderResult } from '@testing-library/react';
+import { HiOutlineArrowCircleDown } from 'react-icons/hi';
 
-import { Accordion } from '.';
-import userEvent from '@testing-library/user-event';
+import { Accordion, AccordionProps } from '.';
+import { Flowbite } from '../Flowbite';
 
-describe('Accordion Component', () => {
-  afterEach(cleanup);
+describe('Components / Accordion', () => {
+  describe('Props', () => {
+    it('should ignore `className`', () => {
+      const dom = render(<TestAccordion className="no-classname" />);
+      const accordion = getAccordion(dom);
+      const content = getAccordionContent(dom)[0];
+      const title = getAccordionTitles(dom)[0];
 
-  it('should be able to render an accordion', () => {
-    const { getByTestId } = render(
-      <Accordion>
-        <Accordion.Panel open>
-          <Accordion.Title>What is Flowbite?</Accordion.Title>
-          <Accordion.Content>
-            <p className="mb-2 text-gray-500 dark:text-gray-400">
-              Flowbite is an open-source library of interactive components built on top of Tailwind CSS including
-              buttons, dropdowns, modals, navbars, and more.
-            </p>
-            <p className="text-gray-500 dark:text-gray-400">
-              Check out this guide to learn how to{' '}
-              <a
-                href="https://flowbite.com/docs/getting-started/introduction/"
-                className="text-blue-600 hover:underline dark:text-blue-500"
-              >
-                get started
-              </a>{' '}
-              and start developing websites even faster with components on top of Tailwind CSS.
-            </p>
-          </Accordion.Content>
-        </Accordion.Panel>
-      </Accordion>,
-    );
-    expect(getByTestId('flowbite-accordion')).toBeTruthy();
+      expect(accordion).not.toHaveClass('no-classname');
+      expect(content).not.toHaveClass('no-classname');
+      expect(title).not.toHaveClass('no-classname');
+    });
+
+    describe('`Accordion.Title`', () => {
+      it('should allow any heading level with `as=""`', () => {
+        const headings = getAccordionHeadings(render(<TestAccordion />));
+        const h3Heading = headings[0];
+        const defaultHeading = headings[1];
+
+        expect(h3Heading.tagName.toLocaleLowerCase()).toEqual('h3');
+        expect(defaultHeading.tagName.toLocaleLowerCase()).toEqual('h2');
+      });
+    });
   });
 
-  it('should be able to render a closed accordion', () => {
-    const { getByTestId } = render(
-      <Accordion>
-        <Accordion.Panel>
-          <Accordion.Title>What is Flowbite?</Accordion.Title>
-          <Accordion.Content>
-            <p className="mb-2 text-gray-500 dark:text-gray-400">
-              Flowbite is an open-source library of interactive components built on top of Tailwind CSS including
-              buttons, dropdowns, modals, navbars, and more.
-            </p>
-            <p className="text-gray-500 dark:text-gray-400">
-              Check out this guide to learn how to{' '}
-              <a
-                href="https://flowbite.com/docs/getting-started/introduction/"
-                className="text-blue-600 hover:underline dark:text-blue-500"
-              >
-                get started
-              </a>{' '}
-              and start developing websites even faster with components on top of Tailwind CSS.
-            </p>
-          </Accordion.Content>
-        </Accordion.Panel>
-      </Accordion>,
-    );
-    expect(getByTestId('flowbite-accordion').children.length).toEqual(1);
+  describe('Rendering', () => {
+    it('should render without crashing', () => {
+      const accordion = getAccordion(render(<TestAccordion />));
+
+      expect(accordion).toBeInTheDocument();
+    });
   });
 
-  it("should be able to open and close an accordion panel when clicking on it's title", () => {
-    const { getByRole, getByTestId } = render(
-      <Accordion>
-        <Accordion.Panel>
-          <Accordion.Title>What is Flowbite?</Accordion.Title>
-          <Accordion.Content>
-            <p className="mb-2 text-gray-500 dark:text-gray-400">
-              Flowbite is an open-source library of interactive components built on top of Tailwind CSS including
-              buttons, dropdowns, modals, navbars, and more.
-            </p>
-            <p className="text-gray-500 dark:text-gray-400">
-              Check out this guide to learn how to{' '}
-              <a
-                href="https://flowbite.com/docs/getting-started/introduction/"
-                className="text-blue-600 hover:underline dark:text-blue-500"
-              >
-                get started
-              </a>{' '}
-              and start developing websites even faster with components on top of Tailwind CSS.
-            </p>
-          </Accordion.Content>
-        </Accordion.Panel>
-      </Accordion>,
-    );
+  describe('Theme', () => {
+    describe('`Accordion`', () => {
+      it('should use custom `base` classes', () => {
+        const theme = {
+          accordion: {
+            base: 'text-4xl',
+          },
+        };
 
-    expect(getByTestId('flowbite-accordion').children.length).toEqual(1);
+        const accordion = getAccordion(
+          render(
+            <Flowbite theme={{ theme }}>
+              <TestAccordion />
+            </Flowbite>,
+          ),
+        );
 
-    // Open first panel
-    userEvent.click(getByRole('button'));
-    expect(getByTestId('flowbite-accordion').children.length).toEqual(2);
+        expect(accordion).toHaveClass('text-4xl');
+      });
 
-    // Close it again
-    userEvent.click(getByRole('button'));
-    expect(getByTestId('flowbite-accordion').children.length).toEqual(1);
+      it('should use custom `flush` classes', () => {
+        const theme = {
+          accordion: {
+            flush: {
+              off: 'text-4xl',
+              on: 'text-3xl',
+            },
+          },
+        };
+
+        const accordions = getAccordions(
+          render(
+            <Flowbite theme={{ theme }}>
+              <TestAccordion />
+              <TestAccordion flush />
+            </Flowbite>,
+          ),
+        );
+        const normal = accordions[0];
+        const flush = accordions[1];
+
+        expect(normal).toHaveClass('text-4xl');
+        expect(flush).toHaveClass('text-3xl');
+      });
+    });
+
+    describe('`Accordion.Content`', () => {
+      it('should use custom `content` classes', () => {
+        const theme = {
+          accordion: {
+            content: {
+              base: 'text-4xl',
+            },
+          },
+        };
+
+        const accordionContent = getAccordionContent(
+          render(
+            <Flowbite theme={{ theme }}>
+              <TestAccordion />
+            </Flowbite>,
+          ),
+        );
+
+        accordionContent.forEach((item) => expect(item).toHaveClass('text-4xl'));
+      });
+    });
+
+    describe('`Accordion.Title`', () => {
+      it('should use custom `title` classes', () => {
+        const theme = {
+          accordion: {
+            title: {
+              arrow: {
+                base: 'w-8 h-8',
+                open: 'text-purple-600',
+              },
+              base: 'p-3',
+              flush: {
+                off: 'text-4xl',
+                on: 'text-3xl',
+              },
+              open: {
+                off: 'text-gray-400',
+                on: 'text-gray-600',
+              },
+            },
+          },
+        };
+
+        const titles = getAccordionTitles(
+          render(
+            <Flowbite theme={{ theme }}>
+              <TestAccordion />
+              <TestAccordion flush />
+            </Flowbite>,
+          ),
+        );
+        const normalTitles = [titles[0], titles[1]];
+        const flushTitles = [titles[2], titles[3]];
+        const openTitles = [titles[0], titles[2]];
+        const closedTitles = [titles[1], titles[3]];
+
+        titles.forEach((title) => expect(title).toHaveClass('p-3'));
+        normalTitles.forEach((title) => expect(title).toHaveClass('text-4xl'));
+        flushTitles.forEach((title) => expect(title).toHaveClass('text-3xl'));
+        openTitles.forEach((title) => expect(title).toHaveClass('text-gray-600'));
+        closedTitles.forEach((title) => expect(title).toHaveClass('text-gray-400'));
+      });
+    });
+  });
+
+  describe('A11y', () => {
+    it('should allow `aria-label`', () => {
+      const accordion = getAccordion(render(<TestAccordion aria-label="My accordion" />));
+
+      expect(accordion).toHaveAccessibleName('My accordion');
+    });
+
+    describe('`Accordion.Content`', () => {
+      it('should allow `aria-labelledby=""`', () => {
+        const dom = render(<TestAccordion />);
+        const title = getAccordionTitles(dom)[0];
+        const content = getAccordionContent(dom)[0];
+
+        expect(title).toHaveAttribute('id', 'accordion-title');
+        expect(content).toHaveAttribute('aria-labelledby', 'accordion-title');
+        expect(content).toHaveAccessibleName('Title');
+      });
+    });
+
+    describe('`Accordion.Title`', () => {
+      it('should contain `role="button"`', () => {
+        const titles = getAccordionTitles(render(<TestAccordion />));
+
+        titles.forEach((title) => expect(title).toHaveAccessibleName('Title'));
+      });
+
+      it('should allow `id=""`', () => {
+        const accordion = getAccordion(render(<TestAccordion aria-label="My accordion" />));
+
+        expect(accordion).toHaveAccessibleName('My accordion');
+      });
+    });
   });
 });
+
+const TestAccordion = ({ ...props }: AccordionProps): JSX.Element => (
+  <Accordion {...props}>
+    <Accordion.Panel open>
+      <Accordion.Title arrowIcon={HiOutlineArrowCircleDown} as="h3" className="no-classname" id="accordion-title">
+        Title
+      </Accordion.Title>
+      <Accordion.Content className="no-classname" aria-labelledby="accordion-title">
+        <p>Content</p>
+      </Accordion.Content>
+    </Accordion.Panel>
+    <Accordion.Panel>
+      <Accordion.Title arrowIcon={HiOutlineArrowCircleDown}>Title</Accordion.Title>
+      <Accordion.Content>
+        <p>Content</p>
+      </Accordion.Content>
+    </Accordion.Panel>
+  </Accordion>
+);
+
+const getAccordion = ({ getByTestId }: RenderResult): HTMLElement => getByTestId('flowbite-accordion');
+
+const getAccordions = ({ getAllByTestId }: RenderResult): HTMLElement[] => getAllByTestId('flowbite-accordion');
+
+const getAccordionContent = ({ getAllByTestId }: RenderResult): HTMLElement[] =>
+  getAllByTestId('flowbite-accordion-content');
+
+const getAccordionHeadings = ({ getAllByTestId }: RenderResult): HTMLElement[] =>
+  getAllByTestId('flowbite-accordion-heading');
+
+const getAccordionTitles = ({ getAllByRole }: RenderResult): HTMLElement[] => getAllByRole('button');

--- a/src/lib/components/Accordion/Accordion.spec.tsx
+++ b/src/lib/components/Accordion/Accordion.spec.tsx
@@ -30,7 +30,7 @@ describe('Accordion Component', () => {
         </Accordion.Panel>
       </Accordion>,
     );
-    expect(getByTestId('accordion-element')).toBeTruthy();
+    expect(getByTestId('flowbite-accordion')).toBeTruthy();
   });
 
   it('should be able to render a closed accordion', () => {
@@ -57,11 +57,11 @@ describe('Accordion Component', () => {
         </Accordion.Panel>
       </Accordion>,
     );
-    expect(getByTestId('accordion-element').children.length).toEqual(1);
+    expect(getByTestId('flowbite-accordion').children.length).toEqual(1);
   });
 
   it("should be able to open and close an accordion panel when clicking on it's title", () => {
-    const { getByTestId } = render(
+    const { getByRole, getByTestId } = render(
       <Accordion>
         <Accordion.Panel>
           <Accordion.Title>What is Flowbite?</Accordion.Title>
@@ -85,14 +85,14 @@ describe('Accordion Component', () => {
       </Accordion>,
     );
 
-    expect(getByTestId('accordion-element').children.length).toEqual(1);
+    expect(getByTestId('flowbite-accordion').children.length).toEqual(1);
 
     // Open first panel
-    userEvent.click(getByTestId('accordion-title-element'));
-    expect(getByTestId('accordion-element').children.length).toEqual(2);
+    userEvent.click(getByRole('button'));
+    expect(getByTestId('flowbite-accordion').children.length).toEqual(2);
 
     // Close it again
-    userEvent.click(getByTestId('accordion-title-element'));
-    expect(getByTestId('accordion-element').children.length).toEqual(1);
+    userEvent.click(getByRole('button'));
+    expect(getByTestId('flowbite-accordion').children.length).toEqual(1);
   });
 });

--- a/src/lib/components/Accordion/AccordionContent.tsx
+++ b/src/lib/components/Accordion/AccordionContent.tsx
@@ -1,21 +1,17 @@
-import classNames from 'classnames';
 import { ComponentProps, FC } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
 import { useTheme } from '../Flowbite/ThemeContext';
 
 import { useAccordionContext } from './AccordionPanelContext';
 
-export const AccordionContent: FC<ComponentProps<'div'>> = ({ children, ...props }) => {
-  const {
-    theme: {
-      accordion: { content },
-    },
-  } = useTheme();
-  const { isOpen } = useAccordionContext();
+export const AccordionContent: FC<ComponentProps<'div'>> = ({ children, ...props }): JSX.Element | null => {
+  const theirProps = excludeClassName(props);
 
-  const baseStyle = classNames('first:rounded-t-lg', content.base);
+  const { isOpen } = useAccordionContext();
+  const theme = useTheme().theme.accordion.content;
 
   return isOpen ? (
-    <div {...props} className={baseStyle}>
+    <div className={theme.base} {...theirProps}>
       {children}
     </div>
   ) : null;

--- a/src/lib/components/Accordion/AccordionContent.tsx
+++ b/src/lib/components/Accordion/AccordionContent.tsx
@@ -4,15 +4,15 @@ import { useTheme } from '../Flowbite/ThemeContext';
 
 import { useAccordionContext } from './AccordionPanelContext';
 
-export const AccordionContent: FC<ComponentProps<'div'>> = ({ children, ...props }): JSX.Element | null => {
+export const AccordionContent: FC<ComponentProps<'div'>> = ({ children, ...props }): JSX.Element => {
   const theirProps = excludeClassName(props);
 
   const { isOpen } = useAccordionContext();
   const theme = useTheme().theme.accordion.content;
 
-  return isOpen ? (
-    <div className={theme.base} {...theirProps}>
+  return (
+    <div className={theme.base} data-testid="flowbite-accordion-content" hidden={!isOpen} {...theirProps}>
       {children}
     </div>
-  ) : null;
+  );
 };

--- a/src/lib/components/Accordion/AccordionPanel.tsx
+++ b/src/lib/components/Accordion/AccordionPanel.tsx
@@ -1,12 +1,12 @@
 import { Children, cloneElement, ComponentProps, FC, PropsWithChildren, ReactElement, useMemo, useState } from 'react';
 import { AccordionPanelContext } from './AccordionPanelContext';
 
-export type AccordionPanelProps = PropsWithChildren<{
-  open?: boolean;
+export interface AccordionPanelProps extends PropsWithChildren<Record<string, unknown>> {
   flush?: boolean;
-}>;
+  open?: boolean;
+}
 
-export const AccordionPanel: FC<AccordionPanelProps> = ({ children, open, flush }) => {
+export const AccordionPanel: FC<AccordionPanelProps> = ({ children, flush, open }): JSX.Element => {
   const [isOpen, setIsOpen] = useState(open);
   const items = useMemo(
     () => Children.map(children as ReactElement<ComponentProps<'div' | 'button'>>[], (child) => cloneElement(child)),

--- a/src/lib/components/Accordion/AccordionTitle.tsx
+++ b/src/lib/components/Accordion/AccordionTitle.tsx
@@ -4,13 +4,16 @@ import { HiChevronDown } from 'react-icons/hi';
 import { useAccordionContext } from './AccordionPanelContext';
 import { useTheme } from '../Flowbite/ThemeContext';
 import { excludeClassName } from '../../helpers/exclude';
+import { HeadingLevel } from '../Flowbite/FlowbiteTheme';
 
 export interface AccordionTitleProps extends ComponentProps<'button'> {
   arrowIcon?: FC<ComponentProps<'svg'>>;
+  as?: HeadingLevel;
 }
 
 export const AccordionTitle: FC<AccordionTitleProps> = ({
   arrowIcon: ArrowIcon = HiChevronDown,
+  as: Heading = 'h2',
   children,
   ...props
 }): JSX.Element => {
@@ -28,8 +31,8 @@ export const AccordionTitle: FC<AccordionTitleProps> = ({
       type="button"
       {...theirProps}
     >
-      <h2>{children}</h2>
-      <ArrowIcon className={classNames(theme.arrow.base, isOpen && theme.arrow.open)} />
+      <Heading data-testid="flowbite-accordion-heading">{children}</Heading>
+      <ArrowIcon aria-hidden className={classNames(theme.arrow.base, isOpen && theme.arrow.open)} />
     </button>
   );
 };

--- a/src/lib/components/Accordion/AccordionTitle.tsx
+++ b/src/lib/components/Accordion/AccordionTitle.tsx
@@ -3,45 +3,33 @@ import classNames from 'classnames';
 import { HiChevronDown } from 'react-icons/hi';
 import { useAccordionContext } from './AccordionPanelContext';
 import { useTheme } from '../Flowbite/ThemeContext';
+import { excludeClassName } from '../../helpers/exclude';
 
-export type AccordionTitleProps = ComponentProps<'button'> & {
+export interface AccordionTitleProps extends ComponentProps<'button'> {
   arrowIcon?: FC<ComponentProps<'svg'>>;
-};
+}
 
 export const AccordionTitle: FC<AccordionTitleProps> = ({
-  children,
   arrowIcon: ArrowIcon = HiChevronDown,
+  children,
   ...props
-}) => {
+}): JSX.Element => {
+  const theirProps = excludeClassName(props);
+
   const { flush, isOpen, setIsOpen } = useAccordionContext();
+  const theme = useTheme().theme.accordion.title;
+
   const onClick = () => setIsOpen(!isOpen);
-
-  const {
-    theme: {
-      accordion: { title },
-    },
-  } = useTheme();
-
-  const baseStyle = classNames(
-    'flex w-full items-center justify-between first:rounded-t-lg last:rounded-b-lg',
-    title.base,
-  );
-  const buttonStateStyle = classNames({
-    [title.notFlushed]: !flush,
-    [title.isOpen]: isOpen,
-    [title.isOpenNotFlushed]: isOpen && !flush,
-  });
 
   return (
     <button
-      data-testid="accordion-title-element"
-      {...props}
-      type="button"
-      className={classNames(baseStyle, buttonStateStyle)}
+      className={classNames(theme.base, theme.flush[flush ? 'on' : 'off'], theme.open[isOpen ? 'on' : 'off'])}
       onClick={onClick}
+      type="button"
+      {...theirProps}
     >
       <h2>{children}</h2>
-      <ArrowIcon className={classNames('h-6 w-6 shrink-0', { 'rotate-180': isOpen })} />
+      <ArrowIcon className={classNames(theme.arrow.base, isOpen && theme.arrow.open)} />
     </button>
   );
 };

--- a/src/lib/components/Accordion/index.tsx
+++ b/src/lib/components/Accordion/index.tsx
@@ -1,24 +1,18 @@
-import { Children, cloneElement, FC, PropsWithChildren, ReactElement, useMemo } from 'react';
+import { Children, cloneElement, ComponentProps, FC, PropsWithChildren, ReactElement, useMemo } from 'react';
 import { AccordionPanel, AccordionPanelProps } from './AccordionPanel';
 import { AccordionTitle } from './AccordionTitle';
 import { AccordionContent } from './AccordionContent';
-import cn from 'classnames';
+import classNames from 'classnames';
 import { useTheme } from '../Flowbite/ThemeContext';
+import { excludeClassName } from '../../helpers/exclude';
 
-export type AccordionProps = PropsWithChildren<{
+export interface AccordionProps extends PropsWithChildren<ComponentProps<'div'>> {
   flush?: boolean;
-}>;
+}
 
-const AccordionComponent: FC<AccordionProps> = ({ children, flush }) => {
-  const {
-    theme: { accordion },
-  } = useTheme();
-
-  const baseStyle = accordion.base;
-  const flushStyle = {
-    'rounded-lg border': !flush,
-    'border-b': flush,
-  };
+const AccordionComponent: FC<AccordionProps> = ({ children, flush, ...props }): JSX.Element => {
+  const theirProps = excludeClassName(props);
+  const theme = useTheme().theme.accordion;
 
   const panels = useMemo(
     () => Children.map(children as ReactElement<AccordionPanelProps>[], (child) => cloneElement(child, { flush })),
@@ -26,7 +20,11 @@ const AccordionComponent: FC<AccordionProps> = ({ children, flush }) => {
   );
 
   return (
-    <div data-testid="accordion-element" className={cn(baseStyle, flushStyle)}>
+    <div
+      className={classNames(theme.base, theme.flush[flush ? 'on' : 'off'])}
+      data-testid="flowbite-accordion"
+      {...theirProps}
+    >
       {panels}
     </div>
   );

--- a/src/lib/components/Accordion/index.tsx
+++ b/src/lib/components/Accordion/index.tsx
@@ -12,6 +12,7 @@ export interface AccordionProps extends PropsWithChildren<ComponentProps<'div'>>
 
 const AccordionComponent: FC<AccordionProps> = ({ children, flush, ...props }): JSX.Element => {
   const theirProps = excludeClassName(props);
+
   const theme = useTheme().theme.accordion;
 
   const panels = useMemo(

--- a/src/lib/components/Alert/index.tsx
+++ b/src/lib/components/Alert/index.tsx
@@ -4,14 +4,18 @@ import { HiX } from 'react-icons/hi';
 import { useTheme } from '../Flowbite/ThemeContext';
 import { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
 
-export type AlertProps = PropsWithChildren<{
+export interface AlertProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'color'>> {
   additionalContent?: ReactNode;
-  color?: keyof FlowbiteColors;
+  color?: keyof AlertColors;
   icon?: FC<ComponentProps<'svg'>>;
   onDismiss?: boolean | (() => void);
   rounded?: boolean;
   withBorderAccent?: boolean;
-}>;
+}
+
+export interface AlertColors extends Pick<FlowbiteColors, 'failure' | 'gray' | 'info' | 'success' | 'warning'> {
+  [key: string]: string;
+}
 
 export const Alert: FC<AlertProps> = ({
   additionalContent,

--- a/src/lib/components/Alert/index.tsx
+++ b/src/lib/components/Alert/index.tsx
@@ -2,11 +2,11 @@ import { ComponentProps, FC, PropsWithChildren, ReactNode } from 'react';
 import classNames from 'classnames';
 import { HiX } from 'react-icons/hi';
 import { useTheme } from '../Flowbite/ThemeContext';
-import { Colors } from '../Flowbite/FlowbiteTheme';
+import { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
 
 export type AlertProps = PropsWithChildren<{
   additionalContent?: ReactNode;
-  color?: keyof Colors;
+  color?: keyof FlowbiteColors;
   icon?: FC<ComponentProps<'svg'>>;
   onDismiss?: boolean | (() => void);
   rounded?: boolean;

--- a/src/lib/components/Avatar/Avatar.spec.tsx
+++ b/src/lib/components/Avatar/Avatar.spec.tsx
@@ -26,8 +26,7 @@ describe('Components / Avatar', () => {
         </Flowbite>,
       );
 
-      expect(getByTestId('flowbite-avatar-img')).toHaveClass('h-64');
-      expect(getByTestId('flowbite-avatar-img')).toHaveClass('w-64');
+      expect(getByTestId('flowbite-avatar-img')).toHaveClass('h-64 w-64');
     });
   });
 });

--- a/src/lib/components/Avatar/index.tsx
+++ b/src/lib/components/Avatar/index.tsx
@@ -42,7 +42,7 @@ const AvatarComponent: FC<AvatarProps> = ({
               bordered && theme.bordered,
               rounded && theme.rounded,
               stacked && theme.stacked,
-              theme.img.enabled,
+              theme.img.on,
               theme.size[size],
             )}
             data-testid="flowbite-avatar-img"
@@ -54,7 +54,7 @@ const AvatarComponent: FC<AvatarProps> = ({
               bordered && theme.bordered,
               rounded && theme.rounded,
               stacked && theme.stacked,
-              theme.img.disabled,
+              theme.img.off,
               theme.size[size],
             )}
             data-testid="flowbite-avatar-img"

--- a/src/lib/components/Avatar/index.tsx
+++ b/src/lib/components/Avatar/index.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { ComponentProps, FC, PropsWithChildren } from 'react';
 import { excludeClassName } from '../../helpers/exclude';
-import { Sizes } from '../Flowbite/FlowbiteTheme';
+import { FlowbitePositions, FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
 import { useTheme } from '../Flowbite/ThemeContext';
 import AvatarGroup from './AvatarGroup';
 import AvatarGroupCounter from './AvatarGroupCounter';
@@ -11,10 +11,14 @@ export interface AvatarProps extends PropsWithChildren<ComponentProps<'div'>> {
   bordered?: boolean;
   img?: string;
   rounded?: boolean;
-  size?: keyof Sizes;
+  size?: keyof AvatarSizes;
   stacked?: boolean;
   status?: 'away' | 'busy' | 'offline' | 'online';
-  statusPosition?: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right';
+  statusPosition?: keyof FlowbitePositions;
+}
+
+export interface AvatarSizes extends FlowbiteSizes {
+  [key: string]: string;
 }
 
 const AvatarComponent: FC<AvatarProps> = ({

--- a/src/lib/components/Badge/Badge.spec.tsx
+++ b/src/lib/components/Badge/Badge.spec.tsx
@@ -64,8 +64,8 @@ describe('Components / Badge', () => {
       const theme = {
         badge: {
           icon: {
-            disabled: 'rounded-lg p-1',
-            enabled: 'rounded-full p-5',
+            off: 'rounded-lg p-1',
+            on: 'rounded-full p-5',
             size: {
               xxl: 'w-6 h-6',
             },

--- a/src/lib/components/Badge/index.tsx
+++ b/src/lib/components/Badge/index.tsx
@@ -24,12 +24,7 @@ export const Badge: FC<BadgeProps> = ({
 
   const Content = (): JSX.Element => (
     <span
-      className={classNames(
-        Icon ? theme.icon.enabled : theme.icon.disabled,
-        theme.base,
-        theme.color[color],
-        theme.size[size],
-      )}
+      className={classNames(Icon ? theme.icon.on : theme.icon.off, theme.base, theme.color[color], theme.size[size])}
       data-testid="flowbite-badge"
       {...theirProps}
     >

--- a/src/lib/components/Badge/index.tsx
+++ b/src/lib/components/Badge/index.tsx
@@ -1,14 +1,22 @@
 import { ComponentProps, FC, PropsWithChildren } from 'react';
 import classNames from 'classnames';
 import { useTheme } from '../Flowbite/ThemeContext';
-import { Colors, BadgeSizes } from '../Flowbite/FlowbiteTheme';
+import { FlowbiteColors, FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
 import { excludeClassName } from '../../helpers/exclude';
 
-export interface BadgeProps extends PropsWithChildren<ComponentProps<'span'>> {
-  color?: keyof Colors;
+export interface BadgeProps extends PropsWithChildren<Omit<ComponentProps<'span'>, 'color'>> {
+  color?: keyof BadgeColors;
   href?: string;
   icon?: FC<ComponentProps<'svg'>>;
   size?: keyof BadgeSizes;
+}
+
+export interface BadgeColors extends FlowbiteColors {
+  [key: string]: string;
+}
+
+export interface BadgeSizes extends FlowbiteSizes {
+  [key: string]: string;
 }
 
 export const Badge: FC<BadgeProps> = ({
@@ -20,6 +28,7 @@ export const Badge: FC<BadgeProps> = ({
   ...props
 }): JSX.Element => {
   const theirProps = excludeClassName(props);
+
   const theme = useTheme().theme.badge;
 
   const Content = (): JSX.Element => (

--- a/src/lib/components/Flowbite/FlowbiteTheme.d.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.d.ts
@@ -3,14 +3,27 @@ export type CustomFlowbiteTheme = DeepPartial<FlowbiteTheme>;
 export interface FlowbiteTheme {
   accordion: {
     base: string;
-    title: {
-      base: string;
-      isOpen: string;
-      isOpenNotFlushed: string;
-      notFlushed: string;
-    };
     content: {
       base: string;
+    };
+    flush: {
+      off: string;
+      on: string;
+    };
+    title: {
+      arrow: {
+        base: string;
+        open: string;
+      };
+      base: string;
+      flush: {
+        off: string;
+        on: string;
+      };
+      open: {
+        off: string;
+        on: string;
+      };
     };
   };
   alert: {

--- a/src/lib/components/Flowbite/FlowbiteTheme.d.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.d.ts
@@ -1,3 +1,6 @@
+import type { AlertColors } from '../Alert';
+import type { AvatarSizes } from '../Avatar';
+
 export type CustomFlowbiteTheme = DeepPartial<FlowbiteTheme>;
 
 export interface FlowbiteTheme {
@@ -31,9 +34,9 @@ export interface FlowbiteTheme {
     borderAccent: string;
     closeButton: {
       base: string;
-      color: Colors;
+      color: AlertColors;
     };
-    color: Colors;
+    color: AlertColors;
     icon: string;
     rounded: string;
   };
@@ -45,7 +48,7 @@ export interface FlowbiteTheme {
       on: string;
     };
     rounded: string;
-    size: Sizes;
+    size: AvatarSizes;
     stacked: string;
     status: {
       away: string;
@@ -54,12 +57,7 @@ export interface FlowbiteTheme {
       offline: string;
       online: string;
     };
-    statusPosition: {
-      'bottom-left': string;
-      'bottom-right': string;
-      'top-left': string;
-      'top-right': string;
-    };
+    statusPosition: FlowbitePositions;
   };
   badge: {
     base: string;
@@ -86,21 +84,23 @@ export interface FlowbiteTheme {
   };
 }
 
-export type Colors = FlowbiteColors & {
-  [key in string]: string;
-};
-
 export interface FlowbiteColors {
+  alternative: string;
+  dark: string;
   failure: string;
   gray: string;
   info: string;
+  light: string;
   success: string;
   warning: string;
 }
 
-export type Sizes = FlowbiteSizes & {
-  [key in string]: string;
-};
+export interface FlowbitePositions {
+  'bottom-left': string;
+  'bottom-right': string;
+  'top-left': string;
+  'top-right': string;
+}
 
 export interface FlowbiteSizes {
   xs: string;
@@ -109,9 +109,3 @@ export interface FlowbiteSizes {
   lg: string;
   xl: string;
 }
-
-export type BadgeSizes = FlowbiteBadgeSizes & {
-  [key in string]: string;
-};
-
-export type FlowbiteBadgeSizes = Pick<FlowbiteSizes, 'xs' | 'sm'>;

--- a/src/lib/components/Flowbite/FlowbiteTheme.d.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.d.ts
@@ -84,6 +84,8 @@ export interface FlowbiteTheme {
   };
 }
 
+export type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
 export interface FlowbiteColors {
   alternative: string;
   dark: string;

--- a/src/lib/components/Flowbite/FlowbiteTheme.d.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.d.ts
@@ -41,8 +41,8 @@ export interface FlowbiteTheme {
     base: string;
     bordered: string;
     img: {
-      disabled: string;
-      enabled: string;
+      off: string;
+      on: string;
     };
     rounded: string;
     size: Sizes;
@@ -66,8 +66,8 @@ export interface FlowbiteTheme {
     color: Colors;
     href: string;
     icon: {
-      disabled: string;
-      enabled: string;
+      off: string;
+      on: string;
       size: BadgeSizes;
     };
     size: BadgeSizes;

--- a/src/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/src/lib/components/Sidebar/Sidebar.stories.tsx
@@ -21,7 +21,7 @@ Default.args = {
           <Sidebar.Item href="#" icon={HiChartPie}>
             Dashboard
           </Sidebar.Item>
-          <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="gray">
+          <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="alternative">
             Kanban
           </Sidebar.Item>
           <Sidebar.Item href="#" icon={HiInbox} label="3">
@@ -54,7 +54,7 @@ WithoutIcons.args = {
       <Sidebar.Items>
         <Sidebar.ItemGroup>
           <Sidebar.Item href="#">Dashboard</Sidebar.Item>
-          <Sidebar.Item href="#" label="Pro" labelColor="gray">
+          <Sidebar.Item href="#" label="Pro" labelColor="alternative">
             Kanban
           </Sidebar.Item>
           <Sidebar.Item href="#" label="3">

--- a/src/lib/components/Sidebar/SidebarItem.tsx
+++ b/src/lib/components/Sidebar/SidebarItem.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { ComponentProps, ElementType, FC, PropsWithChildren } from 'react';
 import { Badge } from '../Badge';
-import { Colors } from '../Flowbite/FlowbiteTheme';
+import { Color } from '../Button';
 import { Tooltip } from '../Tooltip';
 import { useSidebarContext } from './SidebarContext';
 import { useSidebarItemContext } from './SidebarItemContext';
@@ -10,7 +10,7 @@ export interface SidebarItem {
   className?: string;
   icon?: FC<ComponentProps<'svg'>>;
   label?: string;
-  labelColor?: keyof Colors;
+  labelColor?: Color;
 }
 
 export interface SidebarItemProps extends PropsWithChildren<SidebarItem & Record<string, unknown>> {

--- a/src/lib/components/Timeline/TimelineTitle.tsx
+++ b/src/lib/components/Timeline/TimelineTitle.tsx
@@ -1,7 +1,6 @@
 import { FC, PropsWithChildren, ComponentProps } from 'react';
 import classNames from 'classnames';
-
-export type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+import { HeadingLevel } from '../Flowbite/FlowbiteTheme';
 
 export type TimelineTitleProps = PropsWithChildren<
   ComponentProps<HeadingLevel> & {

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -54,8 +54,8 @@ export default {
     base: 'flex items-center space-x-4',
     bordered: 'p-1 ring-2 ring-gray-300 dark:ring-gray-500',
     img: {
-      disabled: 'rounded relative overflow-hidden bg-gray-100 dark:bg-gray-600',
-      enabled: 'rounded',
+      off: 'rounded relative overflow-hidden bg-gray-100 dark:bg-gray-600',
+      on: 'rounded',
     },
     rounded: '!rounded-full',
     size: {
@@ -99,8 +99,8 @@ export default {
     },
     href: 'group',
     icon: {
-      disabled: 'rounded px-2 py-0.5',
-      enabled: 'rounded-full p-1.5',
+      off: 'rounded px-2 py-0.5',
+      on: 'rounded-full p-1.5',
       size: {
         xs: 'w-3 h-3',
         sm: 'w-3.5 h-3.5',

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -1,14 +1,27 @@
 export default {
   accordion: {
     base: 'divide-y divide-gray-200 border-gray-200 dark:divide-gray-700 dark:border-gray-700',
-    title: {
-      base: 'py-5 px-5 text-left font-medium text-gray-500 dark:text-gray-400',
-      isOpen: 'text-gray-900 dark:text-white',
-      isOpenNotFlushed: 'bg-gray-100 dark:bg-gray-800',
-      notFlushed: 'hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 dark:hover:bg-gray-800 dark:focus:ring-gray-800',
-    },
     content: {
-      base: 'py-5 px-5 last:rounded-b-lg dark:bg-gray-900',
+      base: 'py-5 px-5 last:rounded-b-lg dark:bg-gray-900 first:rounded-t-lg',
+    },
+    flush: {
+      off: 'rounded-lg border',
+      on: 'border-b',
+    },
+    title: {
+      arrow: {
+        base: 'h-6 w-6 shrink-0',
+        open: 'rotate-180',
+      },
+      base: 'flex w-full items-center justify-between first:rounded-t-lg last:rounded-b-lg py-5 px-5 text-left font-medium text-gray-500 dark:text-gray-400',
+      flush: {
+        off: 'hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 dark:hover:bg-gray-800 dark:focus:ring-gray-800',
+        on: '!bg-transparent dark:!bg-transparent',
+      },
+      open: {
+        off: '',
+        on: 'text-gray-900 bg-gray-100 dark:bg-gray-800 dark:text-white',
+      },
     },
   },
   alert: {


### PR DESCRIPTION
## Breaking changes

`Accordion`s can now be customized using `<Flowbite theme={..}>`.

```js
accordion: {
  base: string;
  content: {
    base: string;
  };
  flush: {
    off: string;
    on: string;
  };
  title: {
    arrow: {
      base: string;
      open: string;
    };
    base: string;
    flush: {
      off: string;
      on: string;
    };
    open: {
      off: string;
      on: string;
    };
  };
};
```

## Features

- [x] [feature(component): Rewrite Accordion to use FlowbiteTheme, resolves](https://github.com/themesberg/flowbite-react/pull/158/commits/7a8c039aabeb613a1c22c7ed34f9783e427ebac0)
- [x] [feature(component): Allow any heading level on Accordion.Titles](https://github.com/themesberg/flowbite-react/pull/158/commits/44ab557f02ad4de2f87fea27b0143f9c896d7eab)

## Tests

### Unit

- [x] [test(component): Add numerous unit tests for Accordions](https://github.com/themesberg/flowbite-react/pull/158/commits/bdf454baf1ace168567469ff9fdc299d7a731cd1)