### PR TITLE
feat(component): Allow `Label` as self-closing tag, resolves #173

### DIFF
--- a/src/lib/components/FormControls/Label.spec.tsx
+++ b/src/lib/components/FormControls/Label.spec.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 import { HiGlobe, HiLockClosed } from 'react-icons/hi';
 import { describe, expect, it } from 'vitest';
-
 import { Button } from '../Button';
 import { Checkbox } from './Checkbox';
 import { FileInput } from './FileInput';
@@ -13,14 +12,8 @@ import { TextInput } from './TextInput';
 import { ToggleSwitch } from './ToggleSwitch';
 
 describe.concurrent('Components / Form controls / Label', () => {
-  it('should render', () => {
-    render(<Label>Hello</Label>);
-  });
-
   describe('A11y', () => {
     it('should provide accessible name to any form control associated by `htmlFor`', () => {
-      const { getByLabelText } = render(<TestForm />);
-
       const inputLabels = [
         'Your email',
         'Your password',
@@ -31,7 +24,21 @@ describe.concurrent('Components / Form controls / Label', () => {
         'Your message',
       ];
 
+      const { getByLabelText } = render(<TestForm />);
+
       inputLabels.forEach((label) => expect(getByLabelText(label)).toHaveAccessibleName(label));
+    });
+  });
+
+  describe('Rendering', () => {
+    it('should render', () => {
+      render(<Label>Hello</Label>);
+    });
+
+    describe('`value=".."`', () => {
+      it('should render', () => {
+        render(<Label value="Hello" />);
+      });
     });
   });
 });

--- a/src/lib/components/FormControls/Label.tsx
+++ b/src/lib/components/FormControls/Label.tsx
@@ -1,11 +1,12 @@
-import type { ComponentProps, FC } from 'react';
 import classNames from 'classnames';
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
 
 type Color = 'gray' | 'green' | 'red';
 
-export type LabelProps = ComponentProps<'label'> & {
+export interface LabelProps extends PropsWithChildren<ComponentProps<'label'>> {
   color?: Color;
-};
+  value?: string;
+}
 
 const colorClasses: Record<Color, string> = {
   gray: 'text-gray-900 dark:text-gray-300',
@@ -13,8 +14,10 @@ const colorClasses: Record<Color, string> = {
   red: 'text-red-700 dark:text-red-500',
 };
 
-export const Label: FC<LabelProps> = ({ children, color = 'gray', className, ...props }) => (
-  <label className={classNames('text-sm font-medium', colorClasses[color], className)} {...props}>
-    {children}
-  </label>
-);
+export const Label: FC<LabelProps> = ({ children, color = 'gray', className, value, ...props }): JSX.Element => {
+  return (
+    <label className={classNames('text-sm font-medium', colorClasses[color], className)} {...props}>
+      {value ?? children ?? ''}
+    </label>
+  );
+};


### PR DESCRIPTION
## Breaking changes

You can now declare a `<Label />` as a self-closing tag. Instead of `children`, provide `value`:

```js
<Label htmlFor="email" value="Your email" />
```

## Features

- [x] [feat(component): Allow](https://github.com/themesberg/flowbite-react/pull/207/commits/f201279af8b7886c8604efa9c761f0ae6a6f9f92) [Label](https://github.com/themesberg/flowbite-react/pull/207/commits/f201279af8b7886c8604efa9c761f0ae6a6f9f92) [as self-closing tag,](https://github.com/themesberg/flowbite-react/pull/207/commits/f201279af8b7886c8604efa9c761f0ae6a6f9f92) [resolves](https://github.com/themesberg/flowbite-react/pull/207/commits/f201279af8b7886c8604efa9c761f0ae6a6f9f92) https://github.com/themesberg/flowbite-react/issues/173

## Tests

### Unit

- [x] [test(component): Add unit test for <Label value="">](https://github.com/themesberg/flowbite-react/pull/207/commits/5fa6f4afa9be9dc0ed06637729b39e997451c5ba)