### PR TITLE
refactor(tab): adding theme support to component

### DIFF
--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -15,6 +15,7 @@ import type { ModalPositions, ModalSizes } from '../Modal';
 import type { StarSizes } from '../Rating';
 import type { SidebarCTAColors } from '../Sidebar/SidebarCTA';
 import type { SpinnerColors, SpinnerSizes } from '../Spinner';
+import type { TabStyleItem, TabStyles } from '../Tab';
 
 export type CustomFlowbiteTheme = DeepPartial<FlowbiteTheme>;
 
@@ -296,6 +297,19 @@ export interface FlowbiteTheme {
       };
     };
     size: SpinnerSizes;
+  };
+  tab: {
+    base: string;
+    tablist: {
+      base: string;
+      styles: TabStyles;
+      tabitem: {
+        base: string;
+        styles: TabStyleItem<TabStyles>;
+        icon: string;
+      };
+    };
+    tabpanel: string;
   };
   toast: {
     base: string;

--- a/src/lib/components/Tab/TabItem.tsx
+++ b/src/lib/components/Tab/TabItem.tsx
@@ -1,11 +1,10 @@
 import type { ComponentProps, FC, PropsWithChildren, ReactNode } from 'react';
 
-export type TabProps = PropsWithChildren<{
+export interface TabProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'className' | 'title'>> {
   title: ReactNode;
   active?: boolean;
   disabled?: boolean;
   icon?: FC<ComponentProps<'svg'>>;
-  className?: string;
-}>;
+}
 
 export const TabItem: FC<TabProps> = ({ children }) => <>{children}</>;

--- a/src/lib/components/Tab/index.tsx
+++ b/src/lib/components/Tab/index.tsx
@@ -1,49 +1,32 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, KeyboardEvent, PropsWithChildren, ReactElement } from 'react';
 import { Children, useEffect, useId, useMemo, useRef, useState } from 'react';
+import type { FlowbiteBoolean } from '../Flowbite/FlowbiteTheme';
+import { useTheme } from '../Flowbite/ThemeContext';
 import type { TabProps } from './TabItem';
 import { TabItem } from './TabItem';
 
-export type TabStyle = 'default' | 'underline' | 'pills' | 'fullWidth';
+export interface TabStyles {
+  default: string;
+  underline: string;
+  pills: string;
+  fullWidth: string;
+}
+
+export interface TabStyleItemProps {
+  base: string;
+  active: FlowbiteBoolean;
+}
+
+export type TabStyleItem<Type> = {
+  [K in keyof Type]: TabStyleItemProps;
+};
+
 export type TabItemStatus = 'active' | 'notActive';
 
