### PR TITLE
fix #350: hydration issue with SSR/SSG and re-declaration of TableContext

### DIFF
--- a/src/lib/components/Modal/index.tsx
+++ b/src/lib/components/Modal/index.tsx
@@ -59,7 +59,7 @@ const ModalComponent: FC<ModalProps> = ({
         parent.removeChild(container);
       }
     };
-  }, [container, root, show]);
+  }, [container, parent, show]);
 
   return container
     ? createPortal(

--- a/src/lib/components/Modal/index.tsx
+++ b/src/lib/components/Modal/index.tsx
@@ -3,7 +3,6 @@ import type { ComponentProps, FC, PropsWithChildren } from 'react';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { excludeClassName } from '../../helpers/exclude';
-import windowExists from '../../helpers/window-exists';
 import type { FlowbitePositions, FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
 import { useTheme } from '../Flowbite/ThemeContext';
 import { ModalBody } from './ModalBody';
@@ -30,27 +29,35 @@ export interface ModalProps extends PropsWithChildren<Omit<ComponentProps<'div'>
 
 const ModalComponent: FC<ModalProps> = ({
   children,
-  root = windowExists() ? document.body : undefined,
   show,
+  root,
   popup,
   size = '2xl',
   position = 'center',
   onClose,
   ...props
 }) => {
-  const [container] = useState<HTMLDivElement | undefined>(windowExists() ? document.createElement('div') : undefined);
+  const [parent, setParent] = useState<HTMLElement | undefined>(root);
+  const [container, setContainer] = useState<HTMLDivElement | undefined>();
   const theme = useTheme().theme.modal;
   const theirProps = excludeClassName(props);
 
   useEffect(() => {
-    if (!container || !root || !show) {
+    if (!parent) setParent(document.body);
+    if (!container) setContainer(document.createElement('div'));
+  }, []);
+
+  useEffect(() => {
+    if (!container || !parent || !show) {
       return;
     }
 
-    root.appendChild(container);
+    parent.appendChild(container);
 
     return () => {
-      root.removeChild(container);
+      if (container) {
+        parent.removeChild(container);
+      }
     };
   }, [container, root, show]);
 

--- a/src/lib/components/Table/TableContext.tsx
+++ b/src/lib/components/Table/TableContext.tsx
@@ -1,13 +1,13 @@
 import { createContext, useContext } from 'react';
 
-export type TableContext = {
+export type TableContextType = {
   striped?: boolean;
   hoverable?: boolean;
 };
 
-export const TableContext = createContext<TableContext | undefined>(undefined);
+export const TableContext = createContext<TableContextType | undefined>(undefined);
 
-export function useTableContext(): TableContext {
+export function useTableContext(): TableContextType {
   const context = useContext(TableContext);
 
   if (!context) {

--- a/src/lib/components/Table/index.tsx
+++ b/src/lib/components/Table/index.tsx
@@ -2,12 +2,12 @@ import classNames from 'classnames';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
 import { TableBody } from './TableBody';
 import { TableCell } from './TableCell';
-import { TableContext } from './TableContext';
+import { TableContext, TableContextType } from './TableContext';
 import { TableHead } from './TableHead';
 import { TableHeadCell } from './TableHeadCell';
 import { TableRow } from './TableRow';
 
-export type TableProps = PropsWithChildren<ComponentProps<'table'> & TableContext>;
+export type TableProps = PropsWithChildren<ComponentProps<'table'> & TableContextType>;
 
 const TableComponent: FC<TableProps> = ({ children, striped, hoverable, className, ...props }) => {
   return (


### PR DESCRIPTION
`TableContext` is already defined as the type and also redeclared a `React.Context`. Hence renamed the typedef as `TableContextType` and update the Table component.

The 2nd commit resolves #350 ❤

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
