### PR TITLE
refactor(select): adds theme support to select component

### DIFF
--- a/src/docs/pages/ModalPage.tsx
+++ b/src/docs/pages/ModalPage.tsx
@@ -119,18 +119,20 @@ const ModalPage: FC = () => {
       code: (
         <>
           <div className="flex flex-wrap gap-4">
-            <Select className="w-40" defaultValue="md" onChange={(event) => setModalSize(event.target.value)}>
-              <option value="sm">sm</option>
-              <option value="md">md</option>
-              <option value="lg">lg</option>
-              <option value="xl">xl</option>
-              <option value="2xl">2xl</option>
-              <option value="3xl">3xl</option>
-              <option value="4xl">4xl</option>
-              <option value="5xl">5xl</option>
-              <option value="6xl">6xl</option>
-              <option value="7xl">7xl</option>
-            </Select>
+            <div className="w-40">
+              <Select defaultValue="md" onChange={(event) => setModalSize(event.target.value)}>
+                <option value="sm">sm</option>
+                <option value="md">md</option>
+                <option value="lg">lg</option>
+                <option value="xl">xl</option>
+                <option value="2xl">2xl</option>
+                <option value="3xl">3xl</option>
+                <option value="4xl">4xl</option>
+                <option value="5xl">5xl</option>
+                <option value="6xl">6xl</option>
+                <option value="7xl">7xl</option>
+              </Select>
+            </div>
             <Button onClick={() => setOpenModal('size')}>Toggle modal</Button>
           </div>
           <Modal show={openModal === 'size'} size={modalSize} onClose={() => setOpenModal(undefined)}>
@@ -163,17 +165,19 @@ const ModalPage: FC = () => {
       code: (
         <>
           <div className="flex flex-wrap gap-4">
-            <Select className="w-40" defaultValue="center" onChange={(event) => setModalPlacement(event.target.value)}>
-              <option value="center">Center</option>
-              <option value="top-left">Top left</option>
-              <option value="top-center">Top center</option>
-              <option value="top-right">Top right</option>
-              <option value="center-left">Center left</option>
-              <option value="center-right">Center right</option>
-              <option value="bottom-right">Bottom right</option>
-              <option value="bottom-center">Bottom center</option>
-              <option value="bottom-left">Bottom left</option>
-            </Select>
+            <div className="w-40">
+              <Select defaultValue="center" onChange={(event) => setModalPlacement(event.target.value)}>
+                <option value="center">Center</option>
+                <option value="top-left">Top left</option>
+                <option value="top-center">Top center</option>
+                <option value="top-right">Top right</option>
+                <option value="center-left">Center left</option>
+                <option value="center-right">Center right</option>
+                <option value="bottom-right">Bottom right</option>
+                <option value="bottom-center">Bottom center</option>
+                <option value="bottom-left">Bottom left</option>
+              </Select>
+            </div>
             <Button onClick={() => setOpenModal('placement')}>Toggle modal</Button>
           </div>
           <Modal show={openModal === 'placement'} position={modalPlacement} onClose={() => setOpenModal(undefined)}>

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -10,7 +10,7 @@ import type {
   ButtonSizes,
 } from '../Button';
 import type { PositionInButtonGroup } from '../Button/ButtonGroup';
-import type { HelperColors, LabelColors, TextareaColors, TextInputColors, TextInputSizes } from '../FormControls';
+import type { HelperColors, LabelColors, SelectColors, SelectSizes, TextareaColors, TextInputColors, TextInputSizes } from '../FormControls';
 import type { ModalPositions, ModalSizes } from '../Modal';
 import type { ProgressColor, ProgressSizes } from '../Progress';
 import type { StarSizes } from '../Rating';
@@ -216,6 +216,25 @@ export interface FlowbiteTheme {
       base: string;
       colors: TextareaColors;
       withShadow: FlowbiteBoolean;
+    };
+    select: {
+      base: string;
+      addon: string;
+      field: {
+        base: string;
+        icon: {
+          base: string;
+          svg: string;
+        };
+        select: {
+          base: string;
+          withIcon: FlowbiteBoolean;
+          withAddon: FlowbiteBoolean;
+          withShadow: FlowbiteBoolean;
+          sizes: SelectSizes;
+          colors: SelectColors;
+        };
+      };
     };
   };
   listGroup: {

--- a/src/lib/components/FormControls/Select.tsx
+++ b/src/lib/components/FormControls/Select.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, ReactNode } from 'react';
-import type { FlowbiteSizes } from '../../../../lib/esm/components/Flowbite/FlowbiteTheme';
+import type { FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
 import { excludeClassName } from '../../helpers/exclude';
 import type { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
 import { useTheme } from '../Flowbite/ThemeContext';

--- a/src/lib/components/FormControls/Select.tsx
+++ b/src/lib/components/FormControls/Select.tsx
@@ -1,79 +1,69 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, ReactNode } from 'react';
+import type { FlowbiteSizes } from '../../../../lib/esm/components/Flowbite/FlowbiteTheme';
+import { excludeClassName } from '../../helpers/exclude';
+import type { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
+import { useTheme } from '../Flowbite/ThemeContext';
+import HelperText from './HelperText';
 
-type Size = 'sm' | 'md' | 'lg';
-type Color = 'base' | 'green' | 'red';
+export interface SelectColors extends Pick<FlowbiteColors, 'gray' | 'info' | 'failure' | 'warning' | 'success'> {
+  [key: string]: string;
+}
 
-export type SelectProps = ComponentProps<'select'> & {
-  sizing?: Size;
+export interface SelectSizes extends Pick<FlowbiteSizes, 'sm' | 'md' | 'lg'> {
+  [key: string]: string;
+}
+
+export interface SelectProps extends Omit<ComponentProps<'select'>, 'className' | 'color'> {
+  sizing?: keyof SelectSizes;
   shadow?: boolean;
   helperText?: ReactNode;
   addon?: ReactNode;
   icon?: FC<ComponentProps<'svg'>>;
-  color?: Color;
-};
-
-const colorClasses: Record<Color, { input: string; helperText: string }> = {
-  base: {
-    input:
-      'bg-gray-50 border-gray-300 text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500',
-    helperText: 'text-gray-500 dark:text-gray-400',
-  },
-  green: {
-    input:
-      'border-green-500 bg-green-50 text-green-900 placeholder-green-700 focus:border-green-500 focus:ring-green-500 dark:border-green-400 dark:bg-green-100 dark:focus:border-green-500 dark:focus:ring-green-500',
-    helperText: 'text-green-600 dark:text-green-500',
-  },
-  red: {
-    input:
-      'border-red-500 bg-red-50 text-red-900 placeholder-red-700 focus:border-red-500 focus:ring-red-500 dark:border-red-400 dark:bg-red-100 dark:focus:border-red-500 dark:focus:ring-red-500',
-    helperText: 'text-red-600 dark:text-red-500',
-  },
+  color?: keyof SelectColors;
 };
 
 export const Select: FC<SelectProps> = ({
   children,
-  className,
   sizing = 'md',
   shadow,
   helperText,
   addon,
   icon: Icon,
-  color = 'base',
+  color = 'gray',
   ...props
-}) => (
-  <div className="flex">
-    {addon && (
-      <span className="inline-flex items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-200 px-3 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-600 dark:text-gray-400">
-        {addon}
-      </span>
-    )}
-    <div className="relative w-full">
-      {Icon && (
-        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-          <Icon className="h-5 w-5 text-gray-500 dark:text-gray-400" />
-        </div>
+}) => {
+  const theme = useTheme().theme.formControls.select;
+  const theirProps = excludeClassName(props);
+
+  return (
+    <div className={theme.base}>
+      {addon && (
+        <span className={theme.addon}>
+          {addon}
+        </span>
       )}
-      <select
-        className={classNames(
-          'block w-full border disabled:cursor-not-allowed disabled:opacity-50',
-          colorClasses[color].input,
-          {
-            'pl-10': Icon,
-            'rounded-lg': !addon,
-            'rounded-r-lg': addon,
-            'shadow-sm dark:shadow-sm-light': shadow,
-            'p-2 sm:text-xs': sizing === 'sm',
-            'p-2.5 text-sm': sizing === 'md',
-            'sm:text-md p-4': sizing === 'lg',
-          },
-          className,
+      <div className={theme.field.base}>
+        {Icon && (
+          <div className={theme.field.icon.base}>
+            <Icon className={theme.field.icon.svg} />
+          </div>
         )}
-        {...props}
-      >
-        {children}
-      </select>
-      {helperText && <p className={classNames('mt-2 text-sm', colorClasses[color].helperText)}>{helperText}</p>}
+        <select
+          className={classNames(
+            theme.field.select.base,
+            theme.field.select.colors[color],
+            theme.field.select.withIcon[Icon ? 'on' : 'off'],
+            theme.field.select.withAddon[addon ? 'on' : 'off'],
+            theme.field.select.withShadow[shadow ? 'on' : 'off'],
+            theme.field.select.sizes[sizing],
+          )}
+          {...theirProps}
+        >
+          {children}
+        </select>
+        {helperText && <HelperText color={color}>{helperText}</HelperText>}
+      </div>
     </div>
-  </div>
-);
+  )
+};

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -390,6 +390,47 @@ export default {
         off: '',
       },
     },
+    select: {
+      base: 'flex',
+      addon: 'inline-flex items-center rounded-l-md border border-r-0 border-gray-300 bg-gray-200 px-3 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-600 dark:text-gray-400',
+      field: {
+        base: 'relative w-full',
+        icon: {
+          base: 'pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3',
+          svg: 'h-5 w-5 text-gray-500 dark:text-gray-400',
+        },
+        select: {
+          base: 'block w-full border disabled:cursor-not-allowed disabled:opacity-50',
+          withIcon: {
+            on: 'pl-10',
+            off: '',
+          },
+          withAddon: {
+            on: 'rounded-r-lg',
+            off: 'rounded-lg',
+          },
+          withShadow: {
+            on: 'shadow-sm dark:shadow-sm-light',
+            off: '',
+          },
+          sizes: {
+            sm: 'p-2 sm:text-xs',
+            md: 'p-2.5 text-sm',
+            lg: 'sm:text-md p-4',
+          },
+          colors: {
+            gray: 'bg-gray-50 border-gray-300 text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500',
+            info: 'border-blue-500 bg-blue-50 text-blue-900 placeholder-blue-700 focus:border-blue-500 focus:ring-blue-500 dark:border-blue-400 dark:bg-blue-100 dark:focus:border-blue-500 dark:focus:ring-blue-500',
+            failure:
+              'border-red-500 bg-red-50 text-red-900 placeholder-red-700 focus:border-red-500 focus:ring-red-500 dark:border-red-400 dark:bg-red-100 dark:focus:border-red-500 dark:focus:ring-red-500',
+            warning:
+              'border-yellow-500 bg-yellow-50 text-yellow-900 placeholder-yellow-700 focus:border-yellow-500 focus:ring-yellow-500 dark:border-yellow-400 dark:bg-yellow-100 dark:focus:border-yellow-500 dark:focus:ring-yellow-500',
+            success:
+              'border-green-500 bg-green-50 text-green-900 placeholder-green-700 focus:border-green-500 focus:ring-green-500 dark:border-green-400 dark:bg-green-100 dark:focus:border-green-500 dark:focus:ring-green-500',
+          },
+        },
+      },
+    },
   },
   listGroup: {
     base: 'list-none rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white',


### PR DESCRIPTION
## Description

Adds theme support to the `Select` component.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Breaking changes

- Removes direct access to `className` props
- Adds the theme support to the component with the following config:
```js
    select: {
      base: string;
      addon: string;
      field: {
        base: string;
        icon: {
          base: string;
          svg: string;
        };
        select: {
          base: string;
          withIcon: FlowbiteBoolean;
          withAddon: FlowbiteBoolean;
          withShadow: FlowbiteBoolean;
          sizes: SelectSizes;
          colors: SelectColors;
        };
      };
    };
```

## How Has This Been Tested?

- [X] Unit test
- [X] Tested directly at the documentation page

**Test Configuration**:

- Browser: Brave 1.39.122
- OS: Fedora 36

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
