### PR TITLE
feature(component): Allow `Sidebar`s to hide completely, resolves #81

### DIFF
--- a/src/docs/pages/SidebarPage.tsx
+++ b/src/docs/pages/SidebarPage.tsx
@@ -9,7 +9,7 @@ const SidebarPage: FC = () => {
     {
       title: 'Default sidebar',
       code: (
-        <Sidebar className="!bg-gray-50" collapsed={false}>
+        <Sidebar aria-label="Default sidebar example" className="!bg-gray-50 dark:!bg-gray-900">
           <Sidebar.Items>
             <Sidebar.ItemGroup>
               <Sidebar.Item href="#" icon={HiChartPie}>
@@ -41,7 +41,7 @@ const SidebarPage: FC = () => {
     {
       title: 'Multi-level dropdown',
       code: (
-        <Sidebar className="!bg-gray-50" collapsed={false}>
+        <Sidebar aria-label="Sidebar with multi-level dropdown example" className="!bg-gray-50 dark:!bg-gray-900">
           <Sidebar.Items>
             <Sidebar.ItemGroup>
               <Sidebar.Item href="#" icon={HiChartPie}>
@@ -73,7 +73,7 @@ const SidebarPage: FC = () => {
     {
       title: 'Content separator',
       code: (
-        <Sidebar className="!bg-gray-50" collapsed={false}>
+        <Sidebar aria-label="Sidebar with content separator example" className="!bg-gray-50 dark:!bg-gray-900">
           <Sidebar.Items>
             <Sidebar.ItemGroup>
               <Sidebar.Item href="#" icon={HiChartPie}>
@@ -116,7 +116,7 @@ const SidebarPage: FC = () => {
     {
       title: 'CTA button',
       code: (
-        <Sidebar className="!bg-gray-50" collapsed={false}>
+        <Sidebar aria-label="Sidebar with call to action button example" className="!bg-gray-50 dark:!bg-gray-900">
           <Sidebar.Items>
             <Sidebar.ItemGroup>
               <Sidebar.Item href="#" icon={HiChartPie}>
@@ -177,7 +177,7 @@ const SidebarPage: FC = () => {
     {
       title: 'Logo branding',
       code: (
-        <Sidebar className="!bg-gray-50" collapsed={false}>
+        <Sidebar aria-label="Sidebar with logo branding example" className="!bg-gray-50 dark:!bg-gray-900">
           <Sidebar.Logo href="#" img="favicon.png" imgAlt="Flowbite logo">
             Flowbite
           </Sidebar.Logo>

--- a/src/lib/components/Sidebar/Sidebar.spec.tsx
+++ b/src/lib/components/Sidebar/Sidebar.spec.tsx
@@ -1,126 +1,230 @@
-import { render, waitFor } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
-import { HiChartPie, HiInbox, HiUser, HiShoppingBag, HiArrowSmRight, HiTable } from 'react-icons/hi';
+import { render, RenderResult, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HiChartPie, HiInbox, HiShoppingBag } from 'react-icons/hi';
 import { Sidebar, SidebarProps } from '.';
-import { Badge } from '../Badge';
-import { Button } from '../Button';
 
-describe('Sidebar', () => {
-  describe('when collapsed', () => {
-    describe('logo', () => {
-      it('should not display its text label', () => {
-        const { getByTestId } = render(<SidebarTestComponent collapsed />);
-        expect(getByTestId('sidebar-logo')).toHaveClass('sr-only');
+describe('Components / Sidebar', () => {
+  describe('A11y', () => {
+    it('should use `aria-label` if provided', () => {
+      const { getByLabelText } = render(<TestSidebar aria-label="My differently labelled sidebar" />);
+      const sidebar = getByLabelText('My differently labelled sidebar');
+
+      expect(sidebar).toHaveAccessibleName('My differently labelled sidebar');
+    });
+
+    describe('`Sidebar.Collapse` and `Sidebar.Item`', () => {
+      it('should use text content as accessible name', () => {
+        const itemLabels = ['Dashboard', 'E-commerce', 'Products', 'Services', 'Inbox', 'My heading'];
+
+        const { getAllByRole } = render(<TestSidebar />);
+        const collapseButtons = getSidebarCollapseButtons({ getAllByRole });
+
+        collapseButtons.forEach((button) => userEvent.click(button));
+
+        const items = getSidebarItems({ getAllByRole });
+
+        items.forEach((item, i) => {
+          expect(item.firstElementChild).toHaveAccessibleName(itemLabels[i]);
+        });
       });
     });
 
-    describe('items', () => {
-      it('should not display their text content', () => {
-        const { queryAllByTestId } = render(<SidebarTestComponent collapsed />);
-        expect(queryAllByTestId('sidebar-item-content')).toHaveLength(0);
-      });
-      it('should not display their label', () => {
-        const { queryAllByTestId } = render(<SidebarTestComponent collapsed />);
-        expect(queryAllByTestId('sidebar-item-label')).toHaveLength(0);
-      });
-      it('should display a tooltip', async () => {
-        const { queryAllByTestId } = render(<SidebarTestComponent collapsed />);
-        expect(queryAllByTestId('sidebar-item-tooltip')).not.toHaveLength(0);
-      });
-    });
+    describe('`Sidebar.Logo`', () => {
+      it('should use text content as accessible name', () => {
+        const logo = getSidebarLogo(render(<TestSidebar />));
 
-    describe('CTA', () => {
-      it('should not be displayed', () => {
-        const { queryByTestId } = render(<SidebarTestComponent collapsed />);
-        expect(queryByTestId('sidebar-cta')).toBeNull();
+        expect(logo).toHaveAccessibleName('Flowbite');
+      });
+
+      describe('`img=".."` and `imgAlt=".."`', () => {
+        it('should use `imgAlt` as alternative text for image', () => {
+          const { getByAltText } = render(<TestSidebar />);
+          const logoImg = getByAltText('Flowbite logo');
+
+          expect(logoImg).toHaveAccessibleName('Flowbite logo');
+        });
       });
     });
   });
 
-  describe('with a collapsable item', () => {
-    describe('that is closed', () => {
-      it('should expand when clicked', async () => {
-        const { getByTestId } = render(<SidebarTestComponent />);
-        act(() => {
-          getByTestId('sidebar-collapse-button').click();
+  describe('Keyboard interactions', () => {
+    describe('`Space`', () => {
+      describe('`Sidebar.Collapse`', () => {
+        it('should expand/collapse', () => {
+          const { getAllByRole } = render(<TestSidebar />);
+          const collapseButton = getSidebarCollapseButtons({ getAllByRole })[0];
+
+          userEvent.click(collapseButton);
+
+          const collapse = getSidebarCollapses({ getAllByRole })[0];
+
+          expect(collapse).toBeVisible();
         });
-        await waitFor(() => expect(getByTestId('sidebar-collapse')).not.toHaveClass('hidden'));
+      });
+
+      describe('`Sidebar.Item`', () => {
+        describe('`href=".."`', () => {
+          it('should follow link', () => {
+            const { getAllByRole } = render(<TestSidebar />);
+            const link = getAllByRole('link')[1];
+
+            expect(link).toHaveAccessibleName('Dashboard');
+            expect(link).toHaveAttribute('href', '#');
+          });
+        });
       });
     });
 
-    describe('that is open', () => {
-      it('should collapse when clicked', async () => {
-        const { getByTestId } = render(<SidebarTestComponent />);
-        act(() => {
-          getByTestId('sidebar-collapse-button').click();
+    describe('`Tab`', () => {
+      it('should be possible to `Tab` out', async () => {
+        const { getByText } = render(
+          <>
+            <TestSidebar />
+            <button role="checkbox">Outside</button>
+          </>,
+        );
+        const outside = getByText('Outside');
+
+        await waitFor(() => {
+          userEvent.tab();
+
+          expect(outside).toHaveFocus();
         });
-        act(() => {
-          getByTestId('sidebar-collapse-button').click();
+      });
+    });
+  });
+
+  describe('Props', () => {
+    describe('`collapseBehavior="hide"`', () => {
+      it("shouldn't display anything", () => {
+        const { queryByLabelText } = render(<TestSidebar collapseBehavior="hide" collapsed />);
+        const sidebar = queryByLabelText('Sidebar');
+
+        expect(sidebar).not.toBeVisible();
+      });
+    });
+
+    describe('`collapsed={true}`', () => {
+      describe('`Sidebar.CTA`', () => {
+        it("shouldn't be visible", () => {
+          const cta = getSidebarCTA(render(<TestSidebar collapsed />));
+
+          expect(cta).not.toBeVisible();
         });
-        await waitFor(() => expect(getByTestId('sidebar-collapse')).toHaveClass('hidden'));
+      });
+
+      describe('`Sidebar.Collapse` and `Sidebar.Item`', () => {
+        it('should display tooltip', () => {
+          const items = getSidebarItems(render(<TestSidebar collapsed />));
+
+          items.forEach((item) => {
+            expect(item.firstElementChild).toHaveAttribute('data-testid', 'tooltip-target');
+          });
+        });
+
+        it("shouldn't display text content", () => {
+          const items = getSidebarItemContents(render(<TestSidebar collapsed />));
+
+          items.forEach((item) => expect(item).toHaveClass('hidden'));
+        });
+      });
+
+      describe('`Sidebar.Item`', () => {
+        it("shouldn't display `label`", () => {
+          const labels = getSidebarLabels(render(<TestSidebar collapsed />));
+
+          labels.forEach((label) => expect(label).not.toBeVisible());
+        });
+      });
+
+      describe('`Sidebar.Logo`', () => {
+        it("shouldn't display text content", () => {
+          const logo = getSidebarLogo(render(<TestSidebar collapsed />));
+
+          expect(logo.lastElementChild).toHaveClass('hidden');
+        });
+      });
+    });
+
+    describe('`Sidebar.Item`', () => {
+      describe('`as=""`', () => {
+        it('should use that HTML element', () => {
+          const { getByLabelText } = render(<TestSidebar />);
+          const asItem = getByLabelText('My heading');
+
+          expect(asItem.tagName.toLocaleLowerCase()).toEqual('h3');
+        });
+      });
+    });
+  });
+
+  describe('Rendering', () => {
+    it('should render', () => {
+      const sidebar = getSidebar(render(<TestSidebar />));
+
+      expect(sidebar).toBeInTheDocument();
+    });
+
+    describe('`collapseBehavior="hide"`', () => {
+      it('should render', () => {
+        const sidebar = getSidebar(render(<TestSidebar collapseBehavior="hide" collapsed />));
+
+        expect(sidebar).toBeInTheDocument();
+      });
+    });
+
+    describe('`collapsed={true}`', () => {
+      it('should render', () => {
+        const sidebar = getSidebar(render(<TestSidebar collapsed />));
+
+        expect(sidebar).toBeInTheDocument();
       });
     });
   });
 });
 
-const SidebarTestComponent = ({ collapsed }: SidebarProps): JSX.Element => (
-  <Sidebar collapsed={collapsed}>
+const TestSidebar = ({ ...props }: SidebarProps): JSX.Element => (
+  <Sidebar {...props}>
     <Sidebar.Logo href="#" img="favicon.png" imgAlt="Flowbite logo">
       Flowbite
     </Sidebar.Logo>
     <Sidebar.Items>
       <Sidebar.ItemGroup>
-        <Sidebar.Item href="#" icon={HiChartPie}>
+        <Sidebar.Item href="#" icon={HiChartPie} label="3" labelColor="success">
           Dashboard
         </Sidebar.Item>
-        <Sidebar.Collapse icon={HiShoppingBag} label="E-commerce">
+        <Sidebar.Collapse aria-label="E-commerce" icon={HiShoppingBag}>
           <Sidebar.Item href="#">Products</Sidebar.Item>
+          <Sidebar.Item href="#">Services</Sidebar.Item>
         </Sidebar.Collapse>
         <Sidebar.Item href="#" icon={HiInbox}>
           Inbox
         </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiUser}>
-          Users
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiShoppingBag}>
-          Something else
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiArrowSmRight}>
-          Sign In
-        </Sidebar.Item>
-        <Sidebar.Item href="#" icon={HiTable}>
-          Sign Up
-        </Sidebar.Item>
+        <Sidebar.Item as="h3">My heading</Sidebar.Item>
       </Sidebar.ItemGroup>
     </Sidebar.Items>
-    <Sidebar.CTA>
-      <div className="mb-3 flex items-center">
-        <Badge color="yellow">Beta</Badge>
-        <Button
-          aria-label="Close"
-          className="-mx-1.5 -my-1.5 ml-auto !h-6 !w-6 bg-transparent !p-1 text-blue-900 hover:bg-blue-200 dark:!bg-blue-900 dark:text-blue-200 dark:hover:!bg-blue-800"
-          data-collapse-toggle="dropdown-cta"
-        >
-          <span className="sr-only">Close</span>
-          <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-            <path
-              fillRule="evenodd"
-              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
-              clipRule="evenodd"
-            ></path>
-          </svg>
-        </Button>
-      </div>
-      <p className="mb-3 text-sm text-blue-900 dark:text-blue-400">
-        Preview the new Flowbite dashboard navigation! You can turn the new navigation off for a limited time in your
-        profile.
-      </p>
-      <a
-        className="text-sm text-blue-900 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-        href="#"
-      >
-        Turn new navigation off
-      </a>
-    </Sidebar.CTA>
+    <Sidebar.CTA>Some content</Sidebar.CTA>
   </Sidebar>
 );
+
+const getSidebar = ({ getByLabelText }: Pick<RenderResult, 'getByLabelText'>): HTMLElement => getByLabelText('Sidebar');
+
+const getSidebarCollapseButtons = ({ getAllByRole }: Pick<RenderResult, 'getAllByRole'>): HTMLElement[] =>
+  getAllByRole('button');
+
+const getSidebarCollapses = ({ getAllByRole }: Pick<RenderResult, 'getAllByRole'>): HTMLElement[] =>
+  getAllByRole('list').slice(1);
+
+const getSidebarCTA = ({ getByText }: Pick<RenderResult, 'getByText'>): HTMLElement => getByText('Some content');
+
+const getSidebarItemContents = ({ getAllByTestId }: Pick<RenderResult, 'getAllByTestId'>): HTMLElement[] =>
+  getAllByTestId('flowbite-sidebar-item-content');
+
+const getSidebarItems = ({ getAllByRole }: Pick<RenderResult, 'getAllByRole'>): HTMLElement[] =>
+  getAllByRole('listitem');
+
+const getSidebarLabels = ({ queryAllByTestId }: Pick<RenderResult, 'queryAllByTestId'>): HTMLElement[] =>
+  queryAllByTestId('flowbite-sidebar-label');
+
+const getSidebarLogo = ({ getByLabelText }: Pick<RenderResult, 'getByLabelText'>): HTMLElement =>
+  getByLabelText('Flowbite');

--- a/src/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/src/lib/components/Sidebar/Sidebar.stories.tsx
@@ -21,7 +21,7 @@ Default.args = {
           <Sidebar.Item href="#" icon={HiChartPie}>
             Dashboard
           </Sidebar.Item>
-          <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="alternative">
+          <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="gray">
             Kanban
           </Sidebar.Item>
           <Sidebar.Item href="#" icon={HiInbox} label="3">

--- a/src/lib/components/Sidebar/SidebarCTA.tsx
+++ b/src/lib/components/Sidebar/SidebarCTA.tsx
@@ -19,7 +19,7 @@ const colorClasses: Record<Color, string> = {
 };
 
 const SidebarCTA: FC<SidebarCTAProps> = ({ children, className, color = 'blue', ...rest }) => {
-  const { collapsed } = useSidebarContext();
+  const { isCollapsed: collapsed } = useSidebarContext();
 
   return collapsed ? (
     <></>

--- a/src/lib/components/Sidebar/SidebarCTA.tsx
+++ b/src/lib/components/Sidebar/SidebarCTA.tsx
@@ -18,16 +18,15 @@ const colorClasses: Record<Color, string> = {
   purple: 'bg-purple-50 dark:bg-purple-900',
 };
 
-const SidebarCTA: FC<SidebarCTAProps> = ({ children, className, color = 'blue', ...rest }) => {
-  const { isCollapsed: collapsed } = useSidebarContext();
+const SidebarCTA: FC<SidebarCTAProps> = ({ children, className, color = 'blue', ...theirProps }) => {
+  const { isCollapsed } = useSidebarContext();
 
-  return collapsed ? (
-    <></>
-  ) : (
+  return (
     <div
       className={classNames('mt-6 rounded-lg p-4', colorClasses[color], className)}
       data-testid="sidebar-cta"
-      {...rest}
+      hidden={isCollapsed}
+      {...theirProps}
     >
       {children}
     </div>

--- a/src/lib/components/Sidebar/SidebarCollapse.tsx
+++ b/src/lib/components/Sidebar/SidebarCollapse.tsx
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
-import { FC, PropsWithChildren, useState } from 'react';
+import * as nanoid from 'nanoid';
+import { FC, PropsWithChildren, useMemo, useState } from 'react';
 import { HiChevronDown } from 'react-icons/hi';
+import { excludeClassName } from '../../helpers/exclude';
 import { Tooltip } from '../Tooltip';
 import { useSidebarContext } from './SidebarContext';
 import { SidebarItem } from './SidebarItem';
@@ -8,18 +10,21 @@ import { SidebarItemContext } from './SidebarItemContext';
 
 export type SidebarCollapseProps = PropsWithChildren<SidebarItem>;
 
-const SidebarCollapse: FC<SidebarCollapseProps> = ({ children, icon: Icon, label, ...rest }) => {
-  const { collapsed } = useSidebarContext();
-  const [open, setOpen] = useState(false);
+const SidebarCollapse: FC<SidebarCollapseProps> = ({ children, icon: Icon, label, ...props }): JSX.Element => {
+  const theirProps = excludeClassName(props);
 
-  const Wrapper = ({ children: wrapperChildren }: PropsWithChildren<Record<string, unknown>>) => (
+  const id = useMemo(() => nanoid.nanoid(), []);
+  const { isCollapsed } = useSidebarContext();
+  const [isOpen, setOpen] = useState(false);
+
+  const Wrapper = ({ children }: PropsWithChildren<unknown>) => (
     <li>
-      {collapsed ? (
+      {isCollapsed ? (
         <Tooltip content={label} placement="right">
-          {wrapperChildren}
+          {children}
         </Tooltip>
       ) : (
-        wrapperChildren
+        children
       )}
     </li>
   );
@@ -28,35 +33,31 @@ const SidebarCollapse: FC<SidebarCollapseProps> = ({ children, icon: Icon, label
     <Wrapper>
       <button
         className="group flex w-full items-center rounded-lg p-2 text-base font-normal text-gray-900 transition duration-75 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
-        data-testid="sidebar-collapse-button"
-        onClick={() => setOpen(!open)}
+        id={`flowbite-sidebar-collapse-${id}`}
+        onClick={() => setOpen(!isOpen)}
         type="button"
-        {...rest}
+        {...theirProps}
       >
         {Icon && (
           <Icon
+            aria-hidden
             className={classNames(
               'h-6 w-6 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white',
-              { 'text-gray-900': open },
+              { 'text-gray-900': isOpen },
             )}
           />
         )}
-        {collapsed ? (
+        {isCollapsed ? (
           <span className="sr-only">{label}</span>
         ) : (
           <>
             <span className="ml-3 flex-1 whitespace-nowrap text-left">{label}</span>
-            <HiChevronDown className="h-6 w-6" />
+            <HiChevronDown aria-hidden className="h-6 w-6" />
           </>
         )}
       </button>
-      <ul
-        className={classNames('space-y-2 py-2', {
-          hidden: !open,
-        })}
-        data-testid="sidebar-collapse"
-      >
-        <SidebarItemContext.Provider value={{ insideCollapse: true }}>{children}</SidebarItemContext.Provider>
+      <ul aria-labelledby={`flowbite-sidebar-collapse-${id}`} className="space-y-2 py-2" hidden={!isOpen}>
+        <SidebarItemContext.Provider value={{ isInsideCollapse: true }}>{children}</SidebarItemContext.Provider>
       </ul>
     </Wrapper>
   );

--- a/src/lib/components/Sidebar/SidebarContext.tsx
+++ b/src/lib/components/Sidebar/SidebarContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 
 export type SidebarContext = {
-  collapsed: boolean;
+  isCollapsed: boolean;
 };
 
 export const SidebarContext = createContext<SidebarContext | undefined>(undefined);

--- a/src/lib/components/Sidebar/SidebarItem.tsx
+++ b/src/lib/components/Sidebar/SidebarItem.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
-import { ComponentProps, ElementType, FC, PropsWithChildren } from 'react';
+import * as nanoid from 'nanoid';
+import { ComponentProps, ElementType, FC, PropsWithChildren, useMemo } from 'react';
 import { Badge } from '../Badge';
-import { Color } from '../Button';
+import { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
 import { Tooltip } from '../Tooltip';
 import { useSidebarContext } from './SidebarContext';
 import { useSidebarItemContext } from './SidebarItemContext';
@@ -10,35 +11,41 @@ export interface SidebarItem {
   className?: string;
   icon?: FC<ComponentProps<'svg'>>;
   label?: string;
-  labelColor?: Color;
+  labelColor?: keyof SidebarItemLabelColors;
 }
 
-export interface SidebarItemProps extends PropsWithChildren<SidebarItem & Record<string, unknown>> {
+export interface SidebarItemLabelColors extends Pick<FlowbiteColors, 'gray'> {
+  [key: string]: string;
+}
+
+export interface SidebarItemProps
+  extends PropsWithChildren<SidebarItem & ComponentProps<'a'> & Record<string, unknown>> {
   as?: ElementType;
-  active?: boolean;
+  isActive?: boolean;
 }
 
 const SidebarItem: FC<SidebarItemProps> = ({
+  as: Component = 'a',
   children,
   className,
-  as: Component = 'a',
-  active,
   icon: Icon,
+  isActive,
   label,
-  labelColor = 'blue',
-  ...rest
+  labelColor = 'info',
+  ...theirProps
 }) => {
-  const { collapsed } = useSidebarContext();
-  const { insideCollapse } = useSidebarItemContext();
+  const id = useMemo(() => nanoid.nanoid(), []);
+  const { isCollapsed } = useSidebarContext();
+  const { isInsideCollapse } = useSidebarItemContext();
 
-  const Wrapper = ({ children: wrapperChildren }: PropsWithChildren<Record<string, unknown>>) => (
-    <li data-testid="sidebar-item">
-      {collapsed ? (
-        <Tooltip content={children} data-testid="sidebar-item-tooltip" placement="right">
-          {wrapperChildren}
+  const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }): JSX.Element => (
+    <li>
+      {isCollapsed ? (
+        <Tooltip content={children} placement="right">
+          {children}
         </Tooltip>
       ) : (
-        wrapperChildren
+        children
       )}
     </li>
   );
@@ -46,31 +53,35 @@ const SidebarItem: FC<SidebarItemProps> = ({
   return (
     <Wrapper>
       <Component
+        aria-labelledby={`flowbite-sidebar-item-${id}`}
         className={classNames(
           'flex items-center rounded-lg p-2 text-base font-normal text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700',
           {
-            'bg-gray-100 dark:bg-gray-700': active,
-            'group w-full pl-8 transition duration-75': !collapsed && insideCollapse,
+            'bg-gray-100 dark:bg-gray-700': isActive,
+            'group w-full pl-8 transition duration-75': !isCollapsed && isInsideCollapse,
           },
           className,
         )}
-        {...rest}
+        {...theirProps}
       >
         {Icon && (
           <Icon
+            aria-hidden
             className={classNames(
               'h-6 w-6 flex-shrink-0 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white',
-              { 'text-gray-700 dark:text-gray-100': active },
+              { 'text-gray-700 dark:text-gray-100': isActive },
             )}
           />
         )}
-        {!collapsed && (
-          <span className="ml-3 flex-1 whitespace-nowrap" data-testid="sidebar-item-content">
-            {children}
-          </span>
-        )}
-        {!collapsed && label && (
-          <Badge color={labelColor} data-testid="sidebar-item-label">
+        <span
+          className={classNames('ml-3 flex-1 whitespace-nowrap', { hidden: isCollapsed })}
+          data-testid="flowbite-sidebar-item-content"
+          id={`flowbite-sidebar-item-${id}`}
+        >
+          {children}
+        </span>
+        {label && (
+          <Badge color={labelColor} data-testid="flowbite-sidebar-label" hidden={isCollapsed}>
             {label}
           </Badge>
         )}

--- a/src/lib/components/Sidebar/SidebarItem.tsx
+++ b/src/lib/components/Sidebar/SidebarItem.tsx
@@ -20,8 +20,8 @@ export interface SidebarItemLabelColors extends Pick<FlowbiteColors, 'gray'> {
 
 export interface SidebarItemProps
   extends PropsWithChildren<SidebarItem & ComponentProps<'a'> & Record<string, unknown>> {
+  active?: boolean;
   as?: ElementType;
-  isActive?: boolean;
 }
 
 const SidebarItem: FC<SidebarItemProps> = ({
@@ -29,7 +29,7 @@ const SidebarItem: FC<SidebarItemProps> = ({
   children,
   className,
   icon: Icon,
-  isActive,
+  active: isActive,
   label,
   labelColor = 'info',
   ...theirProps

--- a/src/lib/components/Sidebar/SidebarItemContext.tsx
+++ b/src/lib/components/Sidebar/SidebarItemContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react';
 
 export type SidebarItemContext = {
-  insideCollapse: boolean;
+  isInsideCollapse: boolean;
 };
 
 export const SidebarItemContext = createContext<SidebarItemContext | undefined>(undefined);

--- a/src/lib/components/Sidebar/SidebarItemGroup.tsx
+++ b/src/lib/components/Sidebar/SidebarItemGroup.tsx
@@ -11,7 +11,7 @@ const SidebarItemGroup: FC<PropsWithChildren<HTMLAttributes<HTMLUListElement>>> 
       data-testid="sidebar-item-group"
       {...rest}
     >
-      <SidebarItemContext.Provider value={{ insideCollapse: false }}>{children}</SidebarItemContext.Provider>
+      <SidebarItemContext.Provider value={{ isInsideCollapse: false }}>{children}</SidebarItemContext.Provider>
     </ul>
   );
 };

--- a/src/lib/components/Sidebar/SidebarLogo.tsx
+++ b/src/lib/components/Sidebar/SidebarLogo.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import { PropsWithChildren, FC, HTMLAttributes } from 'react';
+import * as nanoid from 'nanoid';
+import { PropsWithChildren, FC, HTMLAttributes, useMemo } from 'react';
 import { useSidebarContext } from './SidebarContext';
 
 export interface SidebarLogoProps extends PropsWithChildren<HTMLAttributes<HTMLAnchorElement>> {
@@ -9,17 +10,23 @@ export interface SidebarLogoProps extends PropsWithChildren<HTMLAttributes<HTMLA
   imgAlt?: string;
 }
 
-const SidebarLogo: FC<SidebarLogoProps> = ({ children, className, href, img, imgAlt = '', ...rest }) => {
-  const { collapsed } = useSidebarContext();
+const SidebarLogo: FC<SidebarLogoProps> = ({ children, className, href, img, imgAlt = '', ...theirProps }) => {
+  const id = useMemo(() => nanoid.nanoid(), []);
+  const { isCollapsed } = useSidebarContext();
 
   return (
-    <a className={classNames('mb-5 flex items-center pl-2.5', className)} href={href} {...rest}>
+    <a
+      aria-labelledby={`flowbite-sidebar-logo-${id}`}
+      className={classNames('mb-5 flex items-center pl-2.5', className)}
+      href={href}
+      {...theirProps}
+    >
       <img alt={imgAlt} className="mr-3 h-6 sm:h-7" src={img} />
       <span
         className={classNames(
-          collapsed ? 'sr-only' : 'self-center whitespace-nowrap text-xl font-semibold dark:text-white',
+          isCollapsed ? 'hidden' : 'self-center whitespace-nowrap text-xl font-semibold dark:text-white',
         )}
-        data-testid="sidebar-logo"
+        id={`flowbite-sidebar-logo-${id}`}
       >
         {children}
       </span>

--- a/src/lib/components/Sidebar/index.tsx
+++ b/src/lib/components/Sidebar/index.tsx
@@ -12,10 +12,10 @@ export interface SidebarProps extends PropsWithChildren<HTMLAttributes<HTMLDivEl
   collapsed?: boolean;
 }
 
-const SidebarComponent: FC<SidebarProps> = ({ children, className, collapsed = false, ...rest }) => {
+const SidebarComponent: FC<SidebarProps> = ({ children, className, collapsed: isCollapsed = false, ...theirProps }) => {
   return (
-    <SidebarContext.Provider value={{ collapsed }}>
-      <aside aria-label="Sidebar" className={classNames('h-full', collapsed ? 'w-16' : 'w-64')} {...rest}>
+    <SidebarContext.Provider value={{ isCollapsed }}>
+      <aside aria-label="Sidebar" className={classNames('h-full', isCollapsed ? 'w-16' : 'w-64')} {...theirProps}>
         <div
           className={classNames(
             'h-full overflow-y-auto overflow-x-hidden rounded bg-white py-4 px-3 dark:bg-gray-800',

--- a/src/lib/components/Sidebar/index.tsx
+++ b/src/lib/components/Sidebar/index.tsx
@@ -9,13 +9,25 @@ import SidebarCollapse from './SidebarCollapse';
 import { SidebarContext } from './SidebarContext';
 
 export interface SidebarProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
+  collapseBehavior?: 'collapse' | 'hide';
   collapsed?: boolean;
 }
 
-const SidebarComponent: FC<SidebarProps> = ({ children, className, collapsed: isCollapsed = false, ...theirProps }) => {
+const SidebarComponent: FC<SidebarProps> = ({
+  children,
+  className,
+  collapseBehavior = 'collapse',
+  collapsed: isCollapsed = false,
+  ...theirProps
+}) => {
   return (
     <SidebarContext.Provider value={{ isCollapsed }}>
-      <aside aria-label="Sidebar" className={classNames('h-full', isCollapsed ? 'w-16' : 'w-64')} {...theirProps}>
+      <aside
+        aria-label="Sidebar"
+        className={classNames('h-full', isCollapsed ? 'w-16' : 'w-64')}
+        hidden={isCollapsed && collapseBehavior === 'hide'}
+        {...theirProps}
+      >
         <div
           className={classNames(
             'h-full overflow-y-auto overflow-x-hidden rounded bg-white py-4 px-3 dark:bg-gray-800',


### PR DESCRIPTION
## Features

- [x] [feature(component): Allow](https://github.com/themesberg/flowbite-react/commit/adedacd2db1475fd33763d5501bf62e04f7b7a08) [Sidebar](https://github.com/themesberg/flowbite-react/commit/adedacd2db1475fd33763d5501bf62e04f7b7a08)[s to hide completely,](https://github.com/themesberg/flowbite-react/commit/adedacd2db1475fd33763d5501bf62e04f7b7a08) [resolves](https://github.com/themesberg/flowbite-react/commit/adedacd2db1475fd33763d5501bf62e04f7b7a08) https://github.com/themesberg/flowbite-react/issues/81

## Bug fixes

- [x] [fix(a11y): Add unique labels to Sidebar examples](https://github.com/themesberg/flowbite-react/commit/50070e9f2930160bb99af87a55eacfba0d995936)
- [x] [fix(story): Update old color name in Sidebar story](https://github.com/themesberg/flowbite-react/commit/fa9d6c9e9e5d2cd0a5f8ceec4ae51f7b4529e076)

## Tests

### Unit

- [x] [test(component): Add numerous unit tests for Sidebars](https://github.com/themesberg/flowbite-react/commit/41142832ed1960373962c631a123e4db20907c58)