### PR TITLE
fix(carousel): carousel size depends on parent size

### DIFF
--- a/src/docs/pages/CarouselPage.tsx
+++ b/src/docs/pages/CarouselPage.tsx
@@ -8,55 +8,63 @@ const CarouselPage: FC = () => {
     {
       title: 'Default carousel',
       code: (
-        <Carousel>
-          <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-3.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-4.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-5.svg" alt="..." />
-        </Carousel>
+        <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
+          <Carousel>
+            <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-3.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-4.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-5.svg" alt="..." />
+          </Carousel>
+        </div>
       ),
     },
     {
       title: 'Sliding interval',
       code: (
-        <Carousel slideInterval={5000}>
-          <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-3.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-4.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-5.svg" alt="..." />
-        </Carousel>
+        <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
+          <Carousel slideInterval={5000}>
+            <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-3.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-4.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-5.svg" alt="..." />
+          </Carousel>
+        </div>
       ),
     },
     {
       title: 'Static carousel',
       code: (
-        <Carousel slide={false}>
-          <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-3.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-4.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-5.svg" alt="..." />
-        </Carousel>
+        <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
+          <Carousel slide={false}>
+            <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-3.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-4.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-5.svg" alt="..." />
+          </Carousel>
+        </div>
       ),
     },
     {
       title: 'Custom Controls',
       code: (
-        <Carousel leftControl="left" rightControl="right">
-          <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-3.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-4.svg" alt="..." />
-          <img src="https://flowbite.com/docs/images/carousel/carousel-5.svg" alt="..." />
-        </Carousel>
+        <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
+          <Carousel leftControl="left" rightControl="right">
+            <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-3.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-4.svg" alt="..." />
+            <img src="https://flowbite.com/docs/images/carousel/carousel-5.svg" alt="..." />
+          </Carousel>
+        </div>
       ),
     },
     {
       title: 'Indicators',
       code: (
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid h-56 grid-cols-2 gap-4 sm:h-64 xl:h-80 2xl:h-96">
           <Carousel>
             <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
             <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
@@ -77,17 +85,19 @@ const CarouselPage: FC = () => {
     {
       title: 'Slide as anything',
       code: (
-        <Carousel>
-          <div className="flex h-full items-center justify-center bg-gray-400 dark:bg-gray-700 dark:text-white">
-            Slide 1
-          </div>
-          <div className="flex h-full items-center justify-center bg-gray-400 dark:bg-gray-700 dark:text-white">
-            Slide 2
-          </div>
-          <div className="flex h-full items-center justify-center bg-gray-400 dark:bg-gray-700 dark:text-white">
-            Slide 3
-          </div>
-        </Carousel>
+        <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
+          <Carousel>
+            <div className="flex h-full items-center justify-center bg-gray-400 dark:bg-gray-700 dark:text-white">
+              Slide 1
+            </div>
+            <div className="flex h-full items-center justify-center bg-gray-400 dark:bg-gray-700 dark:text-white">
+              Slide 2
+            </div>
+            <div className="flex h-full items-center justify-center bg-gray-400 dark:bg-gray-700 dark:text-white">
+              Slide 3
+            </div>
+          </Carousel>
+        </div>
       ),
     },
   ];

--- a/src/lib/components/Carousel/Carousel.stories.tsx
+++ b/src/lib/components/Carousel/Carousel.stories.tsx
@@ -8,13 +8,15 @@ export default {
 } as Meta;
 
 const Template: Story<CarouselProps> = (args) => (
-  <Carousel {...args}>
-    <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
-    <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
-    <img src="https://flowbite.com/docs/images/carousel/carousel-3.svg" alt="..." />
-    <img src="https://flowbite.com/docs/images/carousel/carousel-4.svg" alt="..." />
-    <img src="https://flowbite.com/docs/images/carousel/carousel-5.svg" alt="..." />
-  </Carousel>
+  <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
+    <Carousel {...args}>
+      <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
+      <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
+      <img src="https://flowbite.com/docs/images/carousel/carousel-3.svg" alt="..." />
+      <img src="https://flowbite.com/docs/images/carousel/carousel-4.svg" alt="..." />
+      <img src="https://flowbite.com/docs/images/carousel/carousel-5.svg" alt="..." />
+    </Carousel>
+  </div>
 );
 
 export const Default = Template.bind({});

--- a/src/lib/components/Carousel/index.tsx
+++ b/src/lib/components/Carousel/index.tsx
@@ -34,9 +34,9 @@ export const Carousel: FC<CarouselProps> = ({
 
   const items = useMemo(
     () =>
-      Children.map(children as ReactElement<ComponentProps<'img'>>[], (child: ReactElement<ComponentProps<'img'>>) =>
+      Children.map(children as ReactElement[], (child: ReactElement) =>
         cloneElement(child, {
-          className: theme.item.base,
+          className: classNames(theme.item.base, child.props.className),
         }),
       ),
     [children, theme.item.base],

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -240,7 +240,7 @@ export default {
     },
   },
   carousel: {
-    base: 'relative h-full w-full h-56 sm:h-64 xl:h-80 2xl:h-96',
+    base: 'relative h-full w-full',
     indicators: {
       active: {
         off: 'bg-white/50 hover:bg-white dark:bg-gray-800/50 dark:hover:bg-gray-800',


### PR DESCRIPTION
## Description

This should fix the issue with the `Carousel` component. Now, it respects the size of his parent object, which allows to the user to have more flexibility over the component size and responsiveness.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Breaking changes

The `Carousel` must be wrapped with some `div` that must determine its size.

## How Has This Been Tested?

- [X] Unit test (without any changes)
- [X] Storybook
- [X] Example page at the documentation

**Test Configuration**:

- Brave Browser

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
