### PR TITLE
refactor(toggleSwitch): adding theme support to component

### DIFF
--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -172,6 +172,15 @@ export interface FlowbiteTheme {
     checkbox: {
       base: string;
     };
+    toggleSwitch: {
+      base: string;
+      active: FlowbiteBoolean;
+      toggle: {
+        base: string;
+        checked: FlowbiteBoolean;
+      };
+      label: string;
+    };
   };
   listGroup: {
     base: string;

--- a/src/lib/components/FormControls/ToggleSwitch.tsx
+++ b/src/lib/components/FormControls/ToggleSwitch.tsx
@@ -1,22 +1,16 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, KeyboardEvent, MouseEvent } from 'react';
 import { useId } from 'react';
+import { useTheme } from '../Flowbite/ThemeContext';
 
-export type ToggleSwitchProps = Omit<ComponentProps<'button'>, 'onChange'> & {
+export type ToggleSwitchProps = Omit<ComponentProps<'button'>, 'onChange' | 'className'> & {
   checked: boolean;
   label: string;
   onChange: (checked: boolean) => void;
 };
 
-export const ToggleSwitch: FC<ToggleSwitchProps> = ({
-  checked,
-  className,
-  disabled,
-  label,
-  name,
-  onChange,
-  ...props
-}) => {
+export const ToggleSwitch: FC<ToggleSwitchProps> = ({ checked, disabled, label, name, onChange, ...props }) => {
+  const theme = useTheme().theme.formControls.toggleSwitch;
   const id = useId();
 
   const toggle = (): void => onChange(!checked);
@@ -43,28 +37,14 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
         role="switch"
         tabIndex={0}
         type="button"
-        className={classNames(
-          'group relative flex items-center rounded-lg focus:outline-none',
-          {
-            'cursor-not-allowed opacity-50': disabled,
-            'cursor-pointer': !disabled,
-          },
-          className,
-        )}
+        className={classNames(theme.base, theme.active[disabled ? 'off' : 'on'])}
         {...props}
       >
-        <div
-          className={classNames(
-            'toggle-bg h-6 w-11 rounded-full border group-focus:ring-4 group-focus:ring-blue-500/25',
-            checked
-              ? 'border-blue-700 bg-blue-700 after:translate-x-full after:border-white'
-              : 'border-gray-200 bg-gray-200 dark:border-gray-600 dark:bg-gray-700',
-          )}
-        />
+        <div className={classNames(theme.toggle.base, theme.toggle.checked[checked ? 'on' : 'off'])} />
         <span
           data-testid="flowbite-toggleswitch-label"
           id={`${id}-flowbite-toggleswitch-label`}
-          className="ml-3 text-sm font-medium text-gray-900 dark:text-gray-300"
+          className={theme.label}
         >
           {label}
         </span>

--- a/src/lib/components/FormControls/ToggleSwitch.tsx
+++ b/src/lib/components/FormControls/ToggleSwitch.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, KeyboardEvent, MouseEvent } from 'react';
 import { useId } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
 import { useTheme } from '../Flowbite/ThemeContext';
 
 export type ToggleSwitchProps = Omit<ComponentProps<'button'>, 'onChange' | 'className'> & {
@@ -11,6 +12,7 @@ export type ToggleSwitchProps = Omit<ComponentProps<'button'>, 'onChange' | 'cla
 
 export const ToggleSwitch: FC<ToggleSwitchProps> = ({ checked, disabled, label, name, onChange, ...props }) => {
   const theme = useTheme().theme.formControls.toggleSwitch;
+  const theirProps = excludeClassName(props);
   const id = useId();
 
   const toggle = (): void => onChange(!checked);
@@ -38,7 +40,7 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({ checked, disabled, label, 
         tabIndex={0}
         type="button"
         className={classNames(theme.base, theme.active[disabled ? 'off' : 'on'])}
-        {...props}
+        {...theirProps}
       >
         <div className={classNames(theme.toggle.base, theme.toggle.checked[checked ? 'on' : 'off'])} />
         <span

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -292,6 +292,21 @@ export default {
     checkbox: {
       base: 'h-4 w-4 rounded border border-gray-300 bg-gray-100 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800 dark:focus:ring-blue-600',
     },
+    toggleSwitch: {
+      base: 'group relative flex items-center rounded-lg focus:outline-none',
+      active: {
+        on: 'cursor-pointer',
+        off: 'cursor-not-allowed opacity-50',
+      },
+      toggle: {
+        base: 'toggle-bg h-6 w-11 rounded-full border group-focus:ring-4 group-focus:ring-blue-500/25',
+        checked: {
+          on: 'border-blue-700 bg-blue-700 after:translate-x-full after:border-white',
+          off: 'border-gray-200 bg-gray-200 dark:border-gray-600 dark:bg-gray-700',
+        },
+      },
+      label: 'ml-3 text-sm font-medium text-gray-900 dark:text-gray-300',
+    },
   },
   listGroup: {
     base: 'list-none rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white',


### PR DESCRIPTION
### Breaking changes

**ToggleSwitch** can be customized using  **<Flowbite theme={..} >**

```
  formControls: {
    toggleSwitch: {
      base: string;
      active: FlowbiteBoolean;
      toggle: {
        base: string;
        checked: FlowbiteBoolean;
      };
      label: string;
    };
  };
```

This is part of the #136 