### PR TITLE
feat(component): Add `Accordion.Title` theme for heading

### DIFF
--- a/src/lib/components/Accordion/AccordionTitle.tsx
+++ b/src/lib/components/Accordion/AccordionTitle.tsx
@@ -25,7 +25,9 @@ export const AccordionTitle: FC<AccordionTitleProps> = ({ as: Heading = 'h2', ch
       type="button"
       {...theirProps}
     >
-      <Heading data-testid="flowbite-accordion-heading">{children}</Heading>
+      <Heading className={theme.heading} data-testid="flowbite-accordion-heading">
+        {children}
+      </Heading>
       {ArrowIcon && (
         <ArrowIcon
           aria-hidden

--- a/src/lib/components/Flowbite/FlowbiteTheme.d.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.d.ts
@@ -23,6 +23,7 @@ export interface FlowbiteTheme {
       };
       base: string;
       flush: FlowbiteBoolean;
+      heading: string;
       open: FlowbiteBoolean;
     };
   };

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -21,6 +21,7 @@ export default {
         off: 'hover:bg-gray-100 focus:ring-4 focus:ring-gray-200 dark:hover:bg-gray-800 dark:focus:ring-gray-800',
         on: '!bg-transparent dark:!bg-transparent',
       },
+      heading: '',
       open: {
         off: '',
         on: 'text-gray-900 bg-gray-100 dark:bg-gray-800 dark:text-white',


### PR DESCRIPTION
The heading inside `Accordion.Title` needs to be
able to be customized.

```js
theme: {
  accordion: {
    title: {
      heading: 'something'
    }
  }
}
```