### PR TITLE
fix: `nanoid` requires Node `crypto` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@floating-ui/react-dom": "^0.6.3",
     "@floating-ui/react-dom-interactions": "^0.4.0",
     "classnames": "^2.3.1",
-    "nanoid": "^3.3.4",
     "react-icons": "^4.3.1",
     "react-indiana-drag-scroll": "^2.1.0"
   },

--- a/src/lib/components/Flowbite/index.tsx
+++ b/src/lib/components/Flowbite/index.tsx
@@ -1,5 +1,5 @@
 import type { FC, HTMLAttributes } from 'react';
-import { useLayoutEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { ThemeContext, useThemeMode } from './ThemeContext';
 import { mergeDeep } from '../../helpers/mergeDeep';
 import defaultTheme from '../../theme/default';
@@ -24,7 +24,7 @@ export const Flowbite: FC<FlowbiteProps> = ({ children, theme = {} }) => {
 
   const mergedTheme = mergeDeep(defaultTheme, customTheme) as unknown as FlowbiteTheme;
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (dark) {
       if (setMode != null) {
         setMode('dark');

--- a/src/lib/components/FormControls/ToggleSwitch.tsx
+++ b/src/lib/components/FormControls/ToggleSwitch.tsx
@@ -1,7 +1,6 @@
 import type { ComponentProps, FC, KeyboardEvent, MouseEvent } from 'react';
-import { useMemo } from 'react';
+import { useId } from 'react';
 import classNames from 'classnames';
-import * as nanoid from 'nanoid';
 
 export type ToggleSwitchProps = Omit<ComponentProps<'button'>, 'onChange'> & {
   checked: boolean;
@@ -18,7 +17,7 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
   onChange,
   ...props
 }) => {
-  const id = useMemo(() => nanoid.nanoid(), []);
+  const id = useId();
 
   const toggle = (): void => onChange(!checked);
 

--- a/src/lib/components/Progress/index.tsx
+++ b/src/lib/components/Progress/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
-import * as nanoid from 'nanoid';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import { useId } from 'react';
 
 type Color = 'dark' | 'blue' | 'red' | 'green' | 'yellow' | 'indigo' | 'purple';
 type Size = 'sm' | 'md' | 'lg' | 'xl';
@@ -42,7 +42,7 @@ export const Progress: FC<ProgressProps> = ({
   size = 'md',
   ...props
 }) => {
-  const id = nanoid.nanoid();
+  const id = useId();
 
   return (
     <>

--- a/src/lib/components/Sidebar/SidebarCollapse.tsx
+++ b/src/lib/components/Sidebar/SidebarCollapse.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
-import * as nanoid from 'nanoid';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
-import { useMemo, useState } from 'react';
+import { useId, useState } from 'react';
 import { HiChevronDown } from 'react-icons/hi';
 import { excludeClassName } from '../../helpers/exclude';
 import { Tooltip } from '../Tooltip';
@@ -14,7 +13,7 @@ export type SidebarCollapseProps = PropsWithChildren<ComponentProps<'button'> & 
 const SidebarCollapse: FC<SidebarCollapseProps> = ({ children, icon: Icon, label, ...props }): JSX.Element => {
   const theirProps = excludeClassName(props);
 
-  const id = useMemo(() => nanoid.nanoid(), []);
+  const id = useId();
   const { isCollapsed } = useSidebarContext();
   const [isOpen, setOpen] = useState(false);
 

--- a/src/lib/components/Sidebar/SidebarItem.tsx
+++ b/src/lib/components/Sidebar/SidebarItem.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
-import * as nanoid from 'nanoid';
 import type { ComponentProps, ElementType, FC, PropsWithChildren } from 'react';
-import { useMemo } from 'react';
+import { useId } from 'react';
 import { Badge } from '../Badge';
 import type { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
 import { Tooltip } from '../Tooltip';
@@ -32,8 +31,7 @@ const SidebarItem: FC<SidebarItemProps> = ({
   labelColor = 'info',
   ...theirProps
 }): JSX.Element => {
-  const id = useMemo(() => nanoid.nanoid(), []);
-
+  const id = useId();
   const { isCollapsed } = useSidebarContext();
   const { isInsideCollapse } = useSidebarItemContext();
 

--- a/src/lib/components/Sidebar/SidebarLogo.tsx
+++ b/src/lib/components/Sidebar/SidebarLogo.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames';
-import * as nanoid from 'nanoid';
 import type { PropsWithChildren, FC, HTMLAttributes } from 'react';
-import { useMemo } from 'react';
+import { useId } from 'react';
 import { useSidebarContext } from './SidebarContext';
 
 export interface SidebarLogoProps extends PropsWithChildren<HTMLAttributes<HTMLAnchorElement>> {
@@ -12,7 +11,7 @@ export interface SidebarLogoProps extends PropsWithChildren<HTMLAttributes<HTMLA
 }
 
 const SidebarLogo: FC<SidebarLogoProps> = ({ children, className, href, img, imgAlt = '', ...theirProps }) => {
-  const id = useMemo(() => nanoid.nanoid(), []);
+  const id = useId();
   const { isCollapsed } = useSidebarContext();
 
   return (

--- a/src/lib/components/Tab/index.tsx
+++ b/src/lib/components/Tab/index.tsx
@@ -1,10 +1,10 @@
 import type { ComponentProps, FC, KeyboardEvent, PropsWithChildren, ReactElement } from 'react';
+import { useId } from 'react';
 import { Children, useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 
 import type { TabProps } from './TabItem';
 import { TabItem } from './TabItem';
-import * as nanoid from 'nanoid';
 
 export type TabStyle = 'default' | 'underline' | 'pills' | 'fullWidth';
 export type TabItemStatus = 'active' | 'notActive';
@@ -56,6 +56,7 @@ interface TabKeyboardEventProps extends TabEventProps {
 }
 
 export const TabsComponent: FC<TabsProps> = ({ children, className, style = 'default' as TabStyle, ...rest }) => {
+  const id = useId();
   const tabs = useMemo(
     () => Children.map(children as ReactElement<PropsWithChildren<TabProps>>[], ({ props }) => props),
     [children],
@@ -97,8 +98,6 @@ export const TabsComponent: FC<TabsProps> = ({ children, className, style = 'def
   useEffect(() => {
     tabRefs.current[focusedTab]?.focus();
   }, [focusedTab]);
-
-  const id = useMemo(() => nanoid.nanoid(), []);
 
   return (
     <div className="flex flex-col gap-2">

--- a/src/lib/components/Tooltip/index.tsx
+++ b/src/lib/components/Tooltip/index.tsx
@@ -97,8 +97,8 @@ export const Tooltip: FC<TooltipProps> = ({
           ref: floating,
           style: {
             position: strategy,
-            top: y ?? '',
-            left: x ?? '',
+            top: y ?? ' ',
+            left: x ?? ' ',
           },
           ...rest,
         })}
@@ -114,10 +114,10 @@ export const Tooltip: FC<TooltipProps> = ({
             data-testid="tooltip-arrow"
             ref={arrowRef}
             style={{
-              top: arrowY ?? '',
-              left: arrowX ?? '',
-              right: '',
-              bottom: '',
+              top: arrowY ?? ' ',
+              left: arrowX ?? ' ',
+              right: ' ',
+              bottom: ' ',
               [floatingArrowPlacement({ placement: floatingTooltip.placement })]: '-4px',
             }}
           >

--- a/yarn.lock
+++ b/yarn.lock
@@ -11482,11 +11482,6 @@ nanoid@^3.1.23, nanoid@^3.3.1:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.2.tgz#c89622fafb4381cd221421c69ec58547a1eec557"
   integrity sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==
 
-nanoid@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
-  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
For users running Flowbite in a serverless environment like Cloudflare Workers, Node libraries like `crypto` are unavailable.

Fortunately, React added a hook that serves the exact purpose we need: [`useId()`](https://reactjs.org/blog/2022/03/29/react-v18.html#useid).

## Breaking changes

None.

## Bug fixes

- [x] [fix(component): Fix SSR mismatch in Tooltips](https://github.com/themesberg/flowbite-react/pull/185/commits/d4d95e7cca0ff9b32ae98e8fe92c566e8be65f49)
- [x] [fix(component): Replace nanoid -> useId()](https://github.com/themesberg/flowbite-react/pull/185/commits/31aafc9f4a54c091de0748055a03997b6084962c)