### PR TITLE
chore(navbar): Explicitly call NavbarContext.setIsOpen when props.menuOpen changed, resolves #244

### DIFF
--- a/src/lib/components/Navbar/index.tsx
+++ b/src/lib/components/Navbar/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { excludeClassName } from '../../helpers/exclude';
 import { useTheme } from '../Flowbite/ThemeContext';
 import { NavbarBrand } from './NavbarBrand';
@@ -22,6 +22,10 @@ const NavbarComponent: FC<NavbarComponentProps> = ({ children, menuOpen, fluid =
 
   const theme = useTheme().theme.navbar;
   const theirProps = excludeClassName(props);
+
+  useEffect(() => {
+    setIsOpen(menuOpen);
+  }, [menuOpen])
 
   return (
     <NavbarContext.Provider value={{ isOpen, setIsOpen }}>


### PR DESCRIPTION
## Description

I think the internal state of the NavbarContext isOpen, can be changed by menuOpen prop. Users can then manage Navbar state through their own context. Right?

Fixs: #244

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change contains documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings