### PR TITLE
feat(component): adding helpertext component

### DIFF
--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -10,6 +10,7 @@ import type {
   ButtonSizes,
 } from '../Button';
 import type { PositionInButtonGroup } from '../Button/ButtonGroup';
+import type { HelperColors } from '../FormControls/HelperText';
 import type { ModalPositions, ModalSizes } from '../Modal';
 import type { StarSizes } from '../Rating';
 import type { SidebarCTAColors } from '../Sidebar/SidebarCTA';
@@ -153,6 +154,12 @@ export interface FlowbiteTheme {
   darkThemeToggle: {
     base: string;
     icon: string;
+  };
+  formControls: {
+    helperText: {
+      base: string;
+      colors: HelperColors;
+    };
   };
   listGroup: {
     base: string;

--- a/src/lib/components/FormControls/HelperText.spec.tsx
+++ b/src/lib/components/FormControls/HelperText.spec.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import { describe, it } from 'vitest';
+import HelperText from './HelperText';
+
+describe.concurrent('Components / Form controls / Helper text', () => {
+  it('should render', () => {
+    render(<HelperText />);
+  });
+});

--- a/src/lib/components/FormControls/HelperText.tsx
+++ b/src/lib/components/FormControls/HelperText.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
 import type { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
 import { useTheme } from '../Flowbite/ThemeContext';
 
@@ -12,9 +13,14 @@ export interface HelperTextProps extends PropsWithChildren<Omit<ComponentProps<'
   value?: string;
 }
 
-const HelperText: FC<HelperTextProps> = ({ value, children, color = 'default' }) => {
+const HelperText: FC<HelperTextProps> = ({ value, children, color = 'default', ...props }) => {
   const theme = useTheme().theme.formControls.helperText;
-  return <p className={classNames(theme.base, theme.colors[color])}>{value ?? children ?? ''}</p>;
+  const theirProps = excludeClassName(props);
+  return (
+    <p className={classNames(theme.base, theme.colors[color])} {...theirProps}>
+      {value ?? children ?? ''}
+    </p>
+  );
 };
 
 export default HelperText;

--- a/src/lib/components/FormControls/HelperText.tsx
+++ b/src/lib/components/FormControls/HelperText.tsx
@@ -1,0 +1,20 @@
+import classNames from 'classnames';
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import type { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
+import { useTheme } from '../Flowbite/ThemeContext';
+
+export interface HelperColors extends Pick<FlowbiteColors, 'gray' | 'info' | 'failure' | 'warning' | 'success'> {
+  [key: string]: string;
+}
+
+export interface HelperTextProps extends PropsWithChildren<Omit<ComponentProps<'p'>, 'className'>> {
+  color?: string;
+  value?: string;
+}
+
+const HelperText: FC<HelperTextProps> = ({ value, children, color = 'default' }) => {
+  const theme = useTheme().theme.formControls.helperText;
+  return <p className={classNames(theme.base, theme.colors[color])}>{value ?? children ?? ''}</p>;
+};
+
+export default HelperText;

--- a/src/lib/components/FormControls/index.ts
+++ b/src/lib/components/FormControls/index.ts
@@ -1,5 +1,6 @@
 export * from './Checkbox';
 export * from './FileInput';
+export * from './HelperText';
 export * from './Label';
 export * from './Radio';
 export * from './Select';

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -264,6 +264,18 @@ export default {
     base: 'rounded-lg p-2.5 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-700',
     icon: 'h-5 w-5',
   },
+  formControls: {
+    helperText: {
+      base: 'mt-2 text-sm',
+      colors: {
+        gray: 'text-gray-500 dark:text-gray-400',
+        info: 'text-blue-700 dark:text-blue-800',
+        success: 'text-green-600 dark:text-green-500',
+        failure: 'text-red-600 dark:text-red-500',
+        warning: 'text-yellow-500 dark:text-yellow-600',
+      },
+    },
+  },
   listGroup: {
     base: 'list-none rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white',
     item: {


### PR DESCRIPTION
This is a new component that will help us with #136. It should remove some code duplication.

## Theme configuration

```
  formControls: {
    helperText: {
      base: string;
      colors: HelperColors;
    };
  };
```