### PR TITLE
docs(storybook): add color radio options to `Button` storybook

### DIFF
--- a/src/lib/components/Button/Button.stories.tsx
+++ b/src/lib/components/Button/Button.stories.tsx
@@ -1,10 +1,17 @@
 import type { Meta, Story } from '@storybook/react/types-6-0';
 import type { ButtonProps } from '.';
 import { Button } from '.';
+import theme from '../../theme/default';
 
 export default {
   title: 'Components/Button',
   component: Button,
+  argTypes: {
+    color: {
+      options: Object.keys(theme.button.color),
+      control: { type: 'radio' },
+    },
+  },
 } as Meta;
 
 const Template: Story<ButtonProps> = (args) => <Button {...args} />;


### PR DESCRIPTION
We can use the default theme to automatically pick up on which colors the `Button` supports by default.

## Breaking changes

None.

## Documentation

- [x] [docs(storybook): add color radio options to Button storybook](https://github.com/themesberg/flowbite-react/commit/c20298aec5f0c70f36af7d7e9146aa655f63bcec)