### PR TITLE
fix extra vertical scroll on some pages

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+body {
+  overflow: hidden;
+}
+
 @import '~flowbite';
 
 @tailwind components;


### PR DESCRIPTION
## Description
Fixed extra scroll vertical scroll bar on some pages which was causing extra scroll. This was solved by adding `overflow: hidden;` to the body to eliminate extra scrolls

Fixes #270 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
After adding property `overflow: hidden;` for the body in `index.css`. I tested each and every page to see if  something breaks but everything seems to work fine

- [x] Test on Macbook Air (chrome and firefox)
- [x] Test on Samsung galaxy s9+(chrome)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
