### PR TITLE
feature(component): Rewrite `Spinner`s to use themes, resolves #144

### DIFF
--- a/src/docs/pages/SpinnersPage.tsx
+++ b/src/docs/pages/SpinnersPage.tsx
@@ -13,10 +13,10 @@ const SpinnersPage: FC = () => {
       title: 'Colors',
       code: (
         <div className="flex flex-wrap gap-2">
-          <Spinner color="blue" aria-label="Blue spinner example" />
-          <Spinner color="green" aria-label="Green spinner example" />
-          <Spinner color="red" aria-label="Red spinner example" />
-          <Spinner color="yellow" aria-label="Yellow spinner example" />
+          <Spinner color="info" aria-label="Info spinner example" />
+          <Spinner color="success" aria-label="Success spinner example" />
+          <Spinner color="failure" aria-label="Failure spinner example" />
+          <Spinner color="warning" aria-label="Warning spinner example" />
           <Spinner color="pink" aria-label="Pink spinner example" />
           <Spinner color="purple" aria-label="Purple spinner example" />
         </div>

--- a/src/lib/components/Flowbite/FlowbiteTheme.d.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.d.ts
@@ -1,5 +1,6 @@
 import type { AlertColors } from '../Alert';
 import type { AvatarSizes } from '../Avatar';
+import { SpinnerColors, SpinnerSizes } from '../Spinner';
 
 export type CustomFlowbiteTheme = DeepPartial<FlowbiteTheme>;
 
@@ -97,6 +98,21 @@ export interface FlowbiteTheme {
       };
     };
   };
+  spinner: {
+    base: string;
+    color: SpinnerColors;
+    light: {
+      off: {
+        base: string;
+        color: SpinnerColors;
+      };
+      on: {
+        base: string;
+        color: SpinnerColors;
+      };
+    };
+    size: SpinnerSizes;
+  };
 }
 
 export type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
@@ -108,6 +124,8 @@ export interface FlowbiteColors {
   gray: string;
   info: string;
   light: string;
+  pink: string;
+  purple: string;
   success: string;
   warning: string;
 }

--- a/src/lib/components/Spinner/Spinner.spec.tsx
+++ b/src/lib/components/Spinner/Spinner.spec.tsx
@@ -1,13 +1,101 @@
-import { render } from '@testing-library/react';
+import { render, RenderResult } from '@testing-library/react';
 import { Spinner } from '.';
+import { Flowbite } from '../Flowbite';
 
