### PR TITLE
feature(component): Rewrite `Card`s to use themes, resolves #131

### DIFF
--- a/src/docs/pages/CardPage.tsx
+++ b/src/docs/pages/CardPage.tsx
@@ -8,7 +8,7 @@ const CardPage: FC = () => {
     {
       title: 'Default card',
       code: (
-        <Card className="max-w-sm">
+        <Card>
           <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
             Noteworthy technology acquisitions 2021
           </h5>
@@ -22,46 +22,51 @@ const CardPage: FC = () => {
     {
       title: 'Card with decorative image',
       code: (
-        <Card className="max-w-sm" imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg">
-          <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-            Noteworthy technology acquisitions 2021
-          </h5>
-          <p className="font-normal text-gray-700 dark:text-gray-400">
-            Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
-          </p>
-        </Card>
+        <div className="max-w-sm">
+          <Card imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg">
+            <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+              Noteworthy technology acquisitions 2021
+            </h5>
+            <p className="font-normal text-gray-700 dark:text-gray-400">
+              Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
+            </p>
+          </Card>
+        </div>
       ),
       codeClassName: 'dark:!bg-gray-900',
     },
     {
       title: 'Card with image with alt text',
       code: (
-        <Card
-          className="max-w-sm"
-          imgAlt="Meaningful alt text for an image that is not purely decorative"
-          imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg"
-        >
-          <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-            Noteworthy technology acquisitions 2021
-          </h5>
-          <p className="font-normal text-gray-700 dark:text-gray-400">
-            Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
-          </p>
-        </Card>
+        <div className="max-w-sm">
+          <Card
+            imgAlt="Meaningful alt text for an image that is not purely decorative"
+            imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg"
+          >
+            <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+              Noteworthy technology acquisitions 2021
+            </h5>
+            <p className="font-normal text-gray-700 dark:text-gray-400">
+              Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
+            </p>
+          </Card>
+        </div>
       ),
       codeClassName: 'dark:!bg-gray-900',
     },
     {
       title: 'Horizontal card',
       code: (
-        <Card className="max-w-sm" imgSrc="https://flowbite.com/docs/images/blog/image-4.jpg" horizontal>
-          <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-            Noteworthy technology acquisitions 2021
-          </h5>
-          <p className="font-normal text-gray-700 dark:text-gray-400">
-            Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
-          </p>
-        </Card>
+        <div className="max-w-sm">
+          <Card horizontal imgSrc="https://flowbite.com/docs/images/blog/image-4.jpg">
+            <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+              Noteworthy technology acquisitions 2021
+            </h5>
+            <p className="font-normal text-gray-700 dark:text-gray-400">
+              Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
+            </p>
+          </Card>
+        </div>
       ),
       codeClassName: 'dark:!bg-gray-900',
     },

--- a/src/docs/pages/DemoPage.tsx
+++ b/src/docs/pages/DemoPage.tsx
@@ -30,19 +30,21 @@ export const DemoPage: FC<DemoPageProps> = ({ examples }) => {
         <div key={index} className="flex flex-col gap-2">
           <span className="text-2xl font-bold">{title}</span>
           {content && <div className="py-4">{content}</div>}
-          <Card className={codeClassName}>
-            {showCode && code}
-            <SyntaxHighlighterFix language="tsx" style={dracula}>
-              {reactElementToJSXString(code, {
-                showFunctions: true,
-                functionValue: (fn) => fn.name,
-                sortProps: false,
-                useBooleanShorthandSyntax: false,
-                useFragmentShortSyntax: false,
-                ...codeStringifierOptions,
-              })}
-            </SyntaxHighlighterFix>
-          </Card>
+          <div className={codeClassName}>
+            <Card>
+              {showCode && code}
+              <SyntaxHighlighterFix language="tsx" style={dracula}>
+                {reactElementToJSXString(code, {
+                  showFunctions: true,
+                  functionValue: (fn) => fn.name,
+                  sortProps: false,
+                  useBooleanShorthandSyntax: false,
+                  useFragmentShortSyntax: false,
+                  ...codeStringifierOptions,
+                })}
+              </SyntaxHighlighterFix>
+            </Card>
+          </div>
         </div>
       ))}
     </div>

--- a/src/lib/components/Card/Card.spec.tsx
+++ b/src/lib/components/Card/Card.spec.tsx
@@ -1,39 +1,153 @@
-import { cleanup, render } from '@testing-library/react';
+import { render, RenderResult } from '@testing-library/react';
 import { Card } from '.';
+import { Flowbite } from '../Flowbite';
 
-describe('Card Component should be able to render a', () => {
-  afterEach(cleanup);
+describe('Components / Card', () => {
+  describe('A11y', () => {
+    it('should allow `aria-label`', () => {
+      const card = getCard(render(<Card aria-label="My card" />));
 
-  it('card', () => {
-    const { getByTestId } = render(<Card />);
-    expect(getByTestId('card-element')).toBeTruthy();
-  });
-
-  it('horizontal card', () => {
-    const { getByTestId } = render(<Card horizontal={true} />);
-    expect(getByTestId('card-element').className).toContain('flex-col md:max-w-xl md:flex-row');
-  });
-
-  describe('card with', () => {
-    afterEach(cleanup);
-
-    it('decorative image', () => {
-      const { getByTestId } = render(<Card imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg" />);
-      expect((getByTestId('card-element').children[0] as HTMLImageElement).src).toEqual(
-        'https://flowbite.com/docs/images/blog/image-1.jpg',
-      );
+      expect(card).toHaveAccessibleName('My card');
     });
 
-    it('alt text', () => {
-      const { getByTestId } = render(
-        <Card
-          imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg"
-          imgAlt="Meaningful alt text for an image that is not purely decorative"
-        />,
+    describe('`imgSrc="..."` and `imgAlt="..."`', () => {
+      it('should provide `<img />` with alternative text', () => {
+        const { getByAltText } = render(
+          <Card
+            imgAlt="Meaningful alt text for an image that is not purely decorative"
+            imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg"
+          />,
+        );
+        const img = getByAltText('Meaningful alt text for an image that is not purely decorative');
+
+        expect(img).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Rendering', () => {
+    it('should render', () => {
+      const card = getCard(render(<Card />));
+
+      expect(card).toBeInTheDocument();
+    });
+
+    describe('`horizontal={true}`', () => {
+      it('should render', () => {
+        const card = getCard(render(<Card horizontal />));
+
+        expect(card).toBeInTheDocument();
+      });
+    });
+
+    describe('`imgSrc="..."`', () => {
+      it('should render', () => {
+        const card = getCard(render(<Card imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg" />));
+
+        expect(card).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Theme', () => {
+    it('should use `base` classes', () => {
+      const theme = {
+        card: {
+          base: 'text-blue-100',
+        },
+      };
+
+      const card = getCard(
+        render(
+          <Flowbite theme={{ theme }}>
+            <Card />
+          </Flowbite>,
+        ),
       );
-      expect((getByTestId('card-element').children[0] as HTMLImageElement).alt).toEqual(
-        'Meaningful alt text for an image that is not purely decorative',
+
+      expect(card).toHaveClass('text-blue-100');
+    });
+
+    it('should use `children` classes', () => {
+      const theme = {
+        card: {
+          children: 'text-blue-900',
+        },
+      };
+
+      const { getByLabelText } = render(
+        <Flowbite theme={{ theme }}>
+          <Card>
+            <span aria-label="The content">Some content</span>
+          </Card>
+        </Flowbite>,
       );
+
+      const children = getByLabelText('The content');
+
+      expect(children.parentElement).toHaveClass('text-blue-900');
+    });
+
+    it('should use `horizontal` classes', () => {
+      const theme = {
+        card: {
+          horizontal: {
+            off: 'text-blue-200',
+            on: 'text-blue-300',
+          },
+        },
+      };
+
+      const cards = getCards(
+        render(
+          <Flowbite theme={{ theme }}>
+            <Card />
+            <Card horizontal />
+          </Flowbite>,
+        ),
+      );
+
+      const normalCard = cards[0];
+      const horizontalCard = cards[1];
+
+      expect(normalCard).toHaveClass('text-blue-200');
+      expect(horizontalCard).toHaveClass('text-blue-300');
+    });
+
+    it('should use `img` classes', () => {
+      const theme = {
+        card: {
+          img: {
+            base: 'text-blue-400',
+            horizontal: {
+              off: 'bg-blue-500',
+              on: 'bg-blue-600',
+            },
+          },
+        },
+      };
+
+      const { getByAltText } = render(
+        <Flowbite theme={{ theme }}>
+          <Card imgAlt="Card with image" imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg" />
+          <Card
+            horizontal
+            imgAlt="Horizontal card with image"
+            imgSrc="https://flowbite.com/docs/images/blog/image-1.jpg"
+          />
+        </Flowbite>,
+      );
+
+      const cardWithImage = getByAltText('Card with image');
+      const horizontalCardWithImage = getByAltText('Horizontal card with image');
+
+      expect(cardWithImage).toHaveClass('text-blue-400 bg-blue-500');
+      expect(horizontalCardWithImage).toHaveClass('bg-blue-600');
     });
   });
 });
+
+const getCard = ({ getByTestId }: Pick<RenderResult, 'getByTestId'>): HTMLElement => getByTestId('flowbite-card');
+
+const getCards = ({ getAllByTestId }: Pick<RenderResult, 'getAllByTestId'>): HTMLElement[] =>
+  getAllByTestId('flowbite-card');

--- a/src/lib/components/Card/Card.stories.tsx
+++ b/src/lib/components/Card/Card.stories.tsx
@@ -5,21 +5,43 @@ import { Card, CardProps } from '.';
 export default {
   title: 'Components/Card',
   component: Card,
+  decorators: [
+    (Story): JSX.Element => (
+      <div className="h-1/2 w-1/2">
+        <Story />
+      </div>
+    ),
+  ],
 } as Meta;
 
-const Template: Story<CardProps> = (args) => <Card {...args} />;
+const Template: Story<CardProps> = (args) => (
+  <Card {...args}>
+    <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+      Noteworthy technology acquisitions 2021
+    </h5>
+    <p className="font-normal text-gray-700 dark:text-gray-400">
+      Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
+    </p>
+  </Card>
+);
 
-export const DefaultCard = Template.bind({});
-DefaultCard.storyName = 'Default';
-DefaultCard.args = {
-  children: (
-    <>
-      <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-        Noteworthy technology acquisitions 2021
-      </h5>
-      <p className="font-normal text-gray-700 dark:text-gray-400">
-        Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.
-      </p>
-    </>
-  ),
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Horizontal = Template.bind({});
+Horizontal.args = {
+  horizontal: true,
+};
+
+export const WithA11yImage = Template.bind({});
+WithA11yImage.storyName = 'With image with alt text';
+WithA11yImage.args = {
+  imgAlt: 'Meaningful alt text for an image that is not purely decorative',
+  imgSrc: 'https://flowbite.com/docs/images/blog/image-1.jpg',
+};
+
+export const WithDecorativeImage = Template.bind({});
+WithDecorativeImage.storyName = 'With decorative image';
+WithDecorativeImage.args = {
+  imgSrc: 'https://flowbite.com/docs/images/blog/image-1.jpg',
 };

--- a/src/lib/components/Card/index.tsx
+++ b/src/lib/components/Card/index.tsx
@@ -1,37 +1,33 @@
-import { FC, PropsWithChildren } from 'react';
+import { ComponentProps, FC, PropsWithChildren } from 'react';
 import classNames from 'classnames';
+import { useTheme } from '../Flowbite/ThemeContext';
+import { excludeClassName } from '../../helpers/exclude';
 
-export type CardProps = PropsWithChildren<{
-  className?: string;
+export interface CardProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'className'>> {
   horizontal?: boolean;
   imgAlt?: string;
   imgSrc?: string;
-}>;
+}
 
-export const Card: FC<CardProps> = ({ children, className, horizontal, imgAlt, imgSrc }) => {
+export const Card: FC<CardProps> = ({ children, horizontal, imgAlt, imgSrc, ...props }): JSX.Element => {
+  const theirProps = excludeClassName(props);
+
+  const theme = useTheme().theme.card;
+
   return (
     <div
-      data-testid="card-element"
-      className={classNames(
-        'flex rounded-lg border border-gray-200 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800',
-        {
-          'flex-col': !horizontal,
-          'flex-col md:max-w-xl md:flex-row': horizontal,
-        },
-        className,
-      )}
+      className={classNames(theme.base, theme.horizontal[horizontal ? 'on' : 'off'])}
+      data-testid="flowbite-card"
+      {...theirProps}
     >
       {imgSrc && (
         <img
-          className={classNames({
-            'rounded-t-lg': !horizontal,
-            'h-96 w-full rounded-t-lg object-cover md:h-auto md:w-48 md:rounded-none md:rounded-l-lg': horizontal,
-          })}
-          src={imgSrc}
           alt={imgAlt ?? ''}
+          className={classNames(theme.img.base, theme.img.horizontal[horizontal ? 'on' : 'off'])}
+          src={imgSrc}
         />
       )}
-      <div className="flex h-full flex-col justify-center gap-4 p-6">{children}</div>
+      <div className={theme.children}>{children}</div>
     </div>
   );
 };

--- a/src/lib/components/Flowbite/FlowbiteTheme.d.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.d.ts
@@ -82,6 +82,21 @@ export interface FlowbiteTheme {
     };
     list: string;
   };
+  card: {
+    base: string;
+    children: string;
+    horizontal: {
+      off: string;
+      on: string;
+    };
+    img: {
+      base: string;
+      horizontal: {
+        off: string;
+        on: string;
+      };
+    };
+  };
 }
 
 export type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -123,4 +123,19 @@ export default {
     },
     list: 'flex items-center',
   },
+  card: {
+    base: 'flex rounded-lg border border-gray-200 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800',
+    children: 'flex h-full flex-col justify-center gap-4 p-6',
+    horizontal: {
+      off: 'flex-col',
+      on: 'flex-col md:max-w-xl md:flex-row',
+    },
+    img: {
+      base: '',
+      horizontal: {
+        off: 'rounded-t-lg',
+        on: 'h-96 w-full rounded-t-lg object-cover md:h-auto md:w-48 md:rounded-none md:rounded-l-lg',
+      },
+    },
+  },
 };


### PR DESCRIPTION
## Breaking changes

`Card`s can now be customized with `<Flowbite theme={..}>`.

```js
card: {
  base: 'flex rounded-lg border border-gray-200 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800',
  children: 'flex h-full flex-col justify-center gap-4 p-6',
  horizontal: {
    off: 'flex-col',
    on: 'flex-col md:max-w-xl md:flex-row',
  },
  img: {
    base: '',
    horizontal: {
      off: 'rounded-t-lg',
      on: 'h-96 w-full rounded-t-lg object-cover md:h-auto md:w-48 md:rounded-none md:rounded-l-lg',
    },
  },
},
```

## Features

- [x] [feature(component): Rewrite](https://github.com/themesberg/flowbite-react/commit/88e585baaa9988f75e4897ca5b0b43a6f7bc6ce6) [Card](https://github.com/themesberg/flowbite-react/commit/88e585baaa9988f75e4897ca5b0b43a6f7bc6ce6)[s to use themes,](https://github.com/themesberg/flowbite-react/commit/88e585baaa9988f75e4897ca5b0b43a6f7bc6ce6) [resolves](https://github.com/themesberg/flowbite-react/commit/88e585baaa9988f75e4897ca5b0b43a6f7bc6ce6) https://github.com/themesberg/flowbite-react/issues/131
- [x] [feature(story): Add missing Card stories](https://github.com/themesberg/flowbite-react/commit/37f70234e6ace20fd314a922b502529c9257c3c9)
- [x] [feature(type): Add theme for Cards](https://github.com/themesberg/flowbite-react/commit/3b364c305e7852c477dd956df1681266d8518eec)

## Tests

### Unit

- [x] [test(component): Add unit tests for Cards](https://github.com/themesberg/flowbite-react/commit/b8e6b7f7f6fce55f71c587811fd024b5ee52b546)