### PR TITLE
Added ref forwarding for Select component

### DIFF
--- a/src/lib/components/FormControls/Select.tsx
+++ b/src/lib/components/FormControls/Select.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, ReactNode } from 'react';
+import {forwardRef} from 'react';
 import type { FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
 import { excludeClassName } from '../../helpers/exclude';
 import type { FlowbiteColors } from '../Flowbite/FlowbiteTheme';
@@ -14,7 +15,7 @@ export interface SelectSizes extends Pick<FlowbiteSizes, 'sm' | 'md' | 'lg'> {
   [key: string]: string;
 }
 
-export interface SelectProps extends Omit<ComponentProps<'select'>, 'className' | 'color'> {
+export interface SelectProps extends Omit<ComponentProps<'select'>, 'className' | 'color' | 'ref'> {
   sizing?: keyof SelectSizes;
   shadow?: boolean;
   helperText?: ReactNode;
@@ -23,7 +24,7 @@ export interface SelectProps extends Omit<ComponentProps<'select'>, 'className' 
   color?: keyof SelectColors;
 };
 
-export const Select: FC<SelectProps> = ({
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(({
   children,
   sizing = 'md',
   shadow,
@@ -32,7 +33,7 @@ export const Select: FC<SelectProps> = ({
   icon: Icon,
   color = 'gray',
   ...props
-}) => {
+}, ref) => {
   const theme = useTheme().theme.formControls.select;
   const theirProps = excludeClassName(props);
 
@@ -59,6 +60,7 @@ export const Select: FC<SelectProps> = ({
             theme.field.select.sizes[sizing],
           )}
           {...theirProps}
+          ref={ref}
         >
           {children}
         </select>
@@ -66,4 +68,4 @@ export const Select: FC<SelectProps> = ({
       </div>
     </div>
   )
-};
+});


### PR DESCRIPTION
## Description

Added ref forwarding for `Select` component, including the changes necessary to `SelectProps` in order to not break the Select.stories.tsx file. All the changes where made following the same style used for ref forwarding in `TextInput` (and `TextInputProps`).

The startup I work for wants to use this library but for that we need it to work with the [react-hook-form project](https://react-hook-form.com/get-started), which needs ref forwarding.

Fixes # (issue)

Lack of ref forwarding on Select component

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran "npm run test" and all the tests passed.
I also tried the component as in using it to see how it responds to the changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
