### PR TITLE
Fix: update typo on Footer.Link from Gihub to Github

### DIFF
--- a/src/docs/pages/FooterPage.tsx
+++ b/src/docs/pages/FooterPage.tsx
@@ -74,7 +74,7 @@ const FooterPage: FC = () => {
                 <h2 className="mb-6 text-sm font-semibold uppercase text-gray-900 dark:text-white">Follow us</h2>
                 <Footer.LinkGroup className="flex-col">
                   <Footer.Link className="mb-4" href="#">
-                    Gihub
+                    Github
                   </Footer.Link>
                   <Footer.Link className="mb-4" href="#">
                     Discord

--- a/src/lib/components/Footer/Footer.stories.tsx
+++ b/src/lib/components/Footer/Footer.stories.tsx
@@ -82,7 +82,7 @@ WithSocialMediaFooter.args = {
             <h2 className="mb-6 text-sm font-semibold uppercase text-gray-900 dark:text-white">Follow us</h2>
             <Footer.LinkGroup className="flex-col">
               <Footer.Link className="mb-4" href="#">
-                Gihub
+                Github
               </Footer.Link>
               <Footer.Link className="mb-4" href="#">
                 Discord


### PR DESCRIPTION
There is a typo in the Flowbite React documentation: 
**Gihub** appears but it should be **Github**

<img width="983" alt="Screen Shot 2022-06-07 at 15 15 55" src="https://user-images.githubusercontent.com/31778373/172484188-9d505667-f817-40fc-b608-e882c3f08639.png">
