### PR TITLE
fix: typo in navbar theme typedef

### DIFF
--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -325,7 +325,7 @@ export interface FlowbiteTheme {
     bordered: FlowbiteBoolean;
     inner: {
       base: string;
-      fuild: FlowbiteBoolean;
+      fluid: FlowbiteBoolean;
     };
     brand: string;
     collapse: {

--- a/src/lib/components/Navbar/index.tsx
+++ b/src/lib/components/Navbar/index.tsx
@@ -36,7 +36,7 @@ const NavbarComponent: FC<NavbarComponentProps> = ({
         className={classNames(theme.base, theme.bordered[border ? 'on' : 'off'], theme.rounded[rounded ? 'on' : 'off'])}
         {...theirProps}
       >
-        <div className={classNames(theme.inner.base, theme.inner.fuild[fluid ? 'on' : 'off'])}>{children}</div>
+        <div className={classNames(theme.inner.base, theme.inner.fluid[fluid ? 'on' : 'off'])}>{children}</div>
       </nav>
     </NavbarContext.Provider>
   );

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -574,7 +574,7 @@ export default {
     },
     inner: {
       base: 'mx-auto flex flex-wrap items-center justify-between',
-      fuild: {
+      fluid: {
         on: '',
         off: 'container',
       },


### PR DESCRIPTION
Signed-off-by: chankruze <chankruze@gmail.com>

## Description

This is just a fix for a typo in `FlowbiteTheme.d.ts` ass discussed in the discord chat.

![image](https://user-images.githubusercontent.com/29806845/184184144-4f1db0d2-40e4-45db-89df-0ccd11b146db.png)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change contains documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
