### PR TITLE
fix(component): remove "All Rights Reserved" from `<Footer.Copyright>`

### DIFF
--- a/src/lib/components/Footer/FooterCopyright.tsx
+++ b/src/lib/components/Footer/FooterCopyright.tsx
@@ -15,13 +15,12 @@ export const FooterCopyright: FC<CopyrightProps> = ({ href, by, year }) => {
       <span className={theme.base}>
         © {year}
         {href ? (
-          <a href={href} className={theme.base}>
+          <a href={href} className={theme.href}>
             {by}
           </a>
         ) : (
           <span className={theme.span}>{by}</span>
         )}
-        . All Rights Reserved.
       </span>
     </div>
   );


### PR DESCRIPTION
We shouldn't require this phrase to use the component. Now you can just add "All Rights Reserved" to the `<Footer.Copyright by=""/>` field, if you would like to.

## Breaking changes

If you are using a `Footer` and `Footer.Copyright` with a copyright statement that needs to include "All Rights Reserved", you will want to add that in now like so:

```js
<Footer.Copyright by="My Company. All Rights Reserved." year={2022} />
```

## Bug fixes

- [x] [fix(component): remove "All Rights Reserved" from <Footer.Copyright>](https://github.com/themesberg/flowbite-react/commit/c3efd0ac88ef1ec77f4c05377659c484df4f6e45)