### PR TITLE
feat(component): theme support to tooltip

### DIFF
--- a/src/lib/components/Dropdown/index.tsx
+++ b/src/lib/components/Dropdown/index.tsx
@@ -1,8 +1,6 @@
 import type { ComponentProps, FC, PropsWithChildren, ReactNode } from 'react';
 import { useMemo } from 'react';
 import { HiOutlineChevronDown, HiOutlineChevronLeft, HiOutlineChevronRight, HiOutlineChevronUp } from 'react-icons/hi';
-import classNames from 'classnames';
-
 import type { ButtonComponentProps } from '../Button';
 import { Button } from '../Button';
 import type { TooltipProps } from '../Tooltip';
@@ -10,6 +8,7 @@ import { Tooltip } from '../Tooltip';
 import { DropdownItem } from './DropdownItem';
 import { DropdownDivider } from './DropdownDivider';
 import { DropdownHeader } from './DropdownHeader';
+import { excludeClassName } from '../../helpers/exclude';
 
 export type DropdownProps = ButtonComponentProps &
   Omit<TooltipProps, 'content' | 'style' | 'animation' | 'arrow'> & {
@@ -28,7 +27,8 @@ const icons: Record<string, FC<ComponentProps<'svg'>>> = {
 };
 
 const DropdownComponent: FC<DropdownProps> = (props) => {
-  const { children, className, label, inline, tooltipArrow = false, arrowIcon = true, ...restProps } = props;
+  const theirProps = excludeClassName(props) as DropdownProps;
+  const { children, label, inline, tooltipArrow = false, arrowIcon = true, ...restProps } = theirProps;
   const { placement = inline ? 'bottom-start' : 'bottom', trigger = 'click', ...buttonProps } = restProps;
 
   const Icon = useMemo(() => {
@@ -43,7 +43,6 @@ const DropdownComponent: FC<DropdownProps> = (props) => {
 
   return (
     <Tooltip
-      className={classNames('w-44 !rounded !p-0', className)}
       content={content}
       style="auto"
       animation="duration-100"

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -183,6 +183,27 @@ export interface FlowbiteTheme {
       icon: string;
     };
   };
+  tooltip: {
+    target: string;
+    base: string;
+    animation: string;
+    hidden: string;
+    style: {
+      dark: string;
+      light: string;
+      auto: string;
+    };
+    content: string;
+    arrow: {
+      base: string;
+      style: {
+        dark: string;
+        light: string;
+        auto: string;
+      };
+      placement: string;
+    };
+  };
 }
 
 export interface FlowbiteBoolean {

--- a/src/lib/components/Tooltip/index.tsx
+++ b/src/lib/components/Tooltip/index.tsx
@@ -85,12 +85,12 @@ export const Tooltip: FC<TooltipProps> = ({
       <div
         data-testid="tooltip"
         {...getFloatingProps({
-          className: classNames(theme.base, animation !== false && `${theme.animation} ${animation}`, {
-            [theme.hidden]: !open,
-            [theme.style.dark]: style === 'dark',
-            [theme.style.light]: style === 'light',
-            [theme.style.auto]: style === 'auto',
-          }),
+          className: classNames(
+            theme.base,
+            animation && `${theme.animation} ${animation}`,
+            !open && theme.hidden,
+            theme.style[style],
+          ),
           ref: floating,
           style: {
             position: strategy,

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -329,4 +329,25 @@ export default {
       icon: 'h-5 w-5 shrink-0',
     },
   },
+  tooltip: {
+    target: 'w-fit',
+    base: 'absolute inline-block rounded-lg py-2 px-3 text-sm font-medium shadow-sm',
+    animation: 'transition-opacity',
+    hidden: 'invisible opacity-0',
+    style: {
+      dark: 'bg-gray-900 text-white dark:bg-gray-700',
+      light: 'border border-gray-200 bg-white text-gray-900',
+      auto: 'border border-gray-200 bg-white text-gray-900 dark:border-none dark:bg-gray-700 dark:text-white',
+    },
+    content: 'relative z-20',
+    arrow: {
+      base: 'absolute z-10 h-2 w-2 rotate-45',
+      style: {
+        dark: 'bg-gray-900 dark:bg-gray-700',
+        light: 'bg-white',
+        auto: 'bg-white dark:bg-gray-700',
+      },
+      placement: '-4px',
+    },
+  },
 };


### PR DESCRIPTION
### Breaking changes

**Tooltip** can be customized using  **<Flowbite theme={..}>**

> **Warning**
> This PR introduces an visual issue to `Dropdown` component that will be fixed in a separated task.

```ts
  tooltip: {
    target: string;
    base: string;
    animation: string;
    hidden: string;
    style: {
      dark: string;
      light: string;
      auto: string;
    };
    content: string;
    arrow: {
      base: string;
      style: {
        dark: string;
        light: string;
        auto: string;
      };
      placement: string;
    };
  };
```

closes #147 