### PR TITLE
fix(a11y): Use darker text for `Breadcrumb.Item`s, resolves #102

### DIFF
--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -125,7 +125,7 @@ export default {
       base: 'group flex items-center',
       chevron: 'mx-1 h-6 w-6 text-gray-400 group-first:hidden md:mx-2',
       href: {
-        off: 'flex items-center text-sm font-medium text-gray-400 dark:text-gray-500',
+        off: 'flex items-center text-sm font-medium text-gray-500 dark:text-gray-400',
         on: 'flex items-center text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white',
       },
       icon: 'mr-2 h-4 w-4',


### PR DESCRIPTION
`Breadcrumb.Item`s with no link (`href`) specified have insufficient contrast using the old color.

## Breaking changes

None.

## Bug fixes

- [x] [fix(a11y): Use darker text for](https://github.com/themesberg/flowbite-react/commit/897ac33a9cf797aa3924da9c0901093e9a5d788e) [Breadcrumb.Item](https://github.com/themesberg/flowbite-react/commit/897ac33a9cf797aa3924da9c0901093e9a5d788e)[s,](https://github.com/themesberg/flowbite-react/commit/897ac33a9cf797aa3924da9c0901093e9a5d788e) [resolves](https://github.com/themesberg/flowbite-react/commit/897ac33a9cf797aa3924da9c0901093e9a5d788e) https://github.com/themesberg/flowbite-react/issues/102