-describe('Spinner', () => {
-  describe('with light mode only specified', () => {
-    it("shouldn't change styles in dark mode", () => {
-      const { getByRole } = render(<Spinner light />);
+describe('Components / Spinner', () => {
+  describe('A11y', () => {
+    it('should have `role="status"` by default', () => {
+      const spinner = getSpinner(render(<Spinner aria-label="My spinner" />));
 
-      const spinner = getByRole('status').firstElementChild;
-      expect(spinner?.getAttribute('class')).not.toContain('dark:');
+      expect(spinner).toHaveAccessibleName('My spinner');
+    });
+
+    it('should be able to set no `role`', () => {
+      const { getByLabelText } = render(<Spinner aria-label="My spinner" role={undefined} />);
+
+      const spinner = getByLabelText('My spinner');
+
+      expect(spinner).not.toHaveAttribute('role');
+    });
+  });
+
+  describe('Rendering', () => {
+    it('should render', () => {
+      const spinner = getSpinner(render(<Spinner color="success" />));
+
+      expect(spinner).toBeInTheDocument();
+    });
+
+    it('should render when `light={true}`', () => {
+      const spinner = getSpinner(render(<Spinner color="failure" light />));
+
+      expect(spinner).toBeInTheDocument();
+    });
+  });
+
+  describe('Theme', () => {
+    it('should use `base` classes', () => {
+      const theme = {
+        spinner: {
+          base: 'text-gray-100',
+        },
+      };
+
+      const spinner = getSpinner(
+        render(
+          <Flowbite theme={{ theme }}>
+            <Spinner />
+          </Flowbite>,
+        ),
+      );
+
+      expect(spinner.firstElementChild).toHaveClass('text-gray-100');
+    });
+
+    it('should use `color` classes', () => {
+      const theme = {
+        spinner: {
+          color: {
+            primary: 'text-gray-200',
+          },
+        },
+      };
+
+      const spinner = getSpinner(
+        render(
+          <Flowbite theme={{ theme }}>
+            <Spinner color="primary" />
+          </Flowbite>,
+        ),
+      );
+
+      expect(spinner.firstElementChild).toHaveClass('text-gray-200');
+    });
+
+    it('should use `light` classes', () => {
+      const theme = {
+        spinner: {
+          light: {
+            on: {
+              color: {
+                success: 'text-gray-300',
+              },
+            },
+          },
+        },
+      };
+
+      const spinner = getSpinner(
+        render(
+          <Flowbite theme={{ theme }}>
+            <Spinner color="success" light />
+          </Flowbite>,
+        ),
+      );
+
+      expect(spinner.firstElementChild).toHaveClass('text-gray-300');
     });
   });
 });
+
+const getSpinner = ({ getByRole }: Pick<RenderResult, 'getByRole'>): HTMLElement => getByRole('status');

--- a/src/lib/components/Spinner/Spinner.stories.tsx
+++ b/src/lib/components/Spinner/Spinner.stories.tsx
@@ -10,15 +10,15 @@ export default {
 
 const Template: Story = (args) => <Spinner {...args} />;
 
-export const DefaultSpinner = Template.bind({});
-DefaultSpinner.storyName = 'Default';
-DefaultSpinner.args = {
-  title: 'Default spinner example',
+export const Default = Template.bind({});
+Default.args = {
+  color: 'info',
   size: 'md',
+  title: 'Default spinner example',
 };
 
 export const Alignment = (): JSX.Element => (
-  <div className="flex w-1/3 flex-col gap-3 bg-gray-50 p-6">
+  <div className="flex w-1/3 flex-col gap-3 p-6">
     <div className="text-left">
       <Spinner aria-label="Left-aligned spinner example" />
     </div>
@@ -33,10 +33,10 @@ export const Alignment = (): JSX.Element => (
 
 export const Colors = (): JSX.Element => (
   <div className="flex flex-row gap-3">
-    <Spinner color="blue" aria-label="Blue spinner example" />
-    <Spinner color="green" aria-label="Green spinner example" />
-    <Spinner color="red" aria-label="Red spinner example" />
-    <Spinner color="yellow" aria-label="Yellow spinner example" />
+    <Spinner color="info" aria-label="Info spinner example" />
+    <Spinner color="success" aria-label="Success spinner example" />
+    <Spinner color="failure" aria-label="Failure spinner example" />
+    <Spinner color="warning" aria-label="Warning spinner example" />
     <Spinner color="pink" aria-label="Pink spinner example" />
     <Spinner color="purple" aria-label="Purple spinner example" />
   </div>

--- a/src/lib/components/Spinner/index.tsx
+++ b/src/lib/components/Spinner/index.tsx
@@ -1,44 +1,38 @@
 import { ComponentProps, FC } from 'react';
 import classNames from 'classnames';
+import { FlowbiteColors, FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
+import { excludeClassName } from '../../helpers/exclude';
+import { useTheme } from '../Flowbite/ThemeContext';
 
-type Color = 'blue' | 'gray' | 'green' | 'red' | 'yellow' | 'pink' | 'purple';
-type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-
-export interface SpinnerProps extends ComponentProps<'span'> {
-  className?: string;
-  color?: Color;
+export interface SpinnerProps extends Omit<ComponentProps<'span'>, 'color'> {
+  color?: keyof SpinnerColors;
   light?: boolean;
-  size?: Size;
+  size?: keyof SpinnerSizes;
 }
 
-const sizeClasses: Record<Size, string> = {
-  xs: 'w-3 h-3',
-  sm: 'w-4 h-4',
-  md: 'w-6 h-6',
-  lg: 'w-8 h-8',
-  xl: 'w-10 h-10',
-};
+export interface SpinnerColors
+  extends Pick<FlowbiteColors, 'failure' | 'gray' | 'info' | 'pink' | 'purple' | 'success' | 'warning'> {
+  [key: string]: string;
+}
 
-export const Spinner: FC<SpinnerProps> = ({ className, color = 'blue', light, size = 'md', ...rest }) => {
-  const colorClasses: Record<Color, string> = {
-    blue: 'fill-blue-600',
-    gray: classNames('fill-gray-600', { 'dark:fill-gray-300': !light }),
-    green: classNames('fill-green-500', { 'dark:text-gray-600': !light }),
-    red: 'fill-red-600',
-    yellow: classNames('fill-yellow-400', { 'dark:text-gray-600': !light }),
-    pink: 'fill-pink-600',
-    purple: 'fill-purple-600',
-  };
+export interface SpinnerSizes extends FlowbiteSizes {
+  [key: string]: string;
+}
+
+export const Spinner: FC<SpinnerProps> = ({ color = 'info', light, size = 'md', ...props }): JSX.Element => {
+  const theirProps = excludeClassName(props);
+
+  const theme = useTheme().theme.spinner;
 
   return (
-    <span role="status" {...rest}>
+    <span role="status" {...theirProps}>
       <svg
         className={classNames(
-          'inline animate-spin text-gray-200',
-          { 'dark:text-gray-600': !light },
-          colorClasses[color],
-          sizeClasses[size],
-          className,
+          theme.base,
+          theme.color[color],
+          theme.light[light ? 'on' : 'off'].base,
+          theme.light[light ? 'on' : 'off'].color[color],
+          theme.size[size],
         )}
         fill="none"
         viewBox="0 0 100 101"

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -138,4 +138,49 @@ export default {
       },
     },
   },
+  spinner: {
+    base: 'inline animate-spin text-gray-200',
+    color: {
+      failure: 'fill-red-600',
+      gray: 'fill-gray-600',
+      info: 'fill-blue-600',
+      pink: 'fill-pink-600',
+      purple: 'fill-purple-600',
+      success: 'fill-green-500',
+      warning: 'fill-yellow-400',
+    },
+    light: {
+      off: {
+        base: 'dark:text-gray-600',
+        color: {
+          failure: '',
+          gray: 'dark:fill-gray-300',
+          info: '',
+          pink: '',
+          purple: '',
+          success: '',
+          warning: '',
+        },
+      },
+      on: {
+        base: '',
+        color: {
+          failure: '',
+          gray: '',
+          info: '',
+          pink: '',
+          purple: '',
+          success: '',
+          warning: '',
+        },
+      },
+    },
+    size: {
+      xs: 'w-3 h-3',
+      sm: 'w-4 h-4',
+      md: 'w-6 h-6',
+      lg: 'w-8 h-8',
+      xl: 'w-10 h-10',
+    },
+  },
 };


### PR DESCRIPTION
## Breaking changes

`Spinner`s can now be customized with `<Flowbite theme={..}>`.

```js
spinner: {
  base: 'inline animate-spin text-gray-200',
  color: {
    failure: 'fill-red-600',
    gray: 'fill-gray-600',
    info: 'fill-blue-600',
    pink: 'fill-pink-600',
    purple: 'fill-purple-600',
    success: 'fill-green-500',
    warning: 'fill-yellow-400',
  },
  light: {
    off: {
      base: 'dark:text-gray-600',
      color: {
        failure: '',
        gray: 'dark:fill-gray-300',
        info: '',
        pink: '',
        purple: '',
        success: '',
        warning: '',
      },
    },
    on: {
      base: '',
      color: {
        failure: '',
        gray: '',
        info: '',
        pink: '',
        purple: '',
        success: '',
        warning: '',
      },
    },
  },
  size: {
    xs: 'w-3 h-3',
    sm: 'w-4 h-4',
    md: 'w-6 h-6',
    lg: 'w-8 h-8',
    xl: 'w-10 h-10',
  },
},
```

## Features

- [x] [feature(component): Rewrite](https://github.com/themesberg/flowbite-react/commit/1b642bc4d0b0950b9992d535ee35fc4680a6cf4a) [Spinner](https://github.com/themesberg/flowbite-react/commit/1b642bc4d0b0950b9992d535ee35fc4680a6cf4a)[s to use themes,](https://github.com/themesberg/flowbite-react/commit/1b642bc4d0b0950b9992d535ee35fc4680a6cf4a) [resolves](https://github.com/themesberg/flowbite-react/commit/1b642bc4d0b0950b9992d535ee35fc4680a6cf4a) https://github.com/themesberg/flowbite-react/issues/144
- [x] [feature(type): Add theme for Spinners](https://github.com/themesberg/flowbite-react/commit/da9e531144709b582a94025a223f3fe3009429bf)

## Tests

### Unit

- [x] [test(component): Add unit tests for Spinners](https://github.com/themesberg/flowbite-react/commit/bafdbbe6f2d14a6d0be176209a086369aaf87ca8)