### PR TITLE
feature(component): Rewrite `Carousel`s to use themes, resolves #168, #132

### DIFF
--- a/src/lib/components/Carousel/Carousel.stories.tsx
+++ b/src/lib/components/Carousel/Carousel.stories.tsx
@@ -17,6 +17,29 @@ const Template: Story<CarouselProps> = (args) => (
   </Carousel>
 );
 
-export const DefaultCarousel = Template.bind({});
-DefaultCarousel.storyName = 'Default';
-DefaultCarousel.args = {};
+export const Default = Template.bind({});
+Default.args = {};
+
+export const SlideInterval = Template.bind({});
+SlideInterval.storyName = 'Slide interval';
+SlideInterval.args = {
+  slideInterval: 5000,
+};
+
+export const Static = Template.bind({});
+Static.args = {
+  slide: false,
+};
+
+export const CustomControls = Template.bind({});
+CustomControls.storyName = 'With custom controls';
+CustomControls.args = {
+  leftControl: '<',
+  rightControl: '>',
+};
+
+export const WithNoIndicators = Template.bind({});
+WithNoIndicators.storyName = 'With no indicators';
+WithNoIndicators.args = {
+  indicators: false,
+};

--- a/src/lib/components/Carousel/index.tsx
+++ b/src/lib/components/Carousel/index.tsx
@@ -16,39 +16,42 @@ import classNames from 'classnames';
 import { HiOutlineChevronLeft, HiOutlineChevronRight } from 'react-icons/hi';
 import ScrollContainer from 'react-indiana-drag-scroll';
 import windowExists from '../../helpers/window-exists';
+import { useTheme } from '../Flowbite/ThemeContext';
+import { excludeClassName } from '../../helpers/exclude';
 
