### PR TITLE
refactor(radio): adding theme support to component

### DIFF
--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -166,6 +166,9 @@ export interface FlowbiteTheme {
       colors: LabelColors;
       disabled: string;
     };
+    radio: {
+      base: string;
+    };
   };
   listGroup: {
     base: string;

--- a/src/lib/components/FormControls/Radio.tsx
+++ b/src/lib/components/FormControls/Radio.tsx
@@ -1,15 +1,9 @@
-import classNames from 'classnames';
 import type { ComponentProps, FC } from 'react';
+import { useTheme } from '../Flowbite/ThemeContext';
 
-export type RadioProps = Omit<ComponentProps<'input'>, 'type'>;
+export type RadioProps = Omit<ComponentProps<'input'>, 'type' | 'className'>;
 
-export const Radio: FC<RadioProps> = ({ className, ...props }) => (
-  <input
-    className={classNames(
-      'h-4 w-4 border border-gray-300 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:focus:bg-blue-600 dark:focus:ring-blue-600',
-      className,
-    )}
-    type="radio"
-    {...props}
-  />
-);
+export const Radio: FC<RadioProps> = (props) => {
+  const theme = useTheme().theme.formControls.radio;
+  return <input className={theme.base} type="radio" {...props} />;
+};

--- a/src/lib/components/FormControls/Radio.tsx
+++ b/src/lib/components/FormControls/Radio.tsx
@@ -1,9 +1,11 @@
 import type { ComponentProps, FC } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
 import { useTheme } from '../Flowbite/ThemeContext';
 
 export type RadioProps = Omit<ComponentProps<'input'>, 'type' | 'className'>;
 
 export const Radio: FC<RadioProps> = (props) => {
   const theme = useTheme().theme.formControls.radio;
-  return <input className={theme.base} type="radio" {...props} />;
+  const theirProps = excludeClassName(props);
+  return <input className={theme.base} type="radio" {...theirProps} />;
 };

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -286,6 +286,9 @@ export default {
       },
       disabled: 'opacity-50',
     },
+    radio: {
+      base: 'h-4 w-4 border border-gray-300 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:focus:bg-blue-600 dark:focus:ring-blue-600',
+    },
   },
   listGroup: {
     base: 'list-none rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white',


### PR DESCRIPTION
### Breaking changes

**Radio** can be customized using  **<Flowbite theme={..} >**

```
  formControls: {
    radio: {
      base: string;
    };
  };
```

This is part of the #136 