### PR TITLE
fix(component): Allow `Carousel`s to fill height, resolves #168

### DIFF
--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -239,7 +239,7 @@ export default {
     },
   },
   carousel: {
-    base: 'relative w-full',
+    base: 'relative h-full w-full min-h-56 sm:min-h-64 xl:min-h-80 2xl:min-h-96',
     indicators: {
       active: {
         off: 'bg-white/50 hover:bg-white dark:bg-gray-800/50 dark:hover:bg-gray-800',
@@ -255,7 +255,7 @@ export default {
     leftControl: 'absolute top-0 left-0 flex h-full items-center justify-center px-4 focus:outline-none',
     rightControl: 'absolute top-0 right-0 flex h-full items-center justify-center px-4 focus:outline-none',
     scrollContainer: {
-      base: 'flex h-56 snap-mandatory overflow-y-hidden overflow-x-scroll scroll-smooth rounded-lg sm:h-64 xl:h-80 2xl:h-96',
+      base: 'flex h-full snap-mandatory overflow-y-hidden overflow-x-scroll scroll-smooth rounded-lg',
       snap: 'snap-x',
     },
   },


### PR DESCRIPTION
Slightly tweak the default `Carousel` theme to make slides fill the height specified in `base`, which makes it much easier for users to override.

## Breaking changes

`Carousel`s now automatically fill the height of their parent.

## Bug fixes

- [x] [fix(component): Allow](https://github.com/themesberg/flowbite-react/pull/208/commits/911318b13a2fd97829f5e8b25ac0bff3672634af) [Carousel](https://github.com/themesberg/flowbite-react/pull/208/commits/911318b13a2fd97829f5e8b25ac0bff3672634af)[s to fill height,](https://github.com/themesberg/flowbite-react/pull/208/commits/911318b13a2fd97829f5e8b25ac0bff3672634af) [resolves](https://github.com/themesberg/flowbite-react/pull/208/commits/911318b13a2fd97829f5e8b25ac0bff3672634af) https://github.com/themesberg/flowbite-react/issues/168