### PR TITLE
fix(package): minimal react version is 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   },
   "peerDependencies": {
     "flowbite": "^1",
-    "react": "^17 || ^18",
-    "react-dom": "^17 || ^18",
+    "react": "^18",
+    "react-dom": "^18",
     "tailwindcss": "^3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

The `package.json` was saying that the minimal requirement to the librabry was `react` and `react-dom` 17. It isn't true.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Breaking changes

n/a

## How Has This Been Tested?

- [X] Unit tests

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
