### PR TITLE
fix(component): display text only on Sidebar.Item tooltip

### DIFF
--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -413,7 +413,6 @@ export interface FlowbiteTheme {
       };
       content: {
         base: string;
-        collapsed: string;
       };
       icon: {
         base: string;

--- a/src/lib/components/Sidebar/Sidebar.spec.tsx
+++ b/src/lib/components/Sidebar/Sidebar.spec.tsx
@@ -117,30 +117,6 @@ describe.concurrent('Components / Sidebar', () => {
         });
       });
 
-      describe('`Sidebar.Collapse` and `Sidebar.Item`', () => {
-        it('should display tooltip', () => {
-          const items = getSidebarItems(render(<TestSidebar collapsed />));
-
-          items.forEach((item) => {
-            expect(item.firstElementChild).toHaveAttribute('data-testid', 'tooltip-target');
-          });
-        });
-
-        it("shouldn't display text content", () => {
-          const items = getSidebarItemContents(render(<TestSidebar collapsed />));
-
-          items.forEach((item) => expect(item).toHaveClass('hidden'));
-        });
-      });
-
-      describe('`Sidebar.Item`', () => {
-        it("shouldn't display `label`", () => {
-          const labels = getSidebarLabels(render(<TestSidebar collapsed />));
-
-          labels.forEach((label) => expect(label).not.toBeVisible());
-        });
-      });
-
       describe('`Sidebar.Logo`', () => {
         it("shouldn't display text content", () => {
           const logo = getSidebarLogo(render(<TestSidebar collapsed />));

--- a/src/lib/components/Sidebar/Sidebar.spec.tsx
+++ b/src/lib/components/Sidebar/Sidebar.spec.tsx
@@ -459,8 +459,5 @@ const getSidebarItems = ({ getAllByRole }: Pick<RenderResult, 'getAllByRole'>): 
 const getSidebarItemsContainer = ({ getAllByTestId }: Pick<RenderResult, 'getAllByTestId'>): HTMLElement[] =>
   getAllByTestId('flowbite-sidebar-items');
 
-const getSidebarLabels = ({ queryAllByTestId }: Pick<RenderResult, 'queryAllByTestId'>): HTMLElement[] =>
-  queryAllByTestId('flowbite-sidebar-label');
-
 const getSidebarLogo = ({ getByLabelText }: Pick<RenderResult, 'getByLabelText'>): HTMLElement =>
   getByLabelText('Flowbite');

--- a/src/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/src/lib/components/Sidebar/Sidebar.stories.tsx
@@ -184,7 +184,7 @@ CTAButton.args = {
       </Sidebar.Items>
       <Sidebar.CTA>
         <div className="mb-3 flex items-center">
-          <Badge color="yellow">Beta</Badge>
+          <Badge color="warning">Beta</Badge>
           <div className="-m-1.5 ml-auto">
             <Button aria-label="Close" outline>
               <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">

--- a/src/lib/components/Sidebar/SidebarItem.tsx
+++ b/src/lib/components/Sidebar/SidebarItem.tsx
@@ -32,7 +32,7 @@ const SidebarItem: FC<SidebarItemProps> = ({
   label,
   labelColor = 'info',
   ...props
-}): JSX.Element => {
+}) => {
   const theirProps = excludeClassName(props);
 
   const id = useId();
@@ -40,16 +40,26 @@ const SidebarItem: FC<SidebarItemProps> = ({
   const { isInsideCollapse } = useSidebarItemContext();
   const theme = useTheme().theme.sidebar.item;
 
-  const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }): JSX.Element => (
+  const Wrapper: FC<PropsWithChildren<unknown>> = ({ children: Component }) => (
     <li>
       {isCollapsed ? (
-        <Tooltip content={children} placement="right">
-          {children}
+        <Tooltip content={<Children>{children}</Children>} placement="right">
+          {Component}
         </Tooltip>
       ) : (
-        children
+        Component
       )}
     </li>
+  );
+
+  const Children: FC<PropsWithChildren<unknown>> = ({ children }) => (
+    <span
+      className={classNames(theme.content.base)}
+      data-testid="flowbite-sidebar-item-content"
+      id={`flowbite-sidebar-item-${id}`}
+    >
+      {children}
+    </span>
   );
 
   return (
@@ -70,14 +80,8 @@ const SidebarItem: FC<SidebarItemProps> = ({
             data-testid="flowbite-sidebar-item-icon"
           />
         )}
-        <span
-          className={classNames(theme.content.base, isCollapsed && theme.content.collapsed)}
-          data-testid="flowbite-sidebar-item-content"
-          id={`flowbite-sidebar-item-${id}`}
-        >
-          {children}
-        </span>
-        {label && (
+        {!isCollapsed && <Children>{children}</Children>}
+        {label && !isCollapsed && (
           <Badge color={labelColor} data-testid="flowbite-sidebar-label" hidden={isCollapsed}>
             {label}
           </Badge>

--- a/src/lib/components/Sidebar/index.tsx
+++ b/src/lib/components/Sidebar/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import { ComponentProps, FC, PropsWithChildren } from 'react';
 import { excludeClassName } from '../../helpers/exclude';
 import { useTheme } from '../Flowbite/ThemeContext';
 import SidebarCollapse from './SidebarCollapse';

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -697,8 +697,7 @@ export default {
         insideCollapse: 'group w-full pl-8 transition duration-75',
       },
       content: {
-        base: 'ml-3 flex-1 whitespace-nowrap',
-        collapsed: 'hidden',
+        base: 'px-3 flex-1 whitespace-nowrap',
       },
       icon: {
         base: 'h-6 w-6 flex-shrink-0 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white',


### PR DESCRIPTION
## Breaking changes

None.

## Bug fixes

- [x] [fix(component): display text only on Sidebar.Item tooltip](https://github.com/themesberg/flowbite-react/commit/b44d784602eb6a78c4739d858c205848f226daa5)

## Tests

- [x] [test(component): drop false-positive Sidebar tests](https://github.com/themesberg/flowbite-react/commit/f5d4dae08a5a525995273f2a3c1d4161f6aa4590)