### PR TITLE
feat(component): Use `FlowbiteTheme` in `Sidebar`s, resolves #143

### DIFF
--- a/src/docs/Root.tsx
+++ b/src/docs/Root.tsx
@@ -45,7 +45,7 @@ export const Root: FC = () => {
           <DarkThemeToggle />
         </div>
       </Navbar>
-      <div className="flex h-full overflow-hidden bg-gray-50 dark:bg-gray-900">
+      <div className="flex h-full overflow-hidden bg-white dark:bg-gray-900">
         <Sidebar collapsed={collapsed}>
           <Sidebar.Items>
             <Sidebar.ItemGroup>

--- a/src/docs/pages/SidebarPage.tsx
+++ b/src/docs/pages/SidebarPage.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 import { BiBuoy } from 'react-icons/bi';
 import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, HiViewBoards } from 'react-icons/hi';
-import { Sidebar, Badge, Button } from '../../lib';
+import { Badge, Sidebar } from '../../lib';
 import type { CodeExample } from './DemoPage';
 import { DemoPage } from './DemoPage';
 
@@ -10,201 +10,219 @@ const SidebarPage: FC = () => {
     {
       title: 'Default sidebar',
       code: (
-        <Sidebar aria-label="Default sidebar example" className="!bg-gray-50 dark:!bg-gray-900">
-          <Sidebar.Items>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="alternative">
-                Kanban
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiInbox} label="3">
-                Inbox
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiUser}>
-                Users
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiShoppingBag}>
-                Products
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiArrowSmRight}>
-                Sign In
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiTable}>
-                Sign Up
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-          </Sidebar.Items>
-        </Sidebar>
+        <div className="w-fit bg-gray-50">
+          <Sidebar aria-label="Default sidebar example">
+            <Sidebar.Items>
+              <Sidebar.ItemGroup>
+                <Sidebar.Item href="#" icon={HiChartPie}>
+                  Dashboard
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiViewBoards} label="Pro" labelColor="alternative">
+                  Kanban
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiInbox} label="3">
+                  Inbox
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiUser}>
+                  Users
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiShoppingBag}>
+                  Products
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                  Sign In
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiTable}>
+                  Sign Up
+                </Sidebar.Item>
+              </Sidebar.ItemGroup>
+            </Sidebar.Items>
+          </Sidebar>
+        </div>
       ),
     },
     {
       title: 'Multi-level dropdown',
       code: (
-        <Sidebar aria-label="Sidebar with multi-level dropdown example" className="!bg-gray-50 dark:!bg-gray-900">
-          <Sidebar.Items>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Collapse icon={HiShoppingBag} label="E-commerce">
-                <Sidebar.Item href="#">Products</Sidebar.Item>
-              </Sidebar.Collapse>
-              <Sidebar.Item href="#" icon={HiInbox}>
-                Inbox
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiUser}>
-                Users
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiShoppingBag}>
-                Products
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiArrowSmRight}>
-                Sign In
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiTable}>
-                Sign Up
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-          </Sidebar.Items>
-        </Sidebar>
+        <div className="w-fit bg-gray-50">
+          <Sidebar aria-label="Sidebar with multi-level dropdown example">
+            <Sidebar.Items>
+              <Sidebar.ItemGroup>
+                <Sidebar.Item href="#" icon={HiChartPie}>
+                  Dashboard
+                </Sidebar.Item>
+                <Sidebar.Collapse icon={HiShoppingBag} label="E-commerce">
+                  <Sidebar.Item href="#">Products</Sidebar.Item>
+                </Sidebar.Collapse>
+                <Sidebar.Item href="#" icon={HiInbox}>
+                  Inbox
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiUser}>
+                  Users
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiShoppingBag}>
+                  Products
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                  Sign In
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiTable}>
+                  Sign Up
+                </Sidebar.Item>
+              </Sidebar.ItemGroup>
+            </Sidebar.Items>
+          </Sidebar>
+        </div>
       ),
     },
     {
       title: 'Content separator',
       code: (
-        <Sidebar aria-label="Sidebar with content separator example" className="!bg-gray-50 dark:!bg-gray-900">
-          <Sidebar.Items>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiViewBoards}>
-                Kanban
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiInbox}>
-                Inbox
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiUser}>
-                Users
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiShoppingBag}>
-                Products
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiArrowSmRight}>
-                Sign In
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiTable}>
-                Sign Up
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Upgrade to Pro
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiViewBoards}>
-                Documentation
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={BiBuoy}>
-                Help
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-          </Sidebar.Items>
-        </Sidebar>
+        <div className="w-fit bg-gray-50">
+          <Sidebar aria-label="Sidebar with content separator example">
+            <Sidebar.Items>
+              <Sidebar.ItemGroup>
+                <Sidebar.Item href="#" icon={HiChartPie}>
+                  Dashboard
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiViewBoards}>
+                  Kanban
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiInbox}>
+                  Inbox
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiUser}>
+                  Users
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiShoppingBag}>
+                  Products
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                  Sign In
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiTable}>
+                  Sign Up
+                </Sidebar.Item>
+              </Sidebar.ItemGroup>
+              <Sidebar.ItemGroup>
+                <Sidebar.Item href="#" icon={HiChartPie}>
+                  Upgrade to Pro
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiViewBoards}>
+                  Documentation
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={BiBuoy}>
+                  Help
+                </Sidebar.Item>
+              </Sidebar.ItemGroup>
+            </Sidebar.Items>
+          </Sidebar>
+        </div>
       ),
     },
     {
       title: 'CTA button',
       code: (
-        <Sidebar aria-label="Sidebar with call to action button example" className="!bg-gray-50 dark:!bg-gray-900">
-          <Sidebar.Items>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiViewBoards}>
-                Kanban
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiInbox}>
-                Inbox
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiUser}>
-                Users
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiShoppingBag}>
-                Products
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiArrowSmRight}>
-                Sign In
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiTable}>
-                Sign Up
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-          </Sidebar.Items>
-          <Sidebar.CTA>
-            <div className="mb-3 flex items-center">
-              <Badge color="warning">Beta</Badge>
-              <div className="-mx-1.5 -my-1.5 ml-auto">
-                <Button aria-label="Close" outline>
-                  <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+        <div className="w-fit bg-gray-50">
+          <Sidebar aria-label="Sidebar with call to action button example">
+            <Sidebar.Items>
+              <Sidebar.ItemGroup>
+                <Sidebar.Item href="#" icon={HiChartPie}>
+                  Dashboard
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiViewBoards}>
+                  Kanban
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiInbox}>
+                  Inbox
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiUser}>
+                  Users
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiShoppingBag}>
+                  Products
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                  Sign In
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiTable}>
+                  Sign Up
+                </Sidebar.Item>
+              </Sidebar.ItemGroup>
+            </Sidebar.Items>
+            <Sidebar.CTA>
+              <div className="mb-3 flex items-center">
+                <Badge color="warning">Beta</Badge>
+                <button
+                  aria-label="Close"
+                  className="-mx-1.5 -my-1.5 ml-auto inline-flex h-6 w-6 rounded-lg bg-blue-50 p-1 text-blue-900 hover:bg-blue-200 focus:ring-2 focus:ring-blue-400 dark:bg-blue-900 dark:text-blue-400 dark:hover:bg-blue-800"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden
+                    className="h-4 w-4"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
                     <path
