### PR TITLE
fix(component): add missing display name for checkbox, radio and select

### DIFF
--- a/src/lib/components/FormControls/Checkbox.tsx
+++ b/src/lib/components/FormControls/Checkbox.tsx
@@ -10,3 +10,5 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>((props, ref)
   const theirProps = excludeClassName(props);
   return <input ref={ref} className={theme.base} type="checkbox" {...theirProps} />;
 });
+
+Checkbox.displayName = 'Checkbox';

--- a/src/lib/components/FormControls/Radio.tsx
+++ b/src/lib/components/FormControls/Radio.tsx
@@ -10,3 +10,5 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
   const theirProps = excludeClassName(props);
   return <input ref={ref} className={theme.base} type="radio" {...theirProps} />;
 });
+
+Radio.displayName = 'Radio';

--- a/src/lib/components/FormControls/Select.tsx
+++ b/src/lib/components/FormControls/Select.tsx
@@ -57,3 +57,5 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
     );
   },
 );
+
+Select.displayName = 'Select';


### PR DESCRIPTION
## Description

There are missing display names on checkbox, radio and select. This causes the following in the docs site:
![image](https://user-images.githubusercontent.com/4121492/184274301-96e61763-9c12-44f3-a3b5-90ae38b1da26.png)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change contains documentation update

## Breaking changes

None

## How Has This Been Tested?

Ran test and build

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
