### PR TITLE
feature(component): Change `Accordion`s to close inactive panels, resolves #159

### DIFF
--- a/src/docs/pages/AccordionPage.tsx
+++ b/src/docs/pages/AccordionPage.tsx
@@ -1,98 +1,305 @@
-import { ComponentProps, FC } from 'react';
+import { FC } from 'react';
 import { HiOutlineArrowCircleDown } from 'react-icons/hi';
 
 import { Accordion } from '../../lib';
 import { CodeExample, DemoPage } from './DemoPage';
 
 const AccordionPage: FC = () => {
-  const panels = (icon?: FC<ComponentProps<'svg'>>) => [
-    <Accordion.Panel key={0} open>
-      <Accordion.Title arrowIcon={icon}>What is Flowbite?</Accordion.Title>
-      <Accordion.Content>
-        <p className="mb-2 text-gray-500 dark:text-gray-400">
-          Flowbite is an open-source library of interactive components built on top of Tailwind CSS including buttons,
-          dropdowns, modals, navbars, and more.
-        </p>
-        <p className="text-gray-500 dark:text-gray-400">
-          Check out this guide to learn how to{' '}
-          <a
-            href="https://flowbite.com/docs/getting-started/introduction/"
-            className="text-blue-600 hover:underline dark:text-blue-500"
-          >
-            get started
-          </a>{' '}
-          and start developing websites even faster with components on top of Tailwind CSS.
-        </p>
-      </Accordion.Content>
-    </Accordion.Panel>,
-    <Accordion.Panel key={1}>
-      <Accordion.Title arrowIcon={icon}>Is there a Figma file available?</Accordion.Title>
-      <Accordion.Content>
-        <p className="mb-2 text-gray-500 dark:text-gray-400">
-          Flowbite is first conceptualized and designed using the Figma software so everything you see in the library
-          has a design equivalent in our Figma file.
-        </p>
-        <p className="text-gray-500 dark:text-gray-400">
-          Check out the{' '}
-          <a href="https://flowbite.com/figma/" className="text-blue-600 hover:underline dark:text-blue-500">
-            Figma design system
-          </a>{' '}
-          based on the utility classes from Tailwind CSS and components from Flowbite.
-        </p>
-      </Accordion.Content>
-    </Accordion.Panel>,
-    <Accordion.Panel key={2}>
-      <Accordion.Title arrowIcon={icon}>What are the differences between Flowbite and Tailwind UI?</Accordion.Title>
-      <Accordion.Content>
-        <p className="mb-2 text-gray-500 dark:text-gray-400">
-          The main difference is that the core components from Flowbite are open source under the MIT license, whereas
-          Tailwind UI is a paid product. Another difference is that Flowbite relies on smaller and standalone
-          components, whereas Tailwind UI offers sections of pages.
-        </p>
-        <p className="mb-2 text-gray-500 dark:text-gray-400">
-          However, we actually recommend using both Flowbite, Flowbite Pro, and even Tailwind UI as there is no
-          technical reason stopping you from using the best of two worlds.
-        </p>
-        <p className="mb-2 text-gray-500 dark:text-gray-400">Learn more about these technologies:</p>
-        <ul className="list-disc pl-5 text-gray-500 dark:text-gray-400">
-          <li>
-            <a href="https://flowbite.com/pro/" className="text-blue-600 hover:underline dark:text-blue-500">
-              Flowbite Pro
-            </a>
-          </li>
-          <li>
-            <a
-              href="https://tailwindui.com/"
-              rel="nofollow"
-              className="text-blue-600 hover:underline dark:text-blue-500"
-            >
-              Tailwind UI
-            </a>
-          </li>
-        </ul>
-      </Accordion.Content>
-    </Accordion.Panel>,
-  ];
-
   const examples: CodeExample[] = [
     {
       title: 'Default accordion',
-      code: <Accordion>{panels()}</Accordion>,
+      code: (
+        <Accordion>
+          <Accordion.Panel>
+            <Accordion.Title>What is Flowbite?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                Flowbite is an open-source library of interactive components built on top of Tailwind CSS including
+                buttons, dropdowns, modals, navbars, and more.
+              </p>
+              <p className="text-gray-500 dark:text-gray-400">
+                Check out this guide to learn how to{' '}
+                <a
+                  href="https://flowbite.com/docs/getting-started/introduction/"
+                  className="text-blue-600 hover:underline dark:text-blue-500"
+                >
+                  get started
+                </a>{' '}
+                and start developing websites even faster with components on top of Tailwind CSS.
+              </p>
+            </Accordion.Content>
+          </Accordion.Panel>
+          <Accordion.Panel>
+            <Accordion.Title>Is there a Figma file available?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                Flowbite is first conceptualized and designed using the Figma software so everything you see in the
+                library has a design equivalent in our Figma file.
+              </p>
+              <p className="text-gray-500 dark:text-gray-400">
+                Check out the{' '}
+                <a href="https://flowbite.com/figma/" className="text-blue-600 hover:underline dark:text-blue-500">
+                  Figma design system
+                </a>{' '}
+                based on the utility classes from Tailwind CSS and components from Flowbite.
+              </p>
+            </Accordion.Content>
+          </Accordion.Panel>
+          <Accordion.Panel>
+            <Accordion.Title>What are the differences between Flowbite and Tailwind UI?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                The main difference is that the core components from Flowbite are open source under the MIT license,
+                whereas Tailwind UI is a paid product. Another difference is that Flowbite relies on smaller and
+                standalone components, whereas Tailwind UI offers sections of pages.
+              </p>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                However, we actually recommend using both Flowbite, Flowbite Pro, and even Tailwind UI as there is no
+                technical reason stopping you from using the best of two worlds.
+              </p>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">Learn more about these technologies:</p>
+              <ul className="list-disc pl-5 text-gray-500 dark:text-gray-400">
+                <li>
+                  <a href="https://flowbite.com/pro/" className="text-blue-600 hover:underline dark:text-blue-500">
+                    Flowbite Pro
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://tailwindui.com/"
+                    rel="nofollow"
+                    className="text-blue-600 hover:underline dark:text-blue-500"
+                  >
+                    Tailwind UI
+                  </a>
+                </li>
+              </ul>
+            </Accordion.Content>
+          </Accordion.Panel>
+        </Accordion>
+      ),
       codeClassName: 'dark:!bg-gray-900',
     },
     {
       title: 'Always open',
-      code: <Accordion>{panels()}</Accordion>,
+      code: (
+        <Accordion alwaysOpen>
+          <Accordion.Panel>
+            <Accordion.Title>What is Flowbite?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                Flowbite is an open-source library of interactive components built on top of Tailwind CSS including
+                buttons, dropdowns, modals, navbars, and more.
+              </p>
+              <p className="text-gray-500 dark:text-gray-400">
+                Check out this guide to learn how to{' '}
+                <a
+                  href="https://flowbite.com/docs/getting-started/introduction/"
+                  className="text-blue-600 hover:underline dark:text-blue-500"
+                >
+                  get started
+                </a>{' '}
+                and start developing websites even faster with components on top of Tailwind CSS.
+              </p>
+            </Accordion.Content>
+          </Accordion.Panel>
+          <Accordion.Panel>
+            <Accordion.Title>Is there a Figma file available?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                Flowbite is first conceptualized and designed using the Figma software so everything you see in the
+                library has a design equivalent in our Figma file.
+              </p>
+              <p className="text-gray-500 dark:text-gray-400">
+                Check out the{' '}
+                <a href="https://flowbite.com/figma/" className="text-blue-600 hover:underline dark:text-blue-500">
+                  Figma design system
+                </a>{' '}
+                based on the utility classes from Tailwind CSS and components from Flowbite.
+              </p>
+            </Accordion.Content>
+          </Accordion.Panel>
+          <Accordion.Panel>
+            <Accordion.Title>What are the differences between Flowbite and Tailwind UI?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                The main difference is that the core components from Flowbite are open source under the MIT license,
+                whereas Tailwind UI is a paid product. Another difference is that Flowbite relies on smaller and
+                standalone components, whereas Tailwind UI offers sections of pages.
+              </p>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                However, we actually recommend using both Flowbite, Flowbite Pro, and even Tailwind UI as there is no
+                technical reason stopping you from using the best of two worlds.
+              </p>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">Learn more about these technologies:</p>
+              <ul className="list-disc pl-5 text-gray-500 dark:text-gray-400">
+                <li>
+                  <a href="https://flowbite.com/pro/" className="text-blue-600 hover:underline dark:text-blue-500">
+                    Flowbite Pro
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://tailwindui.com/"
+                    rel="nofollow"
+                    className="text-blue-600 hover:underline dark:text-blue-500"
+                  >
+                    Tailwind UI
+                  </a>
+                </li>
+              </ul>
+            </Accordion.Content>
+          </Accordion.Panel>
+        </Accordion>
+      ),
       codeClassName: 'dark:!bg-gray-900',
     },
     {
       title: 'Flush accordion',
-      code: <Accordion flush>{panels()}</Accordion>,
+      code: (
+        <Accordion flush>
+          <Accordion.Panel>
+            <Accordion.Title>What is Flowbite?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                Flowbite is an open-source library of interactive components built on top of Tailwind CSS including
+                buttons, dropdowns, modals, navbars, and more.
+              </p>
+              <p className="text-gray-500 dark:text-gray-400">
+                Check out this guide to learn how to{' '}
+                <a
+                  href="https://flowbite.com/docs/getting-started/introduction/"
+                  className="text-blue-600 hover:underline dark:text-blue-500"
+                >
+                  get started
+                </a>{' '}
+                and start developing websites even faster with components on top of Tailwind CSS.
+              </p>
+            </Accordion.Content>
+          </Accordion.Panel>
+          <Accordion.Panel>
+            <Accordion.Title>Is there a Figma file available?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                Flowbite is first conceptualized and designed using the Figma software so everything you see in the
+                library has a design equivalent in our Figma file.
+              </p>
+              <p className="text-gray-500 dark:text-gray-400">
+                Check out the{' '}
+                <a href="https://flowbite.com/figma/" className="text-blue-600 hover:underline dark:text-blue-500">
+                  Figma design system
+                </a>{' '}
+                based on the utility classes from Tailwind CSS and components from Flowbite.
+              </p>
+            </Accordion.Content>
+          </Accordion.Panel>
+          <Accordion.Panel>
+            <Accordion.Title>What are the differences between Flowbite and Tailwind UI?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                The main difference is that the core components from Flowbite are open source under the MIT license,
+                whereas Tailwind UI is a paid product. Another difference is that Flowbite relies on smaller and
+                standalone components, whereas Tailwind UI offers sections of pages.
+              </p>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                However, we actually recommend using both Flowbite, Flowbite Pro, and even Tailwind UI as there is no
+                technical reason stopping you from using the best of two worlds.
+              </p>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">Learn more about these technologies:</p>
+              <ul className="list-disc pl-5 text-gray-500 dark:text-gray-400">
+                <li>
+                  <a href="https://flowbite.com/pro/" className="text-blue-600 hover:underline dark:text-blue-500">
+                    Flowbite Pro
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://tailwindui.com/"
+                    rel="nofollow"
+                    className="text-blue-600 hover:underline dark:text-blue-500"
+                  >
+                    Tailwind UI
+                  </a>
+                </li>
+              </ul>
+            </Accordion.Content>
+          </Accordion.Panel>
+        </Accordion>
+      ),
       codeClassName: 'dark:!bg-gray-900',
     },
     {
       title: 'Arrow style',
-      code: <Accordion>{panels(HiOutlineArrowCircleDown)}</Accordion>,
+      code: (
+        <Accordion arrowIcon={HiOutlineArrowCircleDown}>
+          <Accordion.Panel>
+            <Accordion.Title>What is Flowbite?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                Flowbite is an open-source library of interactive components built on top of Tailwind CSS including
+                buttons, dropdowns, modals, navbars, and more.
+              </p>
+              <p className="text-gray-500 dark:text-gray-400">
+                Check out this guide to learn how to{' '}
+                <a
+                  href="https://flowbite.com/docs/getting-started/introduction/"
+                  className="text-blue-600 hover:underline dark:text-blue-500"
+                >
+                  get started
+                </a>{' '}
+                and start developing websites even faster with components on top of Tailwind CSS.
+              </p>
+            </Accordion.Content>
+          </Accordion.Panel>
+          <Accordion.Panel>
+            <Accordion.Title>Is there a Figma file available?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                Flowbite is first conceptualized and designed using the Figma software so everything you see in the
+                library has a design equivalent in our Figma file.
+              </p>
+              <p className="text-gray-500 dark:text-gray-400">
+                Check out the{' '}
+                <a href="https://flowbite.com/figma/" className="text-blue-600 hover:underline dark:text-blue-500">
+                  Figma design system
+                </a>{' '}
+                based on the utility classes from Tailwind CSS and components from Flowbite.
+              </p>
+            </Accordion.Content>
+          </Accordion.Panel>
+          <Accordion.Panel>
+            <Accordion.Title>What are the differences between Flowbite and Tailwind UI?</Accordion.Title>
+            <Accordion.Content>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                The main difference is that the core components from Flowbite are open source under the MIT license,
+                whereas Tailwind UI is a paid product. Another difference is that Flowbite relies on smaller and
+                standalone components, whereas Tailwind UI offers sections of pages.
+              </p>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">
+                However, we actually recommend using both Flowbite, Flowbite Pro, and even Tailwind UI as there is no
+                technical reason stopping you from using the best of two worlds.
+              </p>
+              <p className="mb-2 text-gray-500 dark:text-gray-400">Learn more about these technologies:</p>
+              <ul className="list-disc pl-5 text-gray-500 dark:text-gray-400">
+                <li>
+                  <a href="https://flowbite.com/pro/" className="text-blue-600 hover:underline dark:text-blue-500">
+                    Flowbite Pro
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://tailwindui.com/"
+                    rel="nofollow"
+                    className="text-blue-600 hover:underline dark:text-blue-500"
+                  >
+                    Tailwind UI
+                  </a>
+                </li>
+              </ul>
+            </Accordion.Content>
+          </Accordion.Panel>
+        </Accordion>
+      ),
       codeClassName: 'dark:!bg-gray-900',
     },
   ];

--- a/src/lib/components/Accordion/Accordion.stories.tsx
+++ b/src/lib/components/Accordion/Accordion.stories.tsx
@@ -1,21 +1,25 @@
 import { ComponentProps, FC } from 'react';
 
 import { Meta, Story } from '@storybook/react/types-6-0';
-import { HiChevronDown } from 'react-icons/hi';
+import { HiChevronDown, HiOutlineArrowCircleDown } from 'react-icons/hi';
 
 import { Accordion, AccordionProps } from '.';
 
 export default {
   title: 'Components/Accordion',
   component: Accordion,
+  args: {
+    alwaysOpen: false,
+    flush: false,
+  },
 } as Meta;
 
 const icon: FC<ComponentProps<'svg'>> = HiChevronDown;
 
 const Template: Story<AccordionProps> = (args) => (
-  <Accordion {...args}>
-    <Accordion.Panel key={0} open>
-      <Accordion.Title arrowIcon={icon}>What is Flowbite?</Accordion.Title>
+  <Accordion arrowIcon={icon} {...args}>
+    <Accordion.Panel>
+      <Accordion.Title>What is Flowbite?</Accordion.Title>
       <Accordion.Content>
         <p className="mb-2 text-gray-500 dark:text-gray-400">
           Flowbite is an open-source library of interactive components built on top of Tailwind CSS including buttons,
@@ -33,8 +37,8 @@ const Template: Story<AccordionProps> = (args) => (
         </p>
       </Accordion.Content>
     </Accordion.Panel>
-    <Accordion.Panel key={1}>
-      <Accordion.Title arrowIcon={icon}>Is there a Figma file available?</Accordion.Title>
+    <Accordion.Panel>
+      <Accordion.Title>Is there a Figma file available?</Accordion.Title>
       <Accordion.Content>
         <p className="mb-2 text-gray-500 dark:text-gray-400">
           Flowbite is first conceptualized and designed using the Figma software so everything you see in the library
@@ -49,8 +53,8 @@ const Template: Story<AccordionProps> = (args) => (
         </p>
       </Accordion.Content>
     </Accordion.Panel>
-    <Accordion.Panel key={2}>
-      <Accordion.Title arrowIcon={icon}>What are the differences between Flowbite and Tailwind UI?</Accordion.Title>
+    <Accordion.Panel>
+      <Accordion.Title>What are the differences between Flowbite and Tailwind UI?</Accordion.Title>
       <Accordion.Content>
         <p className="mb-2 text-gray-500 dark:text-gray-400">
           The main difference is that the core components from Flowbite are open source under the MIT license, whereas
@@ -83,6 +87,21 @@ const Template: Story<AccordionProps> = (args) => (
   </Accordion>
 );
 
-export const DefaultAccordion = Template.bind({});
-DefaultAccordion.storyName = 'Default';
-DefaultAccordion.args = {};
+export const AlwaysOpen = Template.bind({});
+AlwaysOpen.storyName = 'Always open';
+AlwaysOpen.args = {
+  alwaysOpen: true,
+};
+
+export const Default = Template.bind({});
+
+export const Flush = Template.bind({});
+Flush.args = {
+  flush: true,
+};
+
+export const WithArrowIcon = Template.bind({});
+WithArrowIcon.storyName = 'With arrow icon';
+WithArrowIcon.args = {
+  arrowIcon: HiOutlineArrowCircleDown,
+};

--- a/src/lib/components/Accordion/AccordionContent.tsx
+++ b/src/lib/components/Accordion/AccordionContent.tsx
@@ -7,11 +7,11 @@ import { useAccordionContext } from './AccordionPanelContext';
 export const AccordionContent: FC<ComponentProps<'div'>> = ({ children, ...props }): JSX.Element => {
   const theirProps = excludeClassName(props);
 
-  const { open } = useAccordionContext();
+  const { isOpen } = useAccordionContext();
   const theme = useTheme().theme.accordion.content;
 
   return (
-    <div className={theme.base} data-testid="flowbite-accordion-content" hidden={!open} {...theirProps}>
+    <div className={theme.base} data-testid="flowbite-accordion-content" hidden={!isOpen} {...theirProps}>
       {children}
     </div>
   );

--- a/src/lib/components/Accordion/AccordionContent.tsx
+++ b/src/lib/components/Accordion/AccordionContent.tsx
@@ -7,11 +7,11 @@ import { useAccordionContext } from './AccordionPanelContext';
 export const AccordionContent: FC<ComponentProps<'div'>> = ({ children, ...props }): JSX.Element => {
   const theirProps = excludeClassName(props);
 
-  const { isOpen } = useAccordionContext();
+  const { open } = useAccordionContext();
   const theme = useTheme().theme.accordion.content;
 
   return (
-    <div className={theme.base} data-testid="flowbite-accordion-content" hidden={!isOpen} {...theirProps}>
+    <div className={theme.base} data-testid="flowbite-accordion-content" hidden={!open} {...theirProps}>
       {children}
     </div>
   );

--- a/src/lib/components/Accordion/AccordionPanel.tsx
+++ b/src/lib/components/Accordion/AccordionPanel.tsx
@@ -3,19 +3,19 @@ import { AccordionProps } from '.';
 import { AccordionPanelContext } from './AccordionPanelContext';
 
 export interface AccordionPanelProps extends PropsWithChildren<AccordionProps> {
-  open?: boolean;
+  isOpen?: boolean;
   setOpen?: () => void;
 }
 
 export const AccordionPanel: FC<AccordionPanelProps> = ({ children, ...props }): JSX.Element => {
   const { alwaysOpen } = props;
-  const [open, setOpen] = useState(props.open);
+  const [isOpen, setOpen] = useState(props.isOpen);
 
   const provider = alwaysOpen
     ? {
         ...props,
-        open,
-        setOpen: () => setOpen(!open),
+        isOpen,
+        setOpen: () => setOpen(!isOpen),
       }
     : props;
 

--- a/src/lib/components/Accordion/AccordionPanel.tsx
+++ b/src/lib/components/Accordion/AccordionPanel.tsx
@@ -1,17 +1,23 @@
-import { Children, cloneElement, ComponentProps, FC, PropsWithChildren, ReactElement, useMemo, useState } from 'react';
+import { FC, PropsWithChildren, useState } from 'react';
+import { AccordionProps } from '.';
 import { AccordionPanelContext } from './AccordionPanelContext';
 
-export interface AccordionPanelProps extends PropsWithChildren<Record<string, unknown>> {
-  flush?: boolean;
+export interface AccordionPanelProps extends PropsWithChildren<AccordionProps> {
   open?: boolean;
+  setOpen?: () => void;
 }
 
-export const AccordionPanel: FC<AccordionPanelProps> = ({ children, flush, open }): JSX.Element => {
-  const [isOpen, setIsOpen] = useState(open);
-  const items = useMemo(
-    () => Children.map(children as ReactElement<ComponentProps<'div' | 'button'>>[], (child) => cloneElement(child)),
-    [children],
-  );
+export const AccordionPanel: FC<AccordionPanelProps> = ({ children, ...props }): JSX.Element => {
+  const { alwaysOpen } = props;
+  const [open, setOpen] = useState(props.open);
 
-  return <AccordionPanelContext.Provider value={{ flush, isOpen, setIsOpen }}>{items}</AccordionPanelContext.Provider>;
+  const provider = alwaysOpen
+    ? {
+        ...props,
+        open,
+        setOpen: () => setOpen(!open),
+      }
+    : props;
+
+  return <AccordionPanelContext.Provider value={provider}>{children}</AccordionPanelContext.Provider>;
 };

--- a/src/lib/components/Accordion/AccordionPanelContext.tsx
+++ b/src/lib/components/Accordion/AccordionPanelContext.tsx
@@ -1,10 +1,7 @@
 import { createContext, useContext } from 'react';
+import { AccordionPanelProps } from './AccordionPanel';
 
-type AccordionPanelContext = {
-  flush?: boolean;
-  isOpen?: boolean;
-  setIsOpen: (isOpen: boolean) => void;
-};
+type AccordionPanelContext = Omit<AccordionPanelProps, 'children'>;
 
 export const AccordionPanelContext = createContext<AccordionPanelContext | undefined>(undefined);
 

--- a/src/lib/components/Accordion/AccordionTitle.tsx
+++ b/src/lib/components/Accordion/AccordionTitle.tsx
@@ -12,14 +12,14 @@ export interface AccordionTitleProps extends ComponentProps<'button'> {
 export const AccordionTitle: FC<AccordionTitleProps> = ({ as: Heading = 'h2', children, ...props }): JSX.Element => {
   const theirProps = excludeClassName(props);
 
-  const { arrowIcon: ArrowIcon, flush, open, setOpen } = useAccordionContext();
+  const { arrowIcon: ArrowIcon, flush, isOpen, setOpen } = useAccordionContext();
   const theme = useTheme().theme.accordion.title;
 
   const onClick = () => typeof setOpen !== 'undefined' && setOpen();
 
   return (
     <button
-      className={classNames(theme.base, theme.flush[flush ? 'on' : 'off'], theme.open[open ? 'on' : 'off'])}
+      className={classNames(theme.base, theme.flush[flush ? 'on' : 'off'], theme.open[isOpen ? 'on' : 'off'])}
       onClick={onClick}
       type="button"
       {...theirProps}
@@ -28,7 +28,7 @@ export const AccordionTitle: FC<AccordionTitleProps> = ({ as: Heading = 'h2', ch
       {ArrowIcon && (
         <ArrowIcon
           aria-hidden
-          className={classNames(theme.arrow.base, theme.arrow.open[open ? 'on' : 'off'])}
+          className={classNames(theme.arrow.base, theme.arrow.open[isOpen ? 'on' : 'off'])}
           data-testid="flowbite-accordion-arrow"
         />
       )}

--- a/src/lib/components/Accordion/AccordionTitle.tsx
+++ b/src/lib/components/Accordion/AccordionTitle.tsx
@@ -1,38 +1,37 @@
 import { ComponentProps, FC } from 'react';
 import classNames from 'classnames';
-import { HiChevronDown } from 'react-icons/hi';
 import { useAccordionContext } from './AccordionPanelContext';
 import { useTheme } from '../Flowbite/ThemeContext';
 import { excludeClassName } from '../../helpers/exclude';
 import { HeadingLevel } from '../Flowbite/FlowbiteTheme';
 
 export interface AccordionTitleProps extends ComponentProps<'button'> {
-  arrowIcon?: FC<ComponentProps<'svg'>>;
   as?: HeadingLevel;
 }
 
-export const AccordionTitle: FC<AccordionTitleProps> = ({
-  arrowIcon: ArrowIcon = HiChevronDown,
-  as: Heading = 'h2',
-  children,
-  ...props
-}): JSX.Element => {
+export const AccordionTitle: FC<AccordionTitleProps> = ({ as: Heading = 'h2', children, ...props }): JSX.Element => {
   const theirProps = excludeClassName(props);
 
-  const { flush, isOpen, setIsOpen } = useAccordionContext();
+  const { arrowIcon: ArrowIcon, flush, open, setOpen } = useAccordionContext();
   const theme = useTheme().theme.accordion.title;
 
-  const onClick = () => setIsOpen(!isOpen);
+  const onClick = () => typeof setOpen !== 'undefined' && setOpen();
 
   return (
     <button
-      className={classNames(theme.base, theme.flush[flush ? 'on' : 'off'], theme.open[isOpen ? 'on' : 'off'])}
+      className={classNames(theme.base, theme.flush[flush ? 'on' : 'off'], theme.open[open ? 'on' : 'off'])}
       onClick={onClick}
       type="button"
       {...theirProps}
     >
       <Heading data-testid="flowbite-accordion-heading">{children}</Heading>
-      <ArrowIcon aria-hidden className={classNames(theme.arrow.base, isOpen && theme.arrow.open)} />
+      {ArrowIcon && (
+        <ArrowIcon
+          aria-hidden
+          className={classNames(theme.arrow.base, theme.arrow.open[open ? 'on' : 'off'])}
+          data-testid="flowbite-accordion-arrow"
+        />
+      )}
     </button>
   );
 };

--- a/src/lib/components/Accordion/index.tsx
+++ b/src/lib/components/Accordion/index.tsx
@@ -1,24 +1,30 @@
-import { Children, cloneElement, ComponentProps, FC, PropsWithChildren, ReactElement, useMemo } from 'react';
+import { Children, cloneElement, ComponentProps, FC, PropsWithChildren, ReactElement, useState } from 'react';
 import { AccordionPanel, AccordionPanelProps } from './AccordionPanel';
 import { AccordionTitle } from './AccordionTitle';
 import { AccordionContent } from './AccordionContent';
 import classNames from 'classnames';
 import { useTheme } from '../Flowbite/ThemeContext';
 import { excludeClassName } from '../../helpers/exclude';
+import { HiChevronDown } from 'react-icons/hi';
 
 export interface AccordionProps extends PropsWithChildren<ComponentProps<'div'>> {
+  alwaysOpen?: boolean;
+  arrowIcon?: FC<ComponentProps<'svg'>>;
+  children: ReactElement<AccordionPanelProps> | ReactElement<AccordionPanelProps>[];
   flush?: boolean;
 }
 
-const AccordionComponent: FC<AccordionProps> = ({ children, flush, ...props }): JSX.Element => {
+const AccordionComponent: FC<AccordionProps> = ({
+  alwaysOpen = false,
+  arrowIcon = HiChevronDown,
+  children,
+  flush = false,
+  ...props
+}): JSX.Element => {
   const theirProps = excludeClassName(props);
 
+  const [open, setOpen] = useState(0);
   const theme = useTheme().theme.accordion;
-
-  const panels = useMemo(
-    () => Children.map(children as ReactElement<AccordionPanelProps>[], (child) => cloneElement(child, { flush })),
-    [children, flush],
-  );
 
   return (
     <div
@@ -26,7 +32,9 @@ const AccordionComponent: FC<AccordionProps> = ({ children, flush, ...props }): 
       data-testid="flowbite-accordion"
       {...theirProps}
     >
-      {panels}
+      {Children.map(children, (child, i) =>
+        cloneElement(child, { alwaysOpen, arrowIcon, flush, open: open === i, setOpen: () => setOpen(i) }),
+      )}
     </div>
   );
 };

--- a/src/lib/components/Accordion/index.tsx
+++ b/src/lib/components/Accordion/index.tsx
@@ -1,4 +1,4 @@
-import { Children, cloneElement, ComponentProps, FC, PropsWithChildren, ReactElement, useState } from 'react';
+import { Children, cloneElement, ComponentProps, FC, PropsWithChildren, ReactElement, useMemo, useState } from 'react';
 import { AccordionPanel, AccordionPanelProps } from './AccordionPanel';
 import { AccordionTitle } from './AccordionTitle';
 import { AccordionContent } from './AccordionContent';
@@ -23,7 +23,14 @@ const AccordionComponent: FC<AccordionProps> = ({
 }): JSX.Element => {
   const theirProps = excludeClassName(props);
 
-  const [open, setOpen] = useState(0);
+  const [isOpen, setOpen] = useState(0);
+  const panels = useMemo(
+    () =>
+      Children.map(children, (child, i) =>
+        cloneElement(child, { alwaysOpen, arrowIcon, flush, isOpen: isOpen === i, setOpen: () => setOpen(i) }),
+      ),
+    [alwaysOpen, arrowIcon, children, flush, isOpen],
+  );
   const theme = useTheme().theme.accordion;
 
   return (
@@ -32,9 +39,7 @@ const AccordionComponent: FC<AccordionProps> = ({
       data-testid="flowbite-accordion"
       {...theirProps}
     >
-      {Children.map(children, (child, i) =>
-        cloneElement(child, { alwaysOpen, arrowIcon, flush, open: open === i, setOpen: () => setOpen(i) }),
-      )}
+      {panels}
     </div>
   );
 };

--- a/src/lib/components/Flowbite/FlowbiteTheme.d.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.d.ts
@@ -17,7 +17,10 @@ export interface FlowbiteTheme {
     title: {
       arrow: {
         base: string;
-        open: string;
+        open: {
+          off: string;
+          on: string;
+        };
       };
       base: string;
       flush: {

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -11,7 +11,10 @@ export default {
     title: {
       arrow: {
         base: 'h-6 w-6 shrink-0',
-        open: 'rotate-180',
+        open: {
+          off: '',
+          on: 'rotate-180',
+        },
       },
       base: 'flex w-full items-center justify-between first:rounded-t-lg last:rounded-b-lg py-5 px-5 text-left font-medium text-gray-500 dark:text-gray-400',
       flush: {


### PR DESCRIPTION
## Breaking changes

`Accordion`s used to let more than one `Accordion.Panel` be open at once. Now, only the most recently clicked panel will be open.

To override this behavior, specify `<Accordion alwaysOpen>`.

See the [Flowbite Accordion docs](https://flowbite.com/docs/components/accordion/) - notably, the `Default accordion` and `Always open` examples

## Features

- [x] [feature(component): Change Accordions to close inactive panels, res…](https://github.com/themesberg/flowbite-react/commit/58ab0f1b13732d691ee63542343d4bad8766625d)
- [x] [feature(story): Add missing Accordion stories](https://github.com/themesberg/flowbite-react/commit/e6d7e2d1927e98bedf233c15384ed3f9e0e1d4de)

## Tests

### Unit

- [x] [test(component): Add numerous unit tests for Accordions](https://github.com/themesberg/flowbite-react/commit/7e54b587539cd438b9ce9c99e56cd3e96201d14f)