### PR TITLE
fix(component): Remove `type="button"` when not a `<button>`

### DIFF
--- a/src/lib/components/ListGroup/ListGroupItem.tsx
+++ b/src/lib/components/ListGroup/ListGroupItem.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
 import { useTheme } from '../Flowbite/ThemeContext';
 
 export interface ListGroupItemProps extends PropsWithChildren<Omit<ComponentProps<'a' | 'button'>, 'className'>> {
@@ -16,22 +17,23 @@ export const ListGroupItem: FC<ListGroupItemProps> = ({
   href,
   icon: Icon,
   onClick,
+  ...props
 }): JSX.Element => {
-  const theme = useTheme().theme.listGroup.item;
+  const isLink = typeof href !== 'undefined';
 
-  const Component = typeof href === 'undefined' ? 'button' : 'a';
+  const Component = isLink ? 'a' : 'button';
+  const theirProps = excludeClassName(props);
+
+  const theme = useTheme().theme.listGroup.item;
 
   return (
     <li>
       <Component
-        className={classNames(
-          theme.active[isActive ? 'on' : 'off'],
-          theme.base,
-          theme.href[typeof href === 'undefined' ? 'off' : 'on'],
-        )}
+        className={classNames(theme.active[isActive ? 'on' : 'off'], theme.base, theme.href[isLink ? 'on' : 'off'])}
         href={href}
         onClick={onClick}
-        type="button"
+        type={isLink ? undefined : 'button'}
+        {...theirProps}
       >
         {Icon && <Icon aria-hidden className={theme.icon} data-testid="flowbite-list-group-item-icon" />}
         {children}


### PR DESCRIPTION
`ListGroup.Item`s currently have `type="button"` always,
even though they can be an anchor (`<a>`) element
instead. That's changed now.

Also adds `props` since they weren't being passed
in for some reason.

## Breaking changes

None.

## Bug fixes

- [x] [fix(component): Remove type="button" when not a <button>](https://github.com/themesberg/flowbite-react/commit/36e3db8e9af86d5b646ac993865092d5887af247)