### PR TITLE
refactor(dropdown): adds theme support to dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "test:coverage": "vitest run --coverage",
     "test:open": "vitest --ui",
     "test:e2e": "start-test 3000 cypress:run",
-    "test:e2e:open": "start-test 3000 cypress:open",
-    "commit": "cz"
+    "test:e2e:open": "start-test 3000 cypress:open"
   },
   "dependencies": {
     "@floating-ui/react-dom": "^0.6.3",

--- a/src/lib/components/Dropdown/index.tsx
+++ b/src/lib/components/Dropdown/index.tsx
@@ -4,20 +4,19 @@ import { HiOutlineChevronDown, HiOutlineChevronLeft, HiOutlineChevronRight, HiOu
 import { excludeClassName } from '../../helpers/exclude';
 import type { ButtonProps } from '../Button';
 import { Button } from '../Button';
-import type { TooltipProps } from '../Tooltip';
-import { Tooltip } from '../Tooltip';
+import type { FloatingProps } from '../Floating';
+import { Floating } from '../Floating';
+import { useTheme } from '../Flowbite/ThemeContext';
 import { DropdownDivider } from './DropdownDivider';
 import { DropdownHeader } from './DropdownHeader';
 import { DropdownItem } from './DropdownItem';
 
-export type DropdownProps = ButtonProps &
-  Omit<TooltipProps, 'content' | 'style' | 'animation' | 'arrow'> & {
-    className?: string;
-    label: ReactNode;
-    inline?: boolean;
-    tooltipArrow?: boolean;
-    arrowIcon?: boolean;
-  };
+export interface DropdownProps extends PropsWithChildren<Pick<FloatingProps, 'placement' | 'trigger'>>, ButtonProps {
+  label: ReactNode;
+  inline?: boolean;
+  floatingArrow?: boolean;  
+  arrowIcon?: boolean;
+};
 
 const icons: Record<string, FC<ComponentProps<'svg'>>> = {
   top: HiOutlineChevronUp,
@@ -26,35 +25,44 @@ const icons: Record<string, FC<ComponentProps<'svg'>>> = {
   left: HiOutlineChevronLeft,
 };
 
-const DropdownComponent: FC<DropdownProps> = (props) => {
+const DropdownComponent: FC<DropdownProps> = ({ children, ...props }) => {
+  const theme = useTheme().theme.dropdown;
   const theirProps = excludeClassName(props) as DropdownProps;
-  const { children, label, inline, tooltipArrow = false, arrowIcon = true, ...restProps } = theirProps;
-  const { placement = inline ? 'bottom-start' : 'bottom', trigger = 'click', ...buttonProps } = restProps;
+  const { 
+    placement = props.inline ? 'bottom-start' : 'bottom', 
+    trigger = 'click',
+    label,
+    inline,
+    floatingArrow = false,
+    arrowIcon = true,
+    ...buttonProps
+  } = theirProps;
 
   const Icon = useMemo(() => {
     const [p] = placement.split('-');
-
     return icons[p] ?? HiOutlineChevronDown;
   }, [placement]);
-  const content = useMemo(() => <ul className="py-1">{children}</ul>, [children]);
 
-  const TriggerWrapper: FC<PropsWithChildren<ComponentProps<'button'>>> = ({ children }): JSX.Element =>
-    inline ? <button className="flex items-center">{children}</button> : <Button {...buttonProps}>{children}</Button>;
+  const content = useMemo(() => <ul className={theme.content}>{children}</ul>, [children, theme]);
+
+  const TriggerWrapper: FC<ButtonProps> = ({ children }): JSX.Element =>
+    inline ? <button className={theme.inlineWrapper}>{children}</button> : <Button {...buttonProps}>{children}</Button>;
 
   return (
-    <Tooltip
+    <Floating
       content={content}
       style="auto"
       animation="duration-100"
       placement={placement}
-      arrow={tooltipArrow}
+      arrow={floatingArrow}
       trigger={trigger}
+      theme={theme.floating}
     >
       <TriggerWrapper>
         {label}
-        {arrowIcon && <Icon className="ml-2 h-4 w-4" />}
+        {arrowIcon && <Icon className={theme.arrowIcon} />}
       </TriggerWrapper>
-    </Tooltip>
+    </Floating>
   );
 };
 

--- a/src/lib/components/Floating/index.tsx
+++ b/src/lib/components/Floating/index.tsx
@@ -1,0 +1,146 @@
+import type { Placement } from '@floating-ui/core';
+import {
+  autoUpdate,
+  useClick,
+  useFloating,
+  useFocus,
+  useHover,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react-dom-interactions';
+import classNames from 'classnames';
+import type { ComponentProps, FC, PropsWithChildren, ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { excludeClassName } from '../../helpers/exclude';
+import { getArrowPlacement, getMiddleware, getPlacement } from '../../helpers/floating';
+
+export interface FlowbiteFloatingTheme {
+  target: string;
+  base: string;
+  animation: string;
+  hidden: string;
+  style: {
+    dark: string;
+    light: string;
+    auto: string;
+  };
+  content: string;
+  arrow: {
+    base: string;
+    style: {
+      dark: string;
+      light: string;
+      auto: string;
+    };
+    placement: string;
+  };
+}
+
+export interface FloatingProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'className' | 'style'>> {
+  content: ReactNode;
+  theme: FlowbiteFloatingTheme;
+  placement?: 'auto' | Placement;
+  trigger?: 'hover' | 'click';
+  style?: 'dark' | 'light' | 'auto';
+  animation?: false | `duration-${number}`;
+  arrow?: boolean;
+}
+
+/**
+ * @see https://floating-ui.com/docs/react-dom-interactions
+ */
+export const Floating: FC<FloatingProps> = ({
+  children,
+  content,
+  theme,
+  animation = 'duration-300',
+  arrow = true,
+  placement = 'top',
+  style = 'dark',
+  trigger = 'hover',
+  ...props
+}) => {
+  const theirProps = excludeClassName(props);
+
+  const arrowRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const floatingTooltip = useFloating<HTMLElement>({
+    middleware: getMiddleware({ arrowRef, placement }),
+    onOpenChange: setOpen,
+    open,
+    placement: getPlacement({ placement }),
+  });
+  const {
+    context,
+    floating,
+    middlewareData: { arrow: { x: arrowX, y: arrowY } = {} },
+    reference,
+    refs,
+    strategy,
+    update,
+    x,
+    y,
+  } = floatingTooltip;
+
+  const { getFloatingProps, getReferenceProps } = useInteractions([
+    useClick(context, { enabled: trigger === 'click' }),
+    useFocus(context),
+    useHover(context, { enabled: trigger === 'hover' }),
+    useRole(context, { role: 'tooltip' }),
+  ]);
+
+  useEffect(() => {
+    if (refs.reference.current && refs.floating.current && open) {
+      return autoUpdate(refs.reference.current, refs.floating.current, update);
+    }
+  }, [open, refs.floating, refs.reference, update]);
+
+  return (
+    <>
+      <div className={theme.target} {...getReferenceProps({ ref: reference })} data-testid="tooltip-target">
+        {children}
+      </div>
+      <div
+        data-testid="tooltip"
+        {...getFloatingProps({
+          className: classNames(
+            theme.base,
+            animation && `${theme.animation} ${animation}`,
+            !open && theme.hidden,
+            theme.style[style],
+          ),
+          ref: floating,
+          style: {
+            position: strategy,
+            top: y ?? ' ',
+            left: x ?? ' ',
+          },
+          ...theirProps,
+        })}
+      >
+        <div className={theme.content}>{content}</div>
+        {arrow && (
+          <div
+            className={classNames(theme.arrow.base, {
+              [theme.arrow.style.dark]: style === 'dark',
+              [theme.arrow.style.light]: style === 'light',
+              [theme.arrow.style.auto]: style === 'auto',
+            })}
+            data-testid="tooltip-arrow"
+            ref={arrowRef}
+            style={{
+              top: arrowY ?? ' ',
+              left: arrowX ?? ' ',
+              right: ' ',
+              bottom: ' ',
+              [getArrowPlacement({ placement: floatingTooltip.placement })]: theme.arrow.placement,
+            }}
+          >
+            &nbsp;
+          </div>
+        )}
+      </div>
+    </>
+  );
+};

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -10,6 +10,7 @@ import type {
   ButtonSizes,
 } from '../Button';
 import type { PositionInButtonGroup } from '../Button/ButtonGroup';
+import type { FlowbiteFloatingTheme } from '../Floating';
 import type { HelperColors, LabelColors, SelectColors, SelectSizes, TextareaColors, TextInputColors, TextInputSizes } from '../FormControls';
 import type { ModalPositions, ModalSizes } from '../Modal';
 import type { ProgressColor, ProgressSizes } from '../Progress';
@@ -459,27 +460,13 @@ export interface FlowbiteTheme {
       icon: string;
     };
   };
-  tooltip: {
-    target: string;
-    base: string;
-    animation: string;
-    hidden: string;
-    style: {
-      dark: string;
-      light: string;
-      auto: string;
-    };
+  tooltip: FlowbiteFloatingTheme;
+  dropdown: {
+    floating: FlowbiteFloatingTheme;
     content: string;
-    arrow: {
-      base: string;
-      style: {
-        dark: string;
-        light: string;
-        auto: string;
-      };
-      placement: string;
-    };
-  };
+    inlineWrapper: string;
+    arrowIcon: string;
+  }
 }
 
 export interface FlowbiteBoolean {

--- a/src/lib/components/Tooltip/index.tsx
+++ b/src/lib/components/Tooltip/index.tsx
@@ -1,21 +1,7 @@
 import type { Placement } from '@floating-ui/core';
-import { arrow, autoPlacement, shift } from '@floating-ui/core';
-import type { Middleware } from '@floating-ui/react-dom-interactions';
-import {
-  autoUpdate,
-  flip,
-  offset,
-  useClick,
-  useFloating,
-  useFocus,
-  useHover,
-  useInteractions,
-  useRole,
-} from '@floating-ui/react-dom-interactions';
-import classNames from 'classnames';
-import type { ComponentProps, FC, PropsWithChildren, ReactNode, RefObject } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import type { ComponentProps, FC, PropsWithChildren, ReactNode } from 'react';
 import { excludeClassName } from '../../helpers/exclude';
+import { Floating } from '../Floating';
 import { useTheme } from '../Flowbite/ThemeContext';
 
 export interface TooltipProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'className' | 'style'>> {
@@ -43,121 +29,18 @@ export const Tooltip: FC<TooltipProps> = ({
   const theme = useTheme().theme.tooltip;
   const theirProps = excludeClassName(props);
 
-  const arrowRef = useRef<HTMLDivElement>(null);
-  const [open, setOpen] = useState(false);
-
-  const floatingTooltip = useFloating<HTMLElement>({
-    middleware: floatingMiddleware({ arrowRef, placement }),
-    onOpenChange: setOpen,
-    open,
-    placement: floatingPlacement({ placement }),
-  });
-  const {
-    context,
-    floating,
-    middlewareData: { arrow: { x: arrowX, y: arrowY } = {} },
-    reference,
-    refs,
-    strategy,
-    update,
-    x,
-    y,
-  } = floatingTooltip;
-
-  const { getFloatingProps, getReferenceProps } = useInteractions([
-    useClick(context, { enabled: trigger === 'click' }),
-    useFocus(context),
-    useHover(context, { enabled: trigger === 'hover' }),
-    useRole(context, { role: 'tooltip' }),
-  ]);
-
-  useEffect(() => {
-    if (refs.reference.current && refs.floating.current && open) {
-      return autoUpdate(refs.reference.current, refs.floating.current, update);
-    }
-  }, [open, refs.floating, refs.reference, update]);
-
   return (
-    <>
-      <div className={theme.target} {...getReferenceProps({ ref: reference })} data-testid="tooltip-target">
-        {children}
-      </div>
-      <div
-        data-testid="tooltip"
-        {...getFloatingProps({
-          className: classNames(
-            theme.base,
-            animation && `${theme.animation} ${animation}`,
-            !open && theme.hidden,
-            theme.style[style],
-          ),
-          ref: floating,
-          style: {
-            position: strategy,
-            top: y ?? ' ',
-            left: x ?? ' ',
-          },
-          ...theirProps,
-        })}
-      >
-        <div className={theme.content}>{content}</div>
-        {arrow && (
-          <div
-            className={classNames(theme.arrow.base, {
-              [theme.arrow.style.dark]: style === 'dark',
-              [theme.arrow.style.light]: style === 'light',
-              [theme.arrow.style.auto]: style === 'auto',
-            })}
-            data-testid="tooltip-arrow"
-            ref={arrowRef}
-            style={{
-              top: arrowY ?? ' ',
-              left: arrowX ?? ' ',
-              right: ' ',
-              bottom: ' ',
-              [floatingArrowPlacement({ placement: floatingTooltip.placement })]: theme.arrow.placement,
-            }}
-          >
-            &nbsp;
-          </div>
-        )}
-      </div>
-    </>
+    <Floating
+      content={content}
+      style={style}
+      animation={animation}
+      placement={placement}
+      arrow={arrow}
+      trigger={trigger}
+      theme={theme}
+      {...theirProps}
+    >
+      {children}
+    </Floating>
   );
-};
-
-/**
- * @see https://floating-ui.com/docs/middleware
- */
-const floatingMiddleware = ({
-  arrowRef,
-  placement,
-}: {
-  arrowRef: RefObject<HTMLDivElement>;
-  placement: 'auto' | Placement;
-}): Middleware[] => {
-  const middleware = [];
-
-  middleware.push(offset(8));
-  middleware.push(placement === 'auto' ? autoPlacement() : flip());
-  middleware.push(shift({ padding: 8 }));
-
-  if (arrowRef.current) {
-    middleware.push(arrow({ element: arrowRef.current }));
-  }
-
-  return middleware;
-};
-
-const floatingPlacement = ({ placement }: { placement: 'auto' | Placement }): Placement | undefined => {
-  return placement === 'auto' ? undefined : placement;
-};
-
-const floatingArrowPlacement = ({ placement }: { placement: Placement }): Placement => {
-  return {
-    top: 'bottom',
-    right: 'left',
-    bottom: 'top',
-    left: 'right',
-  }[placement.split('-')[0]] as Placement;
 };

--- a/src/lib/helpers/floating.ts
+++ b/src/lib/helpers/floating.ts
@@ -1,0 +1,41 @@
+import type { Middleware } from '@floating-ui/react-dom-interactions';
+import type { Placement } from "@floating-ui/react-dom";
+import type { RefObject } from "react";
+import { arrow, autoPlacement, shift } from '@floating-ui/core';
+import { flip, offset } from '@floating-ui/react-dom-interactions';
+
+/**
+ * @see https://floating-ui.com/docs/middleware
+ */
+export const getMiddleware = ({
+    arrowRef,
+    placement,
+}: {
+    arrowRef: RefObject<HTMLDivElement>;
+    placement: 'auto' | Placement;
+}): Middleware[] => {
+    const middleware = [];
+
+    middleware.push(offset(8));
+    middleware.push(placement === 'auto' ? autoPlacement() : flip());
+    middleware.push(shift({ padding: 8 }));
+
+    if (arrowRef.current) {
+        middleware.push(arrow({ element: arrowRef.current }));
+    }
+
+    return middleware;
+};
+
+export const getPlacement = ({ placement }: { placement: 'auto' | Placement }): Placement | undefined => {
+    return placement === 'auto' ? undefined : placement;
+};
+
+export const getArrowPlacement = ({ placement }: { placement: Placement }): Placement => {
+    return {
+        top: 'bottom',
+        right: 'left',
+        bottom: 'top',
+        left: 'right',
+    }[placement.split('-')[0]] as Placement;
+};

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -830,4 +830,30 @@ export default {
       placement: '-4px',
     },
   },
+  dropdown: {
+    floating: {
+      target: 'w-fit',
+      base: 'absolute inline-block rounded-lg py-2 px-3 text-sm font-medium shadow-sm',
+      animation: 'transition-opacity',
+      hidden: 'invisible opacity-0',
+      style: {
+        dark: 'bg-gray-900 text-white dark:bg-gray-700',
+        light: 'border border-gray-200 bg-white text-gray-900',
+        auto: 'border border-gray-200 bg-white text-gray-900 dark:border-none dark:bg-gray-700 dark:text-white',
+      },
+      content: 'relative z-20',
+      arrow: {
+        base: 'absolute z-10 h-2 w-2 rotate-45',
+        style: {
+          dark: 'bg-gray-900 dark:bg-gray-700',
+          light: 'bg-white',
+          auto: 'bg-white dark:bg-gray-700',
+        },
+        placement: '-4px',
+      },
+    },
+    arrowIcon: 'ml-2 h-4 w-4',
+    inlineWrapper: 'flex items-center',
+    content: 'py-1',
+  },
 };


### PR DESCRIPTION
## Description

Adds theme support to `Dropdown` component. It was necessary to do some refactoring at the `Tooltip` and to create a new intermediary component named `Floating` that is being used in both. It isn't the best solution IMHO, but for now it does the job.

Fixes #134

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Breaking changes

- Dropdown doesn't have direct access to `className` property anymore;
- Dropdown now supports theme:
```
  dropdown: {
    floating: FlowbiteFloatingTheme;
    content: string;
    inlineWrapper: string;
    arrowIcon: string;
  }
```

## How Has This Been Tested?

- [X] Unit tests
- [X] Manual tests

**Test Configuration**:

- Browser: Brave 1.40.107
- OS: Fedora 36

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
