### PR TITLE
refactor(label): adding theme support to label

### DIFF
--- a/src/docs/pages/CardPage.tsx
+++ b/src/docs/pages/CardPage.tsx
@@ -167,15 +167,15 @@ const CardPage: FC = () => {
           <Card>
             <form className="flex flex-col gap-4">
               <div>
-                <Label className="mb-2 block" htmlFor="email1">
-                  Your email
-                </Label>
+                <div className="mb-2 block">
+                  <Label htmlFor="email1" value="Your email" />
+                </div>
                 <TextInput id="email1" type="email" placeholder="name@flowbite.com" required />
               </div>
               <div>
-                <Label className="mb-2 block" htmlFor="password1">
-                  Your password
-                </Label>
+                <div className="mb-2 block">
+                  <Label htmlFor="password1" value="Your password" />
+                </div>
                 <TextInput id="password1" type="password" required />
               </div>
               <div className="flex items-center gap-2">

--- a/src/docs/pages/FormsPage.tsx
+++ b/src/docs/pages/FormsPage.tsx
@@ -15,15 +15,15 @@ const FormsPage: FC = () => {
       code: (
         <form className="flex flex-col gap-4">
           <div>
-            <Label className="mb-2 block" htmlFor="email1">
-              Your email
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="email1" value="Your email" />
+            </div>
             <TextInput id="email1" type="email" placeholder="name@flowbite.com" required />
           </div>
           <div>
-            <Label className="mb-2 block" htmlFor="password1">
-              Your password
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="password1" value="Your password" />
+            </div>
             <TextInput id="password1" type="password" required />
           </div>
           <div className="flex items-center gap-2">
@@ -39,21 +39,21 @@ const FormsPage: FC = () => {
       code: (
         <div className="flex flex-col gap-4">
           <div>
-            <Label className="mb-2 block" htmlFor="small">
-              Small input
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="small" value="Small input" />
+            </div>
             <TextInput id="small" type="text" sizing="sm" />
           </div>
           <div>
-            <Label className="mb-2 block" htmlFor="base">
-              Base input
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="base" value="Base input" />
+            </div>
             <TextInput id="base" type="text" sizing="md" />
           </div>
           <div>
-            <Label className="mb-2 block" htmlFor="large">
-              Large input
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="large" value="Large input" />
+            </div>
             <TextInput id="large" type="text" sizing="lg" />
           </div>
         </div>
@@ -75,21 +75,21 @@ const FormsPage: FC = () => {
       code: (
         <form className="flex flex-col gap-4">
           <div>
-            <Label className="mb-2 block" htmlFor="email2">
-              Your email
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="email2" value="Your email" />
+            </div>
             <TextInput id="email2" type="email" placeholder="name@flowbite.com" required shadow />
           </div>
           <div>
-            <Label className="mb-2 block" htmlFor="password2">
-              Your password
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="password2" value="Your password" />
+            </div>
             <TextInput id="password2" type="password" required shadow />
           </div>
           <div>
-            <Label className="mb-2 block" htmlFor="repeat-password">
-              Repeat password
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="repeat-password" value="Repeat password" />
+            </div>
             <TextInput id="repeat-password" type="password" required shadow />
           </div>
           <div className="flex items-center gap-2">
@@ -109,9 +109,9 @@ const FormsPage: FC = () => {
       title: 'Helper text',
       code: (
         <div>
-          <Label className="mb-2 block" htmlFor="email3">
-            Your email
-          </Label>
+          <div className="mb-2 block">
+            <Label htmlFor="email3" value="Your email" />
+          </div>
           <TextInput
             id="email3"
             type="email"
@@ -134,9 +134,9 @@ const FormsPage: FC = () => {
       title: 'Input element with icon',
       code: (
         <div>
-          <Label className="mb-2 block" htmlFor="email4">
-            Your email
-          </Label>
+          <div className="mb-2 block">
+            <Label htmlFor="email4" value="Your email" />
+          </div>
           <TextInput id="email4" type="email" placeholder="name@flowbite.com" required icon={HiMail} />
         </div>
       ),
@@ -145,9 +145,9 @@ const FormsPage: FC = () => {
       title: 'Input element with addon',
       code: (
         <div>
-          <Label className="mb-2 block" htmlFor="username">
-            Username
-          </Label>
+          <div className="mb-2 block">
+            <Label htmlFor="username" value="Username" />
+          </div>
           <TextInput id="username3" placeholder="Bonnie Green" required addon="@" />
         </div>
       ),
@@ -157,9 +157,9 @@ const FormsPage: FC = () => {
       code: (
         <div className="flex flex-col gap-4">
           <div>
-            <Label className="mb-2 block" htmlFor="username3" color="green">
-              Your name
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="username3" color="green" value="Your name" />
+            </div>
             <TextInput
               id="username"
               placeholder="Bonnie Green"
@@ -173,9 +173,9 @@ const FormsPage: FC = () => {
             />
           </div>
           <div>
-            <Label className="mb-2 block" htmlFor="username4" color="red">
-              Your name
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="username4" color="red" value="Your name" />
+            </div>
             <TextInput
               id="username4"
               placeholder="Bonnie Green"
@@ -195,9 +195,9 @@ const FormsPage: FC = () => {
       title: 'Textarea',
       code: (
         <div id="textarea">
-          <Label className="mb-2 block" htmlFor="comment">
-            Your message
-          </Label>
+          <div className="mb-2 block">
+            <Label htmlFor="comment" value="Your message" />
+          </div>
           <Textarea id="comment" placeholder="Leave a comment..." required rows={4} />
         </div>
       ),
@@ -206,9 +206,9 @@ const FormsPage: FC = () => {
       title: 'Select input',
       code: (
         <div id="select">
-          <Label className="mb-2 block" htmlFor="countries">
-            Select your country
-          </Label>
+          <div className="mb-2 block">
+            <Label htmlFor="countries" value="Select your country" />
+          </div>
           <Select id="countries" required>
             <option>United States</option>
             <option>Canada</option>
@@ -255,7 +255,7 @@ const FormsPage: FC = () => {
           </div>
           <div className="flex items-center gap-2">
             <Checkbox id="disabled" disabled />
-            <Label htmlFor="disabled" className="opacity-50">
+            <Label htmlFor="disabled" disabled>
               Eligible for international shipping (disabled)
             </Label>
           </div>
@@ -285,7 +285,7 @@ const FormsPage: FC = () => {
           </div>
           <div className="flex items-center gap-2">
             <Radio id="china" name="countries" value="China" disabled />
-            <Label className="opacity-50" htmlFor="china">
+            <Label htmlFor="china" disabled>
               China (disabled)
             </Label>
           </div>
@@ -296,9 +296,9 @@ const FormsPage: FC = () => {
       title: 'File upload',
       code: (
         <div id="fileUpload">
-          <Label className="mb-2 block" htmlFor="file">
-            Upload file
-          </Label>
+          <div className="mb-2 block">
+            <Label htmlFor="file" value="Upload file" />
+          </div>
           <FileInput id="file" helperText="A profile picture is useful to confirm your are logged into your account" />
         </div>
       ),

--- a/src/docs/pages/ModalPage.tsx
+++ b/src/docs/pages/ModalPage.tsx
@@ -79,9 +79,9 @@ const ModalPage: FC = () => {
               <div className="space-y-6 px-6 pb-4 sm:pb-6 lg:px-8 xl:pb-8">
                 <h3 className="text-xl font-medium text-gray-900 dark:text-white">Sign in to our platform</h3>
                 <div>
-                  <Label className="mb-2 block" htmlFor="email">
-                    Your email
-                  </Label>
+                  <div className="mb-2 block">
+                    <Label htmlFor="email" value="Your email" />
+                  </div>
                   <TextInput
                     id="email"
                     className="dark:border-gray-500 dark:bg-gray-600"
@@ -90,9 +90,9 @@ const ModalPage: FC = () => {
                   />
                 </div>
                 <div>
-                  <Label className="mb-2 block" htmlFor="password">
-                    Your password
-                  </Label>
+                  <div className="mb-2 block">
+                    <Label htmlFor="password" value="Your password" />
+                  </div>
                   <TextInput id="password" className="dark:border-gray-500 dark:bg-gray-600" type="password" required />
                 </div>
                 <div className="flex justify-between">

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -10,7 +10,7 @@ import type {
   ButtonSizes,
 } from '../Button';
 import type { PositionInButtonGroup } from '../Button/ButtonGroup';
-import type { HelperColors } from '../FormControls/HelperText';
+import type { HelperColors, LabelColors } from '../FormControls';
 import type { ModalPositions, ModalSizes } from '../Modal';
 import type { StarSizes } from '../Rating';
 import type { SidebarCTAColors } from '../Sidebar/SidebarCTA';
@@ -160,6 +160,11 @@ export interface FlowbiteTheme {
     helperText: {
       base: string;
       colors: HelperColors;
+    };
+    label: {
+      base: string;
+      colors: LabelColors;
+      disabled: string;
     };
   };
   listGroup: {
@@ -348,34 +353,36 @@ export interface FlowbiteBoolean {
   on: string;
 }
 
-export interface FlowbiteColors {
+export interface FlowbiteStateColors {
+  info: string;
+  failure: string;
+  success: string;
+  warning: string;
+}
+
+export interface FlowbiteColors extends FlowbiteStateColors {
+  [key: string]: string;
   blue: string;
   cyan: string;
   dark: string;
-  failure: string;
   gray: string;
   green: string;
   indigo: string;
-  info: string;
   light: string;
   lime: string;
   pink: string;
   purple: string;
   red: string;
-  success: string;
   teal: string;
-  warning: string;
   yellow: string;
 }
 
-export interface FlowbiteGradientColors {
+export interface FlowbiteGradientColors extends Omit<FlowbiteStateColors, 'warning'> {
+  [key: string]: string;
   cyan: string;
-  failure: string;
-  info: string;
   lime: string;
   pink: string;
   purple: string;
-  success: string;
   teal: string;
 }
 

--- a/src/lib/components/FormControls/Label.tsx
+++ b/src/lib/components/FormControls/Label.tsx
@@ -1,22 +1,29 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import type { FlowbiteStateColors } from '../Flowbite/FlowbiteTheme';
+import { useTheme } from '../Flowbite/ThemeContext';
 
-type Color = 'gray' | 'green' | 'red';
-
-export interface LabelProps extends PropsWithChildren<ComponentProps<'label'>> {
-  color?: Color;
-  value?: string;
+export interface LabelColors extends FlowbiteStateColors {
+  [key: string]: string;
+  default: string;
 }
 
-const colorClasses: Record<Color, string> = {
-  gray: 'text-gray-900 dark:text-gray-300',
-  green: 'text-green-700 dark:text-green-500',
-  red: 'text-red-700 dark:text-red-500',
-};
+export interface LabelProps extends PropsWithChildren<Omit<ComponentProps<'label'>, 'className' | 'color'>> {
+  color?: keyof LabelColors;
+  value?: string;
+  disabled?: boolean;
+}
 
-export const Label: FC<LabelProps> = ({ children, color = 'gray', className, value, ...props }): JSX.Element => {
+export const Label: FC<LabelProps> = ({
+  children,
+  color = 'default',
+  disabled = false,
+  value,
+  ...props
+}): JSX.Element => {
+  const theme = useTheme().theme.formControls.label;
   return (
-    <label className={classNames('text-sm font-medium', colorClasses[color], className)} {...props}>
+    <label className={classNames(theme.base, theme.colors[color], disabled ?? theme.disabled)} {...props}>
       {value ?? children ?? ''}
     </label>
   );

--- a/src/lib/components/FormControls/Label.tsx
+++ b/src/lib/components/FormControls/Label.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
 import type { FlowbiteStateColors } from '../Flowbite/FlowbiteTheme';
 import { useTheme } from '../Flowbite/ThemeContext';
 
@@ -22,8 +23,9 @@ export const Label: FC<LabelProps> = ({
   ...props
 }): JSX.Element => {
   const theme = useTheme().theme.formControls.label;
+  const theirProps = excludeClassName(props);
   return (
-    <label className={classNames(theme.base, theme.colors[color], disabled ?? theme.disabled)} {...props}>
+    <label className={classNames(theme.base, theme.colors[color], disabled ?? theme.disabled)} {...theirProps}>
       {value ?? children ?? ''}
     </label>
   );

--- a/src/lib/components/Modal/Modal.stories.tsx
+++ b/src/lib/components/Modal/Modal.stories.tsx
@@ -86,9 +86,9 @@ FormElements.args = {
         <div className="space-y-6 px-6 pb-4 sm:pb-6 lg:px-8 xl:pb-8">
           <h3 className="text-xl font-medium text-gray-900 dark:text-white">Sign in to our platform</h3>
           <div>
-            <Label className="mb-2 block" htmlFor="email">
-              Your email
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="email" value="Your email" />
+            </div>
             <TextInput
               id="email"
               className="dark:border-gray-500 dark:bg-gray-600"
@@ -97,9 +97,9 @@ FormElements.args = {
             />
           </div>
           <div>
-            <Label className="mb-2 block" htmlFor="password">
-              Your password
-            </Label>
+            <div className="mb-2 block">
+              <Label htmlFor="password" value="Your password" />
+            </div>
             <TextInput id="password" className="dark:border-gray-500 dark:bg-gray-600" type="password" required />
           </div>
           <div className="flex justify-between">

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -275,6 +275,17 @@ export default {
         warning: 'text-yellow-500 dark:text-yellow-600',
       },
     },
+    label: {
+      base: 'text-sm font-medium',
+      colors: {
+        default: 'text-gray-900 dark:text-gray-300',
+        info: 'text-blue-500 dark:text-blue-600',
+        failure: 'text-red-700 dark:text-red-500',
+        warning: 'text-yellow-500 dark:text-yellow-600',
+        success: 'text-green-700 dark:text-green-500',
+      },
+      disabled: 'opacity-50',
+    },
   },
   listGroup: {
     base: 'list-none rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white',


### PR DESCRIPTION
### Breaking changes

**Label** can be customized using  **<Flowbite theme={..} >**

```
  formControls: {
    label: {
      base: string;
      colors: LabelColors;
      disabled: string;
    };
  };
```

This is part of the #136 