### PR TITLE
refactor(textarea): adds theme support to textarea component

### DIFF
--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -10,7 +10,7 @@ import type {
   ButtonSizes,
 } from '../Button';
 import type { PositionInButtonGroup } from '../Button/ButtonGroup';
-import type { HelperColors, LabelColors, TextInputColors, TextInputSizes } from '../FormControls';
+import type { HelperColors, LabelColors, TextareaColors, TextInputColors, TextInputSizes } from '../FormControls';
 import type { ModalPositions, ModalSizes } from '../Modal';
 import type { ProgressColor, ProgressSizes } from '../Progress';
 import type { StarSizes } from '../Rating';
@@ -212,6 +212,11 @@ export interface FlowbiteTheme {
       };
       label: string;
     };
+    textarea: {
+      base: string;
+      colors: TextareaColors;
+      withShadow: FlowbiteBoolean;
+    }
   };
   listGroup: {
     base: string;

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -216,7 +216,7 @@ export interface FlowbiteTheme {
       base: string;
       colors: TextareaColors;
       withShadow: FlowbiteBoolean;
-    }
+    };
   };
   listGroup: {
     base: string;

--- a/src/lib/components/FormControls/Textarea.tsx
+++ b/src/lib/components/FormControls/Textarea.tsx
@@ -5,16 +5,14 @@ import type { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
 import { useTheme } from '../Flowbite/ThemeContext';
 import HelperText from './HelperText';
 
-type Color = 'base' | 'green' | 'red';
-
 export interface TextareaColors extends Pick<FlowbiteColors, 'gray' | 'info' | 'failure' | 'warning' | 'success'> {
   [key: string]: string;
 }
 
-export interface TextareaProps extends Omit<ComponentProps<'textarea'>, 'className'> {
+export interface TextareaProps extends Omit<ComponentProps<'textarea'>, 'className' | 'color'> {
   shadow?: boolean;
   helperText?: ReactNode;
-  color?: Color;
+  color?: keyof TextareaColors;
 }
 
 

--- a/src/lib/components/FormControls/Textarea.tsx
+++ b/src/lib/components/FormControls/Textarea.tsx
@@ -15,18 +15,13 @@ export interface TextareaProps extends Omit<ComponentProps<'textarea'>, 'classNa
   color?: keyof TextareaColors;
 }
 
-
 export const Textarea: FC<TextareaProps> = ({ shadow, helperText, color = 'gray', ...props }) => {
   const theme = useTheme().theme.formControls.textarea;
   const theirProps = excludeClassName(props)
   return (
     <>
-      <textarea
-        className={classNames(
-          theme.base,
-          theme.colors[color],
-          theme.withShadow[shadow ? 'on' : 'off']
-        )}
+      <textarea 
+        className={classNames(theme.base, theme.colors[color], theme.withShadow[shadow ? 'on' : 'off'])}
         {...theirProps}
       />
       {helperText && <HelperText color={color}>{helperText}</HelperText>}
@@ -34,4 +29,4 @@ export const Textarea: FC<TextareaProps> = ({ shadow, helperText, color = 'gray'
   )
 };
 
-Textarea.displayName = "Textarea";
+Textarea.displayName = 'Textarea';

--- a/src/lib/components/FormControls/Textarea.tsx
+++ b/src/lib/components/FormControls/Textarea.tsx
@@ -1,45 +1,39 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, ReactNode } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
+import type { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
+import { useTheme } from '../Flowbite/ThemeContext';
+import HelperText from './HelperText';
 
 type Color = 'base' | 'green' | 'red';
 
-export type TextareaProps = ComponentProps<'textarea'> & {
+export interface TextareaColors extends Pick<FlowbiteColors, 'gray' | 'info' | 'failure' | 'warning' | 'success'> {
+  [key: string]: string;
+}
+
+export interface TextareaProps extends Omit<ComponentProps<'textarea'>, 'className'> {
   shadow?: boolean;
   helperText?: ReactNode;
   color?: Color;
+}
+
+
+export const Textarea: FC<TextareaProps> = ({ shadow, helperText, color = 'gray', ...props }) => {
+  const theme = useTheme().theme.formControls.textarea;
+  const theirProps = excludeClassName(props)
+  return (
+    <>
+      <textarea
+        className={classNames(
+          theme.base,
+          theme.colors[color],
+          theme.withShadow[shadow ? 'on' : 'off']
+        )}
+        {...theirProps}
+      />
+      {helperText && <HelperText color={color}>{helperText}</HelperText>}
+    </>
+  )
 };
 
-const colorClasses: Record<Color, { input: string; helperText: string }> = {
-  base: {
-    input:
-      'bg-gray-50 border-gray-300 text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500',
-    helperText: 'text-gray-500 dark:text-gray-400',
-  },
-  green: {
-    input:
-      'border-green-500 bg-green-50 text-green-900 placeholder-green-700 focus:border-green-500 focus:ring-green-500 dark:border-green-400 dark:bg-green-100 dark:focus:border-green-500 dark:focus:ring-green-500',
-    helperText: 'text-green-600 dark:text-green-500',
-  },
-  red: {
-    input:
-      'border-red-500 bg-red-50 text-red-900 placeholder-red-700 focus:border-red-500 focus:ring-red-500 dark:border-red-400 dark:bg-red-100 dark:focus:border-red-500 dark:focus:ring-red-500',
-    helperText: 'text-red-600 dark:text-red-500',
-  },
-};
-
-export const Textarea: FC<TextareaProps> = ({ className, shadow, helperText, color = 'base', ...props }) => (
-  <>
-    <textarea
-      className={classNames(
-        'block w-full rounded-lg border disabled:cursor-not-allowed disabled:opacity-50',
-        colorClasses[color].input,
-        {
-          'shadow-sm dark:shadow-sm-light': shadow,
-        },
-        className,
-      )}
-      {...props}
-    />
-    {helperText && <p className={classNames('mt-2 text-sm', colorClasses[color].helperText)}>{helperText}</p>}
-  </>
-);
+Textarea.displayName = "Textarea";

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -373,6 +373,23 @@ export default {
       },
       label: 'ml-3 text-sm font-medium text-gray-900 dark:text-gray-300',
     },
+    textarea: {
+      base: 'block w-full rounded-lg border disabled:cursor-not-allowed disabled:opacity-50',
+      colors: {
+        gray: 'bg-gray-50 border-gray-300 text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500',
+        info: 'border-blue-500 bg-blue-50 text-blue-900 placeholder-blue-700 focus:border-blue-500 focus:ring-blue-500 dark:border-blue-400 dark:bg-blue-100 dark:focus:border-blue-500 dark:focus:ring-blue-500',
+        failure:
+          'border-red-500 bg-red-50 text-red-900 placeholder-red-700 focus:border-red-500 focus:ring-red-500 dark:border-red-400 dark:bg-red-100 dark:focus:border-red-500 dark:focus:ring-red-500',
+        warning:
+          'border-yellow-500 bg-yellow-50 text-yellow-900 placeholder-yellow-700 focus:border-yellow-500 focus:ring-yellow-500 dark:border-yellow-400 dark:bg-yellow-100 dark:focus:border-yellow-500 dark:focus:ring-yellow-500',
+        success:
+          'border-green-500 bg-green-50 text-green-900 placeholder-green-700 focus:border-green-500 focus:ring-green-500 dark:border-green-400 dark:bg-green-100 dark:focus:border-green-500 dark:focus:ring-green-500',
+      },
+      withShadow: {
+        on: 'shadow-sm dark:shadow-sm-light',
+        off: '',
+      },
+    },
   },
   listGroup: {
     base: 'list-none rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white',


### PR DESCRIPTION
## Description

Adding the theme support to `Textarea` component.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Breaking changes

- It remove the direct access to component's `Classname` props
- It introduce the theme support to the component using the configuration:
```js
  textarea: {
    base: string;
    colors: TextareaColors;
    withShadow: FlowbiteBoolean;
  }
```

## How Has This Been Tested?

- [X] Unit test
- [X] Tested the component at the documentation page

**Test Configuration**:

- Browser: Brave 1.39.122
- OS: Firefox 36

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