-                      clipRule="evenodd"
-                      d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
                       fillRule="evenodd"
+                      d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                      clipRule="evenodd"
                     />
                   </svg>
-                </Button>
+                </button>
               </div>
-            </div>
-            <p className="mb-3 text-sm text-blue-900 dark:text-blue-400">
-              Preview the new Flowbite dashboard navigation! You can turn the new navigation off for a limited time in
-              your profile.
-            </p>
-            <a
-              className="text-sm text-blue-900 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-              href="#"
-            >
-              Turn new navigation off
-            </a>
-          </Sidebar.CTA>
-        </Sidebar>
+              <p className="mb-3 text-sm text-blue-900 dark:text-blue-400">
+                Preview the new Flowbite dashboard navigation! You can turn the new navigation off for a limited time in
+                your profile.
+              </p>
+              <a
+                className="text-sm text-blue-900 underline hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
+                href="#"
+              >
+                Turn new navigation off
+              </a>
+            </Sidebar.CTA>
+          </Sidebar>
+        </div>
       ),
     },
     {
       title: 'Logo branding',
       code: (
-        <Sidebar aria-label="Sidebar with logo branding example" className="!bg-gray-50 dark:!bg-gray-900">
-          <Sidebar.Logo href="#" img="favicon.png" imgAlt="Flowbite logo">
-            Flowbite
-          </Sidebar.Logo>
-          <Sidebar.Items>
-            <Sidebar.ItemGroup>
-              <Sidebar.Item href="#" icon={HiChartPie}>
-                Dashboard
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiViewBoards}>
-                Kanban
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiInbox}>
-                Inbox
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiUser}>
-                Users
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiShoppingBag}>
-                Products
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiArrowSmRight}>
-                Sign In
-              </Sidebar.Item>
-              <Sidebar.Item href="#" icon={HiTable}>
-                Sign Up
-              </Sidebar.Item>
-            </Sidebar.ItemGroup>
-          </Sidebar.Items>
-        </Sidebar>
+        <div className="w-fit bg-gray-50">
+          <Sidebar aria-label="Sidebar with logo branding example">
+            <Sidebar.Logo href="#" img="favicon.png" imgAlt="Flowbite logo">
+              Flowbite
+            </Sidebar.Logo>
+            <Sidebar.Items>
+              <Sidebar.ItemGroup>
+                <Sidebar.Item href="#" icon={HiChartPie}>
+                  Dashboard
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiViewBoards}>
+                  Kanban
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiInbox}>
+                  Inbox
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiUser}>
+                  Users
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiShoppingBag}>
+                  Products
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiArrowSmRight}>
+                  Sign In
+                </Sidebar.Item>
+                <Sidebar.Item href="#" icon={HiTable}>
+                  Sign Up
+                </Sidebar.Item>
+              </Sidebar.ItemGroup>
+            </Sidebar.Items>
+          </Sidebar>
+        </div>
       ),
     },
   ];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,6 @@ import { BrowserRouter } from 'react-router-dom';
 import { Flowbite } from './lib/components';
 
 import './index.css';
-import 'flowbite';
 
 const container = document.getElementById('root');
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,9 +9,15 @@ const container = document.getElementById('root');
 
 if (container) {
   const root = createRoot(container);
+  const theme = {
+    sidebar: {
+      base: 'h-full bg-inherit',
+      inner: 'h-full overflow-y-auto overflow-x-hidden rounded bg-inherit py-4 px-3',
+    },
+  };
 
   root.render(
-    <Flowbite>
+    <Flowbite theme={{ theme }}>
       <BrowserRouter>
         <Root />
       </BrowserRouter>

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -8,6 +8,7 @@ import type { DeepPartial } from '../../helpers/deep-partial';
 import type { PositionInButtonGroup } from '../Button/ButtonGroup';
 import type { StarSizes } from '../Rating';
 import type { ModalPositions, ModalSizes } from '../Modal';
+import type { SidebarCTAColors } from '../Sidebar/SidebarCTA';
 
 export type CustomFlowbiteTheme = DeepPartial<FlowbiteTheme>;
 
@@ -226,6 +227,49 @@ export interface FlowbiteTheme {
       };
     };
   };