-export const tabGroupStyleClasses: Record<TabStyle, string> = {
-  default: 'flex-wrap border-b border-gray-200 dark:border-gray-700',
-  underline: 'flex-wrap -mb-px',
-  pills: 'flex-wrap font-medium text-sm text-gray-500 dark:text-gray-400',
-  fullWidth:
-    'hidden text-sm font-medium rounded-lg divide-x divide-gray-200 shadow sm:flex dark:divide-gray-700 dark:text-gray-400',
-};
-
-export const tabItemStyleClasses: Record<TabStyle, Record<TabItemStatus, string>> = {
-  default: {
-    active: 'bg-gray-100 text-blue-600 dark:bg-gray-800 dark:text-blue-500',
-    notActive:
-      'text-gray-500 hover:bg-gray-50 hover:text-gray-600 dark:text-gray-400 dark:hover:bg-gray-800  dark:hover:text-gray-300',
-  },
-  underline: {
-    active: 'text-blue-600 rounded-t-lg border-b-2 border-blue-600 active dark:text-blue-500 dark:border-blue-500',
-    notActive:
-      'border-b-2 border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300',
-  },
-  pills: {
-    active: 'rounded-lg bg-blue-600 text-white',
-    notActive: 'rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white',
-  },
-  fullWidth: {
-    active:
-      'inline-block p-4 w-full text-gray-900 bg-gray-100 focus:ring-4 focus:ring-blue-300 active focus:outline-none dark:bg-gray-700 dark:text-white',
-    notActive:
-      'bg-white hover:text-gray-700 hover:bg-gray-50 focus:ring-4 focus:ring-blue-300 focus:outline-none dark:hover:text-white dark:bg-gray-800 dark:hover:bg-gray-700',
-  },
-};
-
-export type TabsProps = PropsWithChildren<
-  ComponentProps<'div'> & {
-    className?: string;
-    style?: TabStyle;
-  }
->;
+export interface TabsProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'className' | 'style'>> {
+  style?: keyof TabStyles;
+}
 
 interface TabEventProps {
   target: number;
@@ -53,7 +36,9 @@ interface TabKeyboardEventProps extends TabEventProps {
   event: KeyboardEvent<HTMLButtonElement>;
 }
 
-export const TabsComponent: FC<TabsProps> = ({ children, className, style = 'default' as TabStyle, ...rest }) => {
+export const TabsComponent: FC<TabsProps> = ({ children, style = 'default', ...rest }) => {
+  const theme = useTheme().theme.tab;
+
   const id = useId();
   const tabs = useMemo(
     () => Children.map(children as ReactElement<PropsWithChildren<TabProps>>[], ({ props }) => props),
@@ -98,13 +83,11 @@ export const TabsComponent: FC<TabsProps> = ({ children, className, style = 'def
   }, [focusedTab]);
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className={theme.base}>
       <div
         aria-label="Tabs"
         role="tablist"
-        className={classNames('flex text-center', tabGroupStyleClasses[style], {
-          'border-b border-gray-200 dark:border-gray-700': style === 'underline',
-        })}
+        className={classNames(theme.tablist.base, theme.tablist.styles[style])}
         {...rest}
       >
         {tabs.map((tab, index) => (
@@ -113,16 +96,10 @@ export const TabsComponent: FC<TabsProps> = ({ children, className, style = 'def
             type="button"
             aria-controls={`${id}-tabpanel-${index}`}
             aria-selected={index === activeTab}
-            className={classNames(
-              'flex items-center justify-center p-4 text-sm font-medium first:ml-0 disabled:cursor-not-allowed disabled:text-gray-400 disabled:dark:text-gray-500',
-              {
-                'ml-2 first:ml-0': style !== 'fullWidth',
-                'rounded-t-lg': style === 'underline' || style === 'default',
-                'w-full first:rounded-l-lg last:rounded-r-lg': style === 'fullWidth',
-                [tabItemStyleClasses[style].active]: index === activeTab,
-                [tabItemStyleClasses[style].notActive]: index !== activeTab && !tab.disabled,
-              },
-            )}
+            className={classNames(theme.tablist.tabitem.base, theme.tablist.tabitem.styles[style], {
+              [theme.tablist.tabitem.styles[style].active.on]: index === activeTab,
+              [theme.tablist.tabitem.styles[style].active.off]: index !== activeTab && !tab.disabled,
+            })}
             disabled={tab.disabled}
             id={`${id}-tab-${index}`}
             onClick={() => handleClick({ target: index })}
@@ -131,7 +108,7 @@ export const TabsComponent: FC<TabsProps> = ({ children, className, style = 'def
             role="tab"
             tabIndex={index === focusedTab ? 0 : -1}
           >
-            {tab.icon && <tab.icon className="mr-2 h-5 w-5" />}
+            {tab.icon && <tab.icon className={theme.tablist.tabitem.icon} />}
             {tab.title}
           </button>
         ))}
@@ -141,7 +118,7 @@ export const TabsComponent: FC<TabsProps> = ({ children, className, style = 'def
           <div
             key={index}
             aria-labelledby={`${id}-tab-${index}`}
-            className={classNames('p-4', className, tab.className)}
+            className={theme.tabpanel}
             hidden={index !== activeTab}
             id={`${id}-tabpanel-${index}`}
             role="tabpanel"

--- a/src/lib/components/Tab/index.tsx
+++ b/src/lib/components/Tab/index.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, KeyboardEvent, PropsWithChildren, ReactElement } from 'react';
 import { Children, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
 import type { FlowbiteBoolean } from '../Flowbite/FlowbiteTheme';
 import { useTheme } from '../Flowbite/ThemeContext';
 import type { TabProps } from './TabItem';
@@ -38,6 +39,7 @@ interface TabKeyboardEventProps extends TabEventProps {
 
 export const TabsComponent: FC<TabsProps> = ({ children, style = 'default', ...rest }) => {
   const theme = useTheme().theme.tab;
+  const theirProps = excludeClassName(rest);
 
   const id = useId();
   const tabs = useMemo(
@@ -88,7 +90,7 @@ export const TabsComponent: FC<TabsProps> = ({ children, style = 'default', ...r
         aria-label="Tabs"
         role="tablist"
         className={classNames(theme.tablist.base, theme.tablist.styles[style])}
-        {...rest}
+        {...theirProps}
       >
         {tabs.map((tab, index) => (
           <button

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -500,6 +500,54 @@ export default {
       xl: 'w-10 h-10',
     },
   },
+  tab: {
+    base: 'flex flex-col gap-2',
+    tablist: {
+      base: 'flex text-center',
+      styles: {
+        default: 'flex-wrap border-b border-gray-200 dark:border-gray-700',
+        underline: 'flex-wrap -mb-px border-b border-gray-200 dark:border-gray-700',
+        pills: 'flex-wrap font-medium text-sm text-gray-500 dark:text-gray-400',
+        fullWidth:
+          'hidden text-sm font-medium rounded-lg divide-x divide-gray-200 shadow sm:flex dark:divide-gray-700 dark:text-gray-400',
+      },
+      tabitem: {
+        base: 'flex items-center justify-center p-4 text-sm font-medium first:ml-0 disabled:cursor-not-allowed disabled:text-gray-400 disabled:dark:text-gray-500',
+        styles: {
+          default: {
+            base: 'rounded-t-lg',
+            active: {
+              on: 'bg-gray-100 text-blue-600 dark:bg-gray-800 dark:text-blue-500',
+              off: 'text-gray-500 hover:bg-gray-50 hover:text-gray-600 dark:text-gray-400 dark:hover:bg-gray-800  dark:hover:text-gray-300',
+            },
+          },
+          underline: {
+            base: 'rounded-t-lg',
+            active: {
+              on: 'text-blue-600 rounded-t-lg border-b-2 border-blue-600 active dark:text-blue-500 dark:border-blue-500',
+              off: 'border-b-2 border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300',
+            },
+          },
+          pills: {
+            base: '',
+            active: {
+              on: 'rounded-lg bg-blue-600 text-white',
+              off: 'rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 dark:hover:text-white',
+            },
+          },
+          fullWidth: {
+            base: 'ml-2 first:ml-0 w-full first:rounded-l-lg last:rounded-r-lg',
+            active: {
+              on: 'inline-block p-4 w-full text-gray-900 bg-gray-100 focus:ring-4 focus:ring-blue-300 active focus:outline-none dark:bg-gray-700 dark:text-white',
+              off: 'bg-white hover:text-gray-700 hover:bg-gray-50 focus:ring-4 focus:ring-blue-300 focus:outline-none dark:hover:text-white dark:bg-gray-800 dark:hover:bg-gray-700',
+            },
+          },
+        },
+        icon: 'mr-2 h-5 w-5',
+      },
+    },
+    tabpanel: 'p-4',
+  },
   toast: {
     base: 'flex w-full max-w-xs items-center rounded-lg bg-white p-4 text-gray-500 shadow dark:bg-gray-800 dark:text-gray-400',
     closed: 'opacity-0 ease-out',


### PR DESCRIPTION
### Breaking changes

**Tab** can be customized using  **<Flowbite theme={..} >**

```
  tab: {
    base: string;
    tablist: {
      base: string;
      styles: TabStyles;
      tabitem: {
        base: string;
        styles: TabStyleItem<TabStyles>;
        icon: string;
      };
    };
    tabpanel: string;
  };
```
