### PR TITLE
refactor(checkbox): adding theme support to component

### DIFF
--- a/src/docs/pages/ModalPage.tsx
+++ b/src/docs/pages/ModalPage.tsx
@@ -97,7 +97,7 @@ const ModalPage: FC = () => {
                 </div>
                 <div className="flex justify-between">
                   <div className="flex items-center gap-2">
-                    <Checkbox id="remember" className="dark:border-gray-500 dark:bg-gray-600" />
+                    <Checkbox id="remember" />
                     <Label htmlFor="remember">Remember me</Label>
                   </div>
                   <a href="/modal" className="text-sm text-blue-700 hover:underline dark:text-blue-500">

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -169,6 +169,9 @@ export interface FlowbiteTheme {
     radio: {
       base: string;
     };
+    checkbox: {
+      base: string;
+    };
   };
   listGroup: {
     base: string;

--- a/src/lib/components/FormControls/Checkbox.tsx
+++ b/src/lib/components/FormControls/Checkbox.tsx
@@ -1,15 +1,9 @@
-import classNames from 'classnames';
 import type { ComponentProps, FC } from 'react';
+import { useTheme } from '../Flowbite/ThemeContext';
 
-export type CheckboxProps = Omit<ComponentProps<'input'>, 'type'>;
+export type CheckboxProps = Omit<ComponentProps<'input'>, 'type' | 'className'>;
 
-export const Checkbox: FC<CheckboxProps> = ({ className, ...props }) => (
-  <input
-    className={classNames(
-      'h-4 w-4 rounded border border-gray-300 bg-gray-100 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800 dark:focus:ring-blue-600',
-      className,
-    )}
-    type="checkbox"
-    {...props}
-  />
-);
+export const Checkbox: FC<CheckboxProps> = (props) => {
+  const theme = useTheme().theme.formControls.checkbox;
+  return <input className={theme.base} type="checkbox" {...props} />;
+};

--- a/src/lib/components/FormControls/Checkbox.tsx
+++ b/src/lib/components/FormControls/Checkbox.tsx
@@ -1,9 +1,11 @@
 import type { ComponentProps, FC } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
 import { useTheme } from '../Flowbite/ThemeContext';
 
 export type CheckboxProps = Omit<ComponentProps<'input'>, 'type' | 'className'>;
 
 export const Checkbox: FC<CheckboxProps> = (props) => {
   const theme = useTheme().theme.formControls.checkbox;
-  return <input className={theme.base} type="checkbox" {...props} />;
+  const theirProps = excludeClassName(props);
+  return <input className={theme.base} type="checkbox" {...theirProps} />;
 };

--- a/src/lib/components/Modal/Modal.stories.tsx
+++ b/src/lib/components/Modal/Modal.stories.tsx
@@ -104,7 +104,7 @@ FormElements.args = {
           </div>
           <div className="flex justify-between">
             <div className="flex items-center gap-2">
-              <Checkbox id="remember" className="dark:border-gray-500 dark:bg-gray-600" />
+              <Checkbox id="remember" />
               <Label htmlFor="remember">Remember me</Label>
             </div>
             <a href="/modal" className="text-sm text-blue-700 hover:underline dark:text-blue-500">

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -289,6 +289,9 @@ export default {
     radio: {
       base: 'h-4 w-4 border border-gray-300 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:focus:bg-blue-600 dark:focus:ring-blue-600',
     },
+    checkbox: {
+      base: 'h-4 w-4 rounded border border-gray-300 bg-gray-100 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800 dark:focus:ring-blue-600',
+    },
   },
   listGroup: {
     base: 'list-none rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white',


### PR DESCRIPTION
### Breaking changes

**Checkbox** can be customized using  **<Flowbite theme={..} >**

```
  formControls: {
    checkbox: {
      base: string;
    };
  };
```

This is part of the #136 