### PR TITLE
feat(component): theme support to darkthemetoggle

### DIFF
--- a/src/lib/components/DarkThemeToggle/index.tsx
+++ b/src/lib/components/DarkThemeToggle/index.tsx
@@ -8,7 +8,7 @@ export type DarkThemeToggleProps = Omit<ComponentProps<'button'>, 'className'>;
 
 export const DarkThemeToggle: FC<DarkThemeToggleProps> = (props) => {
   const theirProps = excludeClassName(props);
-  const theme = useTheme().theme.darkthemetoggle;
+  const theme = useTheme().theme.darkThemeToggle;
   const { mode, toggleMode } = useContext(ThemeContext);
 
   return (
@@ -21,9 +21,9 @@ export const DarkThemeToggle: FC<DarkThemeToggleProps> = (props) => {
       {...theirProps}
     >
       {mode === 'dark' ? (
-        <HiSun className={theme.icon} data-testid="dark-theme-toggle-disabled" />
+        <HiSun aria-hidden className={theme.icon} data-testid="dark-theme-toggle-disabled" />
       ) : (
-        <HiMoon className={theme.icon} data-testid="dark-theme-toggle-enabled" />
+        <HiMoon aria-hidden className={theme.icon} data-testid="dark-theme-toggle-enabled" />
       )}
     </button>
   );

--- a/src/lib/components/DarkThemeToggle/index.tsx
+++ b/src/lib/components/DarkThemeToggle/index.tsx
@@ -1,23 +1,29 @@
-import type { FC } from 'react';
+import type { ComponentProps, FC } from 'react';
 import { useContext } from 'react';
 import { HiMoon, HiSun } from 'react-icons/hi';
-import { ThemeContext } from '../Flowbite/ThemeContext';
+import { excludeClassName } from '../../helpers/exclude';
+import { ThemeContext, useTheme } from '../Flowbite/ThemeContext';
 
-export const DarkThemeToggle: FC = () => {
+export type DarkThemeToggleProps = Omit<ComponentProps<'button'>, 'className'>;
+
+export const DarkThemeToggle: FC<DarkThemeToggleProps> = (props) => {
+  const theirProps = excludeClassName(props);
+  const theme = useTheme().theme.darkthemetoggle;
   const { mode, toggleMode } = useContext(ThemeContext);
 
   return (
     <button
-      className="rounded-lg p-2.5 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-700"
+      className={theme.base}
       data-testid="dark-theme-toggle"
       onClick={toggleMode}
       type="button"
+      aria-label="Toggle dark mode"
+      {...theirProps}
     >
-      <span className="sr-only">Toggle dark mode</span>
       {mode === 'dark' ? (
-        <HiSun className="h-5 w-5" data-testid="dark-theme-toggle-disabled" />
+        <HiSun className={theme.icon} data-testid="dark-theme-toggle-disabled" />
       ) : (
-        <HiMoon className="h-5 w-5" data-testid="dark-theme-toggle-enabled" />
+        <HiMoon className={theme.icon} data-testid="dark-theme-toggle-enabled" />
       )}
     </button>
   );

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -142,7 +142,7 @@ export interface FlowbiteTheme {
       snap: string;
     };
   };
-  darkthemetoggle: {
+  darkThemeToggle: {
     base: string;
     icon: string;
   };

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -142,6 +142,10 @@ export interface FlowbiteTheme {
       snap: string;
     };
   };
+  darkthemetoggle: {
+    base: string;
+    icon: string;
+  };
   rating: {
     base: string;
     star: {

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -254,6 +254,10 @@ export default {
       snap: 'snap-x',
     },
   },
+  darkthemetoggle: {
+    base: 'rounded-lg p-2.5 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-700',
+    icon: 'h-5 w-5',
+  },
   rating: {
     base: 'flex items-center',
     star: {

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -254,7 +254,7 @@ export default {
       snap: 'snap-x',
     },
   },
-  darkthemetoggle: {
+  darkThemeToggle: {
     base: 'rounded-lg p-2.5 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-700',
     icon: 'h-5 w-5',
   },


### PR DESCRIPTION
### Breaking changes

**DarkThemeToggle** can be customized using  **<Flowbite theme={..}>**

```ts
  darkThemeToggle: {
    base: string;
    icon: string;
  };
```

closes #133 