-export type CarouselProps = PropsWithChildren<{
-  slide?: boolean;
-  slideInterval?: number;
+export interface CarouselProps extends PropsWithChildren<ComponentProps<'div'>> {
   indicators?: boolean;
   leftControl?: ReactNode;
   rightControl?: ReactNode;
-}>;
+  slide?: boolean;
+  slideInterval?: number;
+}
 
 export const Carousel: FC<CarouselProps> = ({
   children,
-  slide = true,
-  slideInterval,
   indicators = true,
   leftControl,
   rightControl,
-}) => {
+  slide = true,
+  slideInterval,
+  ...props
+}): JSX.Element => {
+  const isDeviceMobile = windowExists() && navigator.userAgent.indexOf('IEMobile') !== -1;
+  const theirProps = excludeClassName(props);
+
+  const carouselContainer = useRef<HTMLDivElement>(null);
   const [activeItem, setActiveItem] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
-  const carouselContainer = useRef<HTMLDivElement>(null);
-  const isDeviceMobile = windowExists() && navigator.userAgent.indexOf('IEMobile') !== -1;
+  const theme = useTheme().theme.carousel;
 
   const items = useMemo(
     () =>
       Children.map(children as ReactElement<ComponentProps<'img'>>[], (child: ReactElement<ComponentProps<'img'>>) =>
         cloneElement(child, {
-          className: classNames(
-            child.props.className,
-            'absolute top-1/2 left-1/2 block w-full -translate-x-1/2 -translate-y-1/2',
-          ),
+          className: theme.item.base,
         }),
       ),
-    [children],
+    [children, theme.item.base],
   );
 
   const navigateTo = useCallback(
@@ -79,47 +82,49 @@ export const Carousel: FC<CarouselProps> = ({
   const handleDragging = (dragging: boolean) => () => setIsDragging(dragging);
 
   return (
-    <div className="relative w-full" data-testid="carousel">
+    <div className={theme.base} data-testid="carousel" {...theirProps}>
       <ScrollContainer
         className={classNames(
-          'flex h-56 snap-mandatory overflow-y-hidden overflow-x-scroll scroll-smooth rounded-lg sm:h-64 xl:h-80 2xl:h-96',
-          { 'snap-x': isDeviceMobile || !isDragging },
+          theme.scrollContainer.base,
+          (isDeviceMobile || !isDragging) && theme.scrollContainer.snap,
         )}
         draggingClassName="cursor-grab"
-        onStartScroll={handleDragging(true)}
-        onEndScroll={handleDragging(false)}
         innerRef={carouselContainer}
+        onEndScroll={handleDragging(false)}
+        onStartScroll={handleDragging(true)}
         vertical={false}
       >
-        {items?.map((item, index) => (
-          <div
-            key={index}
-            className="w-full flex-shrink-0 transform cursor-grab snap-center"
-            data-active={activeItem === index}
-            data-testid="carousel-item"
-          >
-            {item}
-          </div>
-        ))}
-      </ScrollContainer>
-
-      {indicators && (
-        <div className="absolute bottom-5 left-1/2 flex -translate-x-1/2 space-x-3">
-          {items.map((_, index) => (
-            <button
+        {items?.map(
+          (item, index): JSX.Element => (
+            <div
               key={index}
-              className={classNames('h-3 w-3 rounded-full', {
-                'bg-white dark:bg-gray-800': index === activeItem,
-                'bg-white/50 hover:bg-white dark:bg-gray-800/50 dark:hover:bg-gray-800': index !== activeItem,
-              })}
-              onClick={navigateTo(index)}
-              data-testid="carousel-indicator"
-            />
-          ))}
+              className={theme.item.wrapper}
+              data-active={activeItem === index}
+              data-testid="carousel-item"
+            >
+              {item}
+            </div>
+          ),
+        )}
+      </ScrollContainer>
+      {indicators && (
+        <div className={theme.indicators.wrapper}>
+          {items.map(
+            (_, index): JSX.Element => (
+              <button
+                key={index}
+                className={classNames(
+                  theme.indicators.base,
+                  theme.indicators.active[index === activeItem ? 'on' : 'off'],
+                )}
+                onClick={navigateTo(index)}
+                data-testid="carousel-indicator"
+              />
+            ),
+          )}
         </div>
       )}
-
-      <div className="absolute top-0 left-0 flex h-full items-center justify-center px-4 focus:outline-none">
+      <div className={theme.leftControl}>
         <button
           className="group"
           data-testid="carousel-left-control"
@@ -129,7 +134,7 @@ export const Carousel: FC<CarouselProps> = ({
           {leftControl ? leftControl : <DefaultLeftControl />}
         </button>
       </div>
-      <div className="absolute top-0 right-0 flex h-full items-center justify-center px-4 focus:outline-none">
+      <div className={theme.rightControl}>
         <button
           className="group"
           data-testid="carousel-right-control"

--- a/src/lib/components/Flowbite/FlowbiteTheme.d.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.d.ts
@@ -98,6 +98,27 @@ export interface FlowbiteTheme {
       };
     };
   };
+  carousel: {
+    base: string;
+    indicators: {
+      active: {
+        off: string;
+        on: string;
+      };
+      base: string;
+      wrapper: string;
+    };
+    item: {
+      base: string;
+      wrapper: string;
+    };
+    leftControl: string;
+    rightControl: string;
+    scrollContainer: {
+      base: string;
+      snap: string;
+    };
+  };
   spinner: {
     base: string;
     color: SpinnerColors;

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -138,6 +138,27 @@ export default {
       },
     },
   },
+  carousel: {
+    base: 'relative w-full',
+    indicators: {
+      active: {
+        off: 'bg-white/50 hover:bg-white dark:bg-gray-800/50 dark:hover:bg-gray-800',
+        on: 'bg-white dark:bg-gray-800',
+      },
+      base: 'h-3 w-3 rounded-full',
+      wrapper: 'absolute bottom-5 left-1/2 flex -translate-x-1/2 space-x-3',
+    },
+    item: {
+      base: 'absolute top-1/2 left-1/2 block w-full -translate-x-1/2 -translate-y-1/2',
+      wrapper: 'w-full flex-shrink-0 transform cursor-grab snap-center',
+    },
+    leftControl: 'absolute top-0 left-0 flex h-full items-center justify-center px-4 focus:outline-none',
+    rightControl: 'absolute top-0 right-0 flex h-full items-center justify-center px-4 focus:outline-none',
+    scrollContainer: {
+      base: 'flex h-56 snap-mandatory overflow-y-hidden overflow-x-scroll scroll-smooth rounded-lg sm:h-64 xl:h-80 2xl:h-96',
+      snap: 'snap-x',
+    },
+  },
   spinner: {
     base: 'inline animate-spin text-gray-200',
     color: {


### PR DESCRIPTION
## Breaking changes

`Carousel`s can now be customized using `<Flowbite theme={..}>`.

```js
carousel: {
  base: 'relative w-full',
  indicators: {
    active: {
      off: 'bg-white/50 hover:bg-white dark:bg-gray-800/50 dark:hover:bg-gray-800',
      on: 'bg-white dark:bg-gray-800',
    },
    base: 'h-3 w-3 rounded-full',
    wrapper: 'absolute bottom-5 left-1/2 flex -translate-x-1/2 space-x-3',
  },
  item: {
    base: 'absolute top-1/2 left-1/2 block w-full -translate-x-1/2 -translate-y-1/2',
    wrapper: 'w-full flex-shrink-0 transform cursor-grab snap-center',
  },
  leftControl: 'absolute top-0 left-0 flex h-full items-center justify-center px-4 focus:outline-none',
  rightControl: 'absolute top-0 right-0 flex h-full items-center justify-center px-4 focus:outline-none',
  scrollContainer: {
    base: 'flex h-56 snap-mandatory overflow-y-hidden overflow-x-scroll scroll-smooth rounded-lg sm:h-64 xl:h-80 2xl:h-96',
    snap: 'snap-x',
  },
},
```

## Features

- [x] [feature(component): Rewrite](https://github.com/themesberg/flowbite-react/commit/38bc0b62d954eebc11be08d106243acb542a4a45) [Carousel](https://github.com/themesberg/flowbite-react/commit/38bc0b62d954eebc11be08d106243acb542a4a45)[s to use themes,](https://github.com/themesberg/flowbite-react/commit/38bc0b62d954eebc11be08d106243acb542a4a45) [resolves](https://github.com/themesberg/flowbite-react/commit/38bc0b62d954eebc11be08d106243acb542a4a45) https://github.com/themesberg/flowbite-react/issues/168[,](https://github.com/themesberg/flowbite-react/commit/38bc0b62d954eebc11be08d106243acb542a4a45) https://github.com/themesberg/flowbite-react/issues/132
- [x] [feature(story): Add missing stories for Carousels](https://github.com/themesberg/flowbite-react/commit/f331559d978b58f78f1484180949e7566d13a151)
- [x] [feature(type): Add theme for Carousels](https://github.com/themesberg/flowbite-react/commit/7716f38826cc82aace02c555cd17afca0e5a84fe)