+  sidebar: {
+    base: string;
+    collapsed: FlowbiteBoolean;
+    inner: string;
+    collapse: {
+      button: string;
+      icon: {
+        base: string;
+        open: FlowbiteBoolean;
+      };
+      label: {
+        base: string;
+        icon: string;
+      };
+      list: string;
+    };
+    cta: {
+      base: string;
+      color: SidebarCTAColors;
+    };
+    item: {
+      active: string;
+      base: string;
+      collapsed: {
+        insideCollapse: string;
+      };
+      content: {
+        base: string;
+        collapsed: string;
+      };
+      icon: {
+        base: string;
+        active: string;
+      };
+    };
+    items: string;
+    itemGroup: string;
+    logo: {
+      base: string;
+      collapsed: FlowbiteBoolean;
+      img: string;
+    };
+  };
   spinner: {
     base: string;
     color: SpinnerColors;
@@ -279,19 +323,23 @@ export interface FlowbiteBoolean {
 }
 
 export interface FlowbiteColors {
+  blue: string;
   cyan: string;
   dark: string;
   failure: string;
   gray: string;
+  green: string;
   indigo: string;
   info: string;
   light: string;
   lime: string;
   pink: string;
   purple: string;
+  red: string;
   success: string;
   teal: string;
   warning: string;
+  yellow: string;
 }
 
 export interface FlowbiteGradientColors {

--- a/src/lib/components/Sidebar/Sidebar.spec.tsx
+++ b/src/lib/components/Sidebar/Sidebar.spec.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { SidebarProps } from '.';
 import { Sidebar } from '.';
+import { Flowbite } from '../Flowbite';
 
 describe.concurrent('Components / Sidebar', () => {
   describe('A11y', () => {
@@ -185,6 +186,223 @@ describe.concurrent('Components / Sidebar', () => {
       });
     });
   });
+
+  describe('Theme', () => {
+    it('should use custom classes', () => {
+      const theme = {
+        sidebar: {
+          base: 'bg-gray-100',
+          collapsed: {
+            off: 'text-gray-200',
+            on: 'text-gray-300',
+          },
+          inner: 'bg-gray-200',
+        },
+      };
+
+      const { getByLabelText } = render(
+        <Flowbite theme={{ theme }}>
+          <TestSidebar aria-label="not-collapsed" />
+          <TestSidebar aria-label="collapsed" collapsed />
+        </Flowbite>,
+      );
+      const sidebar = getByLabelText('not-collapsed');
+      const inner = sidebar.firstElementChild;
+      const collapsedSidebar = getByLabelText('collapsed');
+
+      expect(sidebar).toHaveClass('bg-gray-100');
+      expect(sidebar).toHaveClass('text-gray-200');
+      expect(inner).toHaveClass('bg-gray-200');
+      expect(collapsedSidebar).toHaveClass('text-gray-300');
+    });
+
+    describe('`Sidebar.Collapse`', () => {
+      it('should use custom classes', () => {
+        const theme = {
+          sidebar: {
+            collapse: {
+              button: 'text-gray-100',
+              icon: {
+                base: 'text-gray-200',
+                open: {
+                  off: 'bg-gray-100',
+                  on: 'bg-gray-200',
+                },
+              },
+              label: {
+                base: 'text-gray-300',
+                icon: 'text-gray-400',
+              },
+              list: 'bg-gray-300',
+            },
+          },
+        };
+
+        const { getAllByRole, getAllByTestId } = render(
+          <Flowbite theme={{ theme }}>
+            <TestSidebar />
+          </Flowbite>,
+        );
+        const buttons = getSidebarCollapseButtons({ getAllByRole });
+        let icons = getSidebarCollapseIcons({ getAllByTestId });
+        const labels = getSidebarCollapseLabels({ getAllByTestId });
+        const labelIcons = labels.map((label) => label.nextElementSibling);
+        const list = getSidebarCollapses({ getAllByRole });
+
+        buttons.forEach((button) => expect(button).toHaveClass('text-gray-100'));
+        icons.forEach((icon) => expect(icon).toHaveClass('text-gray-200 bg-gray-100'));
+        labels.forEach((label) => expect(label).toHaveClass('text-gray-300'));
+        labelIcons.forEach((labelicon) => expect(labelicon).toHaveClass('text-gray-400'));
+        list.forEach((list) => expect(list).toHaveClass('bg-gray-300'));
+
+        buttons.forEach((button) => userEvent.click(button));
+
+        icons = getSidebarCollapseIcons({ getAllByTestId });
+
+        icons.forEach((icon) => expect(icon).toHaveClass('bg-gray-200'));
+      });
+    });
+
+    describe('`Sidebar.CTA`', () => {
+      it('should use custom classes', () => {
+        const theme = {
+          sidebar: {
+            cta: {
+              base: 'bg-gray-100',
+              color: {
+                primary: 'text-gray-100',
+              },
+            },
+          },
+        };
+
+        const cta = getSidebarCTA(
+          render(
+            <Flowbite theme={{ theme }}>
+              <TestSidebar />
+            </Flowbite>,
+          ),
+        );
+
+        expect(cta).toHaveClass('bg-gray-100 text-gray-100');
+      });
+    });
+
+    describe('`Sidebar.Item`', () => {
+      it('should use custom classes', () => {
+        const theme = {
+          sidebar: {
+            item: {
+              active: 'text-gray-100',
+              base: 'bg-gray-100',
+              collapsed: {
+                insideCollapse: 'text-gray-300',
+              },
+              content: {
+                base: 'bg-gray-200',
+                collapsed: 'text-gray-600',
+              },
+              icon: {
+                base: 'text-gray-400',
+                active: 'bg-gray-300',
+              },
+            },
+          },
+        };
+
+        const { getAllByRole, getAllByTestId } = render(
+          <Flowbite theme={{ theme }}>
+            <TestSidebar collapsed />
+          </Flowbite>,
+        );
+        const contents = getSidebarItemContents({ getAllByTestId });
+        const icons = getSidebarItemIcons({ getAllByTestId });
+        const items = getSidebarItems({ getAllByRole })
+          .map((item) => item.firstElementChild)
+          .map((item) => item?.firstElementChild)
+          .filter((item) => item?.tagName.toLocaleLowerCase() !== 'button') as HTMLElement[];
+        const activeItems = getAllByTestId('active-item');
+        const activeIcons = activeItems.map((item) => item.firstElementChild);
+        const inactiveIcons = [...icons.filter((icon) => !activeIcons.includes(icon))];
+        const inactiveItems = [...items.filter((item) => item !== null && !activeItems.includes(item))];
+
+        activeIcons.forEach((icon) => expect(icon).toHaveClass('bg-gray-300'));
+        activeItems.forEach((item) => expect(item).toHaveClass('text-gray-100'));
+        contents.forEach((content) => expect(content).toHaveClass('bg-gray-200'));
+        inactiveIcons.forEach((icon) => expect(icon).not.toHaveClass('bg-gray-300'));
+        inactiveItems.forEach((item) => expect(item).not.toHaveClass('text-gray-100'));
+        icons.forEach((icon) => expect(icon).toHaveClass('text-gray-400'));
+        items.forEach((item) => expect(item).toHaveClass('bg-gray-100'));
+      });
+    });
+
+    describe('`Sidebar.Items`', () => {
+      it('should use custom classes', () => {
+        const theme = {
+          sidebar: {
+            items: 'text-gray-100',
+          },
+        };
+
+        const itemsContainers = getSidebarItemsContainer(
+          render(
+            <Flowbite theme={{ theme }}>
+              <TestSidebar />
+            </Flowbite>,
+          ),
+        );
+
+        itemsContainers.forEach((container) => expect(container).toHaveClass('text-gray-100'));
+      });
+    });
+
+    describe('`Sidebar.ItemGroup`', () => {
+      it('should use custom classes', () => {
+        const theme = {
+          sidebar: {
+            itemGroup: 'text-gray-100',
+          },
+        };
+
+        const itemGroups = getSidebarItemGroups(
+          render(
+            <Flowbite theme={{ theme }}>
+              <TestSidebar />
+            </Flowbite>,
+          ),
+        );
+
+        itemGroups.forEach((group) => expect(group).toHaveClass('text-gray-100'));
+      });
+    });
+
+    describe('`Sidebar.Logo`', () => {
+      it('should use custom classes', () => {
+        const theme = {
+          sidebar: {
+            logo: {
+              base: 'text-gray-100',
+              collapsed: {
+                off: 'text-gray-300',
+                on: 'text-gray-400',
+              },
+              img: 'text-gray-200',
+            },
+          },
+        };
+
+        const logo = getSidebarLogo(
+          render(
+            <Flowbite theme={{ theme }}>
+              <TestSidebar />
+            </Flowbite>,
+          ),
+        );
+
+        expect(logo).toHaveClass('text-gray-100');
+      });
+    });
+  });
 });
 
 const TestSidebar = ({ ...props }: SidebarProps): JSX.Element => (
@@ -194,7 +412,7 @@ const TestSidebar = ({ ...props }: SidebarProps): JSX.Element => (
     </Sidebar.Logo>
     <Sidebar.Items>
       <Sidebar.ItemGroup>
-        <Sidebar.Item href="#" icon={HiChartPie} label="3" labelColor="success">
+        <Sidebar.Item active data-testid="active-item" href="#" icon={HiChartPie} label="3" labelColor="success">
           Dashboard
         </Sidebar.Item>
         <Sidebar.Collapse aria-label="E-commerce" icon={HiShoppingBag}>
@@ -207,7 +425,7 @@ const TestSidebar = ({ ...props }: SidebarProps): JSX.Element => (
         <Sidebar.Item as="h3">My heading</Sidebar.Item>
       </Sidebar.ItemGroup>
     </Sidebar.Items>
-    <Sidebar.CTA>Some content</Sidebar.CTA>
+    <Sidebar.CTA color="primary">Some content</Sidebar.CTA>
   </Sidebar>
 );
 
@@ -219,13 +437,28 @@ const getSidebarCollapseButtons = ({ getAllByRole }: Pick<RenderResult, 'getAllB
 const getSidebarCollapses = ({ getAllByRole }: Pick<RenderResult, 'getAllByRole'>): HTMLElement[] =>
   getAllByRole('list').slice(1);
 
+const getSidebarCollapseIcons = ({ getAllByTestId }: Pick<RenderResult, 'getAllByTestId'>): HTMLElement[] =>
+  getAllByTestId('flowbite-sidebar-collapse-icon');
+
+const getSidebarCollapseLabels = ({ getAllByTestId }: Pick<RenderResult, 'getAllByTestId'>): HTMLElement[] =>
+  getAllByTestId('flowbite-sidebar-collapse-label');
+
 const getSidebarCTA = ({ getByText }: Pick<RenderResult, 'getByText'>): HTMLElement => getByText('Some content');
 
 const getSidebarItemContents = ({ getAllByTestId }: Pick<RenderResult, 'getAllByTestId'>): HTMLElement[] =>
   getAllByTestId('flowbite-sidebar-item-content');
 
+const getSidebarItemGroups = ({ getAllByTestId }: Pick<RenderResult, 'getAllByTestId'>): HTMLElement[] =>
+  getAllByTestId('flowbite-sidebar-item-group');
+
+const getSidebarItemIcons = ({ getAllByTestId }: Pick<RenderResult, 'getAllByTestId'>): HTMLElement[] =>
+  getAllByTestId('flowbite-sidebar-item-icon');
+
 const getSidebarItems = ({ getAllByRole }: Pick<RenderResult, 'getAllByRole'>): HTMLElement[] =>
   getAllByRole('listitem');
+
+const getSidebarItemsContainer = ({ getAllByTestId }: Pick<RenderResult, 'getAllByTestId'>): HTMLElement[] =>
+  getAllByTestId('flowbite-sidebar-items');
 
 const getSidebarLabels = ({ queryAllByTestId }: Pick<RenderResult, 'queryAllByTestId'>): HTMLElement[] =>
   queryAllByTestId('flowbite-sidebar-label');

--- a/src/lib/components/Sidebar/SidebarCTA.tsx
+++ b/src/lib/components/Sidebar/SidebarCTA.tsx
@@ -1,30 +1,31 @@
 import classNames from 'classnames';
 import type { PropsWithChildren, FC, ComponentProps } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
+import type { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
+import { useTheme } from '../Flowbite/ThemeContext';
 import { useSidebarContext } from './SidebarContext';
 
-export interface SidebarCTAProps extends PropsWithChildren<ComponentProps<'div'>> {
-  color?: SidebarCTAColor;
+export interface SidebarCTAProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'className' | 'color'>> {
+  color?: keyof SidebarCTAColors;
 }
 
-type SidebarCTAColor = 'alternative' | 'blue' | 'dark' | 'green' | 'light' | 'purple' | 'red' | 'yellow';
+export interface SidebarCTAColors
+  extends Pick<
+    FlowbiteColors,
+    'blue' | 'dark' | 'failure' | 'gray' | 'green' | 'light' | 'purple' | 'red' | 'success' | 'warning' | 'yellow'
+  > {
+  [key: string]: string;
+}
 
-const colorClasses: Record<SidebarCTAColor, string> = {
-  blue: 'bg-blue-50 dark:bg-blue-900',
-  alternative: 'bg-alternative-50 dark:bg-alternative-900',
-  dark: 'bg-dark-50 dark:bg-dark-900',
-  light: 'bg-light-50 dark:bg-light-900',
-  green: 'bg-green-50 dark:bg-green-900',
-  red: 'bg-red-50 dark:bg-red-900',
-  yellow: 'bg-yellow-50 dark:bg-yellow-900',
-  purple: 'bg-purple-50 dark:bg-purple-900',
-};
+const SidebarCTA: FC<SidebarCTAProps> = ({ children, color = 'info', ...props }): JSX.Element => {
+  const theirProps = excludeClassName(props);
 
-const SidebarCTA: FC<SidebarCTAProps> = ({ children, className, color = 'blue', ...theirProps }) => {
   const { isCollapsed } = useSidebarContext();
+  const theme = useTheme().theme.sidebar.cta;
 
   return (
     <div
-      className={classNames('mt-6 rounded-lg p-4', colorClasses[color], className)}
+      className={classNames(theme.base, theme.color[color])}
       data-testid="sidebar-cta"
       hidden={isCollapsed}
       {...theirProps}

--- a/src/lib/components/Sidebar/SidebarCollapse.tsx
+++ b/src/lib/components/Sidebar/SidebarCollapse.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps, FC, PropsWithChildren } from 'react';
 import { useId, useState } from 'react';
 import { HiChevronDown } from 'react-icons/hi';
 import { excludeClassName } from '../../helpers/exclude';
+import { useTheme } from '../Flowbite/ThemeContext';
 import { Tooltip } from '../Tooltip';
 import { useSidebarContext } from './SidebarContext';
 import type { SidebarItemProps } from './SidebarItem';
@@ -16,8 +17,9 @@ const SidebarCollapse: FC<SidebarCollapseProps> = ({ children, icon: Icon, label
   const id = useId();
   const { isCollapsed } = useSidebarContext();
   const [isOpen, setOpen] = useState(false);
+  const theme = useTheme().theme.sidebar.collapse;
 
-  const Wrapper = ({ children }: PropsWithChildren<unknown>) => (
+  const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }): JSX.Element => (
     <li>
       {isCollapsed ? (
         <Tooltip content={label} placement="right">
@@ -32,31 +34,23 @@ const SidebarCollapse: FC<SidebarCollapseProps> = ({ children, icon: Icon, label
   return (
     <Wrapper>
       <button
-        className="group flex w-full items-center rounded-lg p-2 text-base font-normal text-gray-900 transition duration-75 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
+        className={theme.button}
         id={`flowbite-sidebar-collapse-${id}`}
         onClick={() => setOpen(!isOpen)}
         type="button"
         {...theirProps}
       >
-        {Icon && (
-          <Icon
-            aria-hidden
-            className={classNames(
-              'h-6 w-6 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white',
-              { 'text-gray-900': isOpen },
-            )}
-          />
-        )}
+        {Icon && <Icon aria-hidden className={classNames(theme.icon.base, theme.icon.open[isOpen ? 'on' : 'off'])} />}
         {isCollapsed ? (
           <span className="sr-only">{label}</span>
         ) : (
           <>
-            <span className="ml-3 flex-1 whitespace-nowrap text-left">{label}</span>
-            <HiChevronDown aria-hidden className="h-6 w-6" />
+            <span className={theme.label.base}>{label}</span>
+            <HiChevronDown aria-hidden className={theme.label.icon} />
           </>
         )}
       </button>
-      <ul aria-labelledby={`flowbite-sidebar-collapse-${id}`} className="space-y-2 py-2" hidden={!isOpen}>
+      <ul aria-labelledby={`flowbite-sidebar-collapse-${id}`} className={theme.list} hidden={!isOpen}>
         <SidebarItemContext.Provider value={{ isInsideCollapse: true }}>{children}</SidebarItemContext.Provider>
       </ul>
     </Wrapper>

--- a/src/lib/components/Sidebar/SidebarCollapse.tsx
+++ b/src/lib/components/Sidebar/SidebarCollapse.tsx
@@ -40,12 +40,20 @@ const SidebarCollapse: FC<SidebarCollapseProps> = ({ children, icon: Icon, label
         type="button"
         {...theirProps}
       >
-        {Icon && <Icon aria-hidden className={classNames(theme.icon.base, theme.icon.open[isOpen ? 'on' : 'off'])} />}
+        {Icon && (
+          <Icon
+            aria-hidden
+            className={classNames(theme.icon.base, theme.icon.open[isOpen ? 'on' : 'off'])}
+            data-testid="flowbite-sidebar-collapse-icon"
+          />
+        )}
         {isCollapsed ? (
           <span className="sr-only">{label}</span>
         ) : (
           <>
-            <span className={theme.label.base}>{label}</span>
+            <span className={theme.label.base} data-testid="flowbite-sidebar-collapse-label">
+              {label}
+            </span>
             <HiChevronDown aria-hidden className={theme.label.icon} />
           </>
         )}

--- a/src/lib/components/Sidebar/SidebarItem.tsx
+++ b/src/lib/components/Sidebar/SidebarItem.tsx
@@ -1,13 +1,16 @@
 import classNames from 'classnames';
 import type { ComponentProps, ElementType, FC, PropsWithChildren } from 'react';
 import { useId } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
 import { Badge } from '../Badge';
 import type { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
+import { useTheme } from '../Flowbite/ThemeContext';
 import { Tooltip } from '../Tooltip';
 import { useSidebarContext } from './SidebarContext';
 import { useSidebarItemContext } from './SidebarItemContext';
 
-export interface SidebarItemProps extends PropsWithChildren<ComponentProps<'div'> & Record<string, unknown>> {
+export interface SidebarItemProps
+  extends PropsWithChildren<Omit<ComponentProps<'div'>, 'className'> & Record<string, unknown>> {
   active?: boolean;
   as?: ElementType;
   className?: string;
@@ -24,16 +27,18 @@ export interface SidebarItemLabelColors extends Pick<FlowbiteColors, 'gray'> {
 const SidebarItem: FC<SidebarItemProps> = ({
   as: Component = 'a',
   children,
-  className,
   icon: Icon,
   active: isActive,
   label,
   labelColor = 'info',
-  ...theirProps
+  ...props
 }): JSX.Element => {
+  const theirProps = excludeClassName(props);
+
   const id = useId();
   const { isCollapsed } = useSidebarContext();
   const { isInsideCollapse } = useSidebarItemContext();
+  const theme = useTheme().theme.sidebar.item;
 
   const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }): JSX.Element => (
     <li>
@@ -52,26 +57,15 @@ const SidebarItem: FC<SidebarItemProps> = ({
       <Component
         aria-labelledby={`flowbite-sidebar-item-${id}`}
         className={classNames(
-          'flex items-center rounded-lg p-2 text-base font-normal text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700',
-          {
-            'bg-gray-100 dark:bg-gray-700': isActive,
-            'group w-full pl-8 transition duration-75': !isCollapsed && isInsideCollapse,
-          },
-          className,
+          theme.base,
+          isActive && theme.active,
+          !isCollapsed && isInsideCollapse && theme.collapsed.insideCollapse,
         )}
         {...theirProps}
       >
-        {Icon && (
-          <Icon
-            aria-hidden
-            className={classNames(
-              'h-6 w-6 flex-shrink-0 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white',
-              { 'text-gray-700 dark:text-gray-100': isActive },
-            )}
-          />
-        )}
+        {Icon && <Icon aria-hidden className={classNames(theme.icon.base, isActive && theme.icon.active)} />}
         <span
-          className={classNames('ml-3 flex-1 whitespace-nowrap', { hidden: isCollapsed })}
+          className={classNames(theme.content.base, isCollapsed && theme.content.collapsed)}
           data-testid="flowbite-sidebar-item-content"
           id={`flowbite-sidebar-item-${id}`}
         >

--- a/src/lib/components/Sidebar/SidebarItem.tsx
+++ b/src/lib/components/Sidebar/SidebarItem.tsx
@@ -63,7 +63,13 @@ const SidebarItem: FC<SidebarItemProps> = ({
         )}
         {...theirProps}
       >
-        {Icon && <Icon aria-hidden className={classNames(theme.icon.base, isActive && theme.icon.active)} />}
+        {Icon && (
+          <Icon
+            aria-hidden
+            className={classNames(theme.icon.base, isActive && theme.icon.active)}
+            data-testid="flowbite-sidebar-item-icon"
+          />
+        )}
         <span
           className={classNames(theme.content.base, isCollapsed && theme.content.collapsed)}
           data-testid="flowbite-sidebar-item-content"

--- a/src/lib/components/Sidebar/SidebarItemGroup.tsx
+++ b/src/lib/components/Sidebar/SidebarItemGroup.tsx
@@ -9,7 +9,7 @@ const SidebarItemGroup: FC<PropsWithChildren<Omit<ComponentProps<'ul'>, 'classNa
   const theme = useTheme().theme.sidebar.itemGroup;
 
   return (
-    <ul className={theme} data-testid="sidebar-item-group" {...theirProps}>
+    <ul className={theme} data-testid="flowbite-sidebar-item-group" {...theirProps}>
       <SidebarItemContext.Provider value={{ isInsideCollapse: false }}>{children}</SidebarItemContext.Provider>
     </ul>
   );

--- a/src/lib/components/Sidebar/SidebarItemGroup.tsx
+++ b/src/lib/components/Sidebar/SidebarItemGroup.tsx
@@ -1,16 +1,15 @@
-import classNames from 'classnames';
-import type { FC, HTMLAttributes, PropsWithChildren } from 'react';
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
+import { useTheme } from '../Flowbite/ThemeContext';
 import { SidebarItemContext } from './SidebarItemContext';
 
-const SidebarItemGroup: FC<PropsWithChildren<HTMLAttributes<HTMLUListElement>>> = ({ children, ...rest }) => {
+const SidebarItemGroup: FC<PropsWithChildren<Omit<ComponentProps<'ul'>, 'className'>>> = ({ children, ...props }) => {
+  const theirProps = excludeClassName(props);
+
+  const theme = useTheme().theme.sidebar.itemGroup;
+
   return (
-    <ul
-      className={classNames(
-        'mt-4 space-y-2 border-t border-gray-200 pt-4 first:mt-0 first:border-t-0 first:pt-0 dark:border-gray-700',
-      )}
-      data-testid="sidebar-item-group"
-      {...rest}
-    >
+    <ul className={theme} data-testid="sidebar-item-group" {...theirProps}>
       <SidebarItemContext.Provider value={{ isInsideCollapse: false }}>{children}</SidebarItemContext.Provider>
     </ul>
   );

--- a/src/lib/components/Sidebar/SidebarItems.tsx
+++ b/src/lib/components/Sidebar/SidebarItems.tsx
@@ -11,7 +11,7 @@ const SidebarItems: FC<PropsWithChildren<Omit<ComponentProps<'div'>, 'className'
   const theme = useTheme().theme.sidebar.items;
 
   return (
-    <div className={theme} {...theirProps}>
+    <div className={theme} data-testid="flowbite-sidebar-items" {...theirProps}>
       {children}
     </div>
   );

--- a/src/lib/components/Sidebar/SidebarItems.tsx
+++ b/src/lib/components/Sidebar/SidebarItems.tsx
@@ -1,7 +1,20 @@
-import type { FC, PropsWithChildren, HTMLAttributes } from 'react';
+import type { FC, PropsWithChildren, ComponentProps } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
+import { useTheme } from '../Flowbite/ThemeContext';
 
-const SidebarItems: FC<PropsWithChildren<HTMLAttributes<HTMLDivElement>>> = ({ children, ...rest }) => {
-  return <div {...rest}>{children}</div>;
+const SidebarItems: FC<PropsWithChildren<Omit<ComponentProps<'div'>, 'className'>>> = ({
+  children,
+  ...props
+}): JSX.Element => {
+  const theirProps = excludeClassName(props);
+
+  const theme = useTheme().theme.sidebar.items;
+
+  return (
+    <div className={theme} {...theirProps}>
+      {children}
+    </div>
+  );
 };
 
 SidebarItems.displayName = 'Sidebar.Items';

--- a/src/lib/components/Sidebar/SidebarLogo.tsx
+++ b/src/lib/components/Sidebar/SidebarLogo.tsx
@@ -1,33 +1,27 @@
-import classNames from 'classnames';
-import type { PropsWithChildren, FC, HTMLAttributes } from 'react';
+import type { PropsWithChildren, FC, ComponentProps } from 'react';
 import { useId } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
+import { useTheme } from '../Flowbite/ThemeContext';
 import { useSidebarContext } from './SidebarContext';
 
-export interface SidebarLogoProps extends PropsWithChildren<HTMLAttributes<HTMLAnchorElement>> {
+export interface SidebarLogoProps extends PropsWithChildren<Omit<ComponentProps<'a'>, 'className'>> {
   className?: string;
   href: string;
   img: string;
   imgAlt?: string;
 }
 
-const SidebarLogo: FC<SidebarLogoProps> = ({ children, className, href, img, imgAlt = '', ...theirProps }) => {
+const SidebarLogo: FC<SidebarLogoProps> = ({ children, href, img, imgAlt = '', ...props }) => {
+  const theirProps = excludeClassName(props);
+
   const id = useId();
   const { isCollapsed } = useSidebarContext();
+  const theme = useTheme().theme.sidebar.logo;
 
   return (
-    <a
-      aria-labelledby={`flowbite-sidebar-logo-${id}`}
-      className={classNames('mb-5 flex items-center pl-2.5', className)}
-      href={href}
-      {...theirProps}
-    >
-      <img alt={imgAlt} className="mr-3 h-6 sm:h-7" src={img} />
-      <span
-        className={classNames(
-          isCollapsed ? 'hidden' : 'self-center whitespace-nowrap text-xl font-semibold dark:text-white',
-        )}
-        id={`flowbite-sidebar-logo-${id}`}
-      >
+    <a aria-labelledby={`flowbite-sidebar-logo-${id}`} className={theme.base} href={href} {...theirProps}>
+      <img alt={imgAlt} className={theme.img} src={img} />
+      <span className={theme.collapsed[isCollapsed ? 'on' : 'off']} id={`flowbite-sidebar-logo-${id}`}>
         {children}
       </span>
     </a>

--- a/src/lib/components/Sidebar/index.tsx
+++ b/src/lib/components/Sidebar/index.tsx
@@ -1,5 +1,5 @@
-import type { FC, HTMLAttributes, PropsWithChildren } from 'react';
 import classNames from 'classnames';
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
 import SidebarCTA from './SidebarCTA';
 import SidebarLogo from './SidebarLogo';
 import SidebarItem from './SidebarItem';
@@ -7,35 +7,33 @@ import SidebarItemGroup from './SidebarItemGroup';
 import SidebarItems from './SidebarItems';
 import SidebarCollapse from './SidebarCollapse';
 import { SidebarContext } from './SidebarContext';
+import { useTheme } from '../Flowbite/ThemeContext';
+import { excludeClassName } from '../../helpers/exclude';
 
-export interface SidebarProps extends PropsWithChildren<HTMLAttributes<HTMLDivElement>> {
+export interface SidebarProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'className'>> {
   collapseBehavior?: 'collapse' | 'hide';
   collapsed?: boolean;
 }
 
 const SidebarComponent: FC<SidebarProps> = ({
   children,
-  className,
   collapseBehavior = 'collapse',
   collapsed: isCollapsed = false,
-  ...theirProps
-}) => {
+  ...props
+}): JSX.Element => {
+  const theirProps = excludeClassName(props);
+
+  const theme = useTheme().theme.sidebar;
+
   return (
     <SidebarContext.Provider value={{ isCollapsed }}>
       <aside
         aria-label="Sidebar"
-        className={classNames('h-full', isCollapsed ? 'w-16' : 'w-64')}
+        className={classNames(theme.base, theme.collapsed[isCollapsed ? 'on' : 'off'])}
         hidden={isCollapsed && collapseBehavior === 'hide'}
         {...theirProps}
       >
-        <div
-          className={classNames(
-            'h-full overflow-y-auto overflow-x-hidden rounded bg-white py-4 px-3 dark:bg-gray-800',
-            className,
-          )}
-        >
-          {children}
-        </div>
+        <div className={theme.inner}>{children}</div>
       </aside>
     </SidebarContext.Provider>
   );

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -377,6 +377,72 @@ export default {
       },
     },
   },
+  sidebar: {
+    base: 'h-full',
+    inner: 'h-full overflow-y-auto overflow-x-hidden rounded bg-white py-4 px-3 dark:bg-gray-800',
+    collapsed: {
+      on: 'w-16',
+      off: 'w-64',
+    },
+    collapse: {
+      button:
+        'group flex w-full items-center rounded-lg p-2 text-base font-normal text-gray-900 transition duration-75 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700',
+      icon: {
+        base: 'h-6 w-6 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white',
+        open: {
+          off: '',
+          on: 'text-gray-900',
+        },
+      },
+      label: {
+        base: 'ml-3 flex-1 whitespace-nowrap text-left',
+        icon: 'h-6 w-6',
+      },
+      list: 'space-y-2 py-2',
+    },
+    cta: {
+      base: 'mt-6 rounded-lg p-4',
+      color: {
+        blue: 'bg-blue-50 dark:bg-blue-900',
+        dark: 'bg-dark-50 dark:bg-dark-900',
+        failure: 'bg-red-50 dark:bg-red-900',
+        gray: 'bg-alternative-50 dark:bg-alternative-900',
+        green: 'bg-green-50 dark:bg-green-900',
+        light: 'bg-light-50 dark:bg-light-900',
+        red: 'bg-red-50 dark:bg-red-900',
+        purple: 'bg-purple-50 dark:bg-purple-900',
+        success: 'bg-green-50 dark:bg-green-900',
+        yellow: 'bg-yellow-50 dark:bg-yellow-900',
+        warning: 'bg-yellow-50 dark:bg-yellow-900',
+      },
+    },
+    item: {
+      base: 'flex items-center rounded-lg p-2 text-base font-normal text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700',
+      active: 'bg-gray-100 dark:bg-gray-700',
+      collapsed: {
+        insideCollapse: 'group w-full pl-8 transition duration-75',
+      },
+      content: {
+        base: 'ml-3 flex-1 whitespace-nowrap',
+        collapsed: 'hidden',
+      },
+      icon: {
+        base: 'h-6 w-6 flex-shrink-0 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white',
+        active: 'text-gray-700 dark:text-gray-100',
+      },
+    },
+    items: '',
+    itemGroup:
+      'mt-4 space-y-2 border-t border-gray-200 pt-4 first:mt-0 first:border-t-0 first:pt-0 dark:border-gray-700',
+    logo: {
+      base: 'mb-5 flex items-center pl-2.5',
+      collapsed: {
+        on: 'hidden',
+        off: 'self-center whitespace-nowrap text-xl font-semibold dark:text-white',
+      },
+      img: 'mr-3 h-6 sm:h-7',
+    },
+  },
   spinner: {
     base: 'inline animate-spin text-gray-200',
     color: {


### PR DESCRIPTION
## Breaking changes

`Sidebar`s can now be customized via `<Flowbite theme={..}>`.

```js
sidebar: {
    base: string;
    collapsed: FlowbiteBoolean;
    inner: string;
    collapse: {
      button: string;
      icon: {
        base: string;
        open: FlowbiteBoolean;
      };
      label: {
        base: string;
        icon: string;
      };
      list: string;
    };
    cta: {
      base: string;
      color: SidebarCTAColors;
    };
    item: {
      active: FlowbiteBoolean;
      base: string;
      collapsed: {
        insideCollapse: string;
      };
      content: {
        base: string;
        collapsed: string;
      };
      icon: {
        base: string;
        active: string;
      };
    };
    items: string;
    itemGroup: string;
    logo: {
      base: string;
      collapsed: FlowbiteBoolean;
      img: string;
    };
  };
```

## Features

- [x] [feat(component): Use](https://github.com/themesberg/flowbite-react/pull/200/commits/b500c7d7ce131cf3321aec2df723d4046a4d8367) [FlowbiteTheme](https://github.com/themesberg/flowbite-react/pull/200/commits/b500c7d7ce131cf3321aec2df723d4046a4d8367) [in](https://github.com/themesberg/flowbite-react/pull/200/commits/b500c7d7ce131cf3321aec2df723d4046a4d8367) [Sidebar](https://github.com/themesberg/flowbite-react/pull/200/commits/b500c7d7ce131cf3321aec2df723d4046a4d8367)[s,](https://github.com/themesberg/flowbite-react/pull/200/commits/b500c7d7ce131cf3321aec2df723d4046a4d8367) [resolves](https://github.com/themesberg/flowbite-react/pull/200/commits/b500c7d7ce131cf3321aec2df723d4046a4d8367) https://github.com/themesberg/flowbite-react/issues/143
- [x] [feat(type): Add Sidebar to FlowbiteTheme](https://github.com/themesberg/flowbite-react/commit/36ad65999a1700a8c036884b42ec7048149cbe6d)

## Tests

### Unit

- [x] [test(component): Add theme unit tests for Sidebars](https://github.com/themesberg/flowbite-react/commit/589eed502aa5f408222f5d4f7c14dfa3ef02d393)