### PR TITLE
+ Added props to change Previous and Next text on Pagination.

### DIFF
--- a/src/docs/pages/PaginationPage.tsx
+++ b/src/docs/pages/PaginationPage.tsx
@@ -58,6 +58,22 @@ const PaginationPage: FC = (): JSX.Element => {
         </div>
       ),
     },
+    {
+      title: "Change 'Previous' and 'Next' text",
+      code: (
+        <div className="flex items-center justify-center text-center">
+          <Pagination
+            currentPage={currentPage}
+            layout="pagination"
+            onPageChange={onPageChange}
+            showIcons
+            totalPages={1000}
+            previousText="Go back"
+            nextText="Go forward"
+          ></Pagination>
+        </div>
+      ),
+    },
   ];
 
   return <DemoPage examples={examples} />;

--- a/src/docs/pages/PaginationPage.tsx
+++ b/src/docs/pages/PaginationPage.tsx
@@ -68,8 +68,8 @@ const PaginationPage: FC = (): JSX.Element => {
             onPageChange={onPageChange}
             showIcons
             totalPages={1000}
-            previousText="Go back"
-            nextText="Go forward"
+            previousLabel="Go back"
+            nextLabel="Go forward"
           ></Pagination>
         </div>
       ),

--- a/src/lib/components/Pagination/Pagination.spec.tsx
+++ b/src/lib/components/Pagination/Pagination.spec.tsx
@@ -75,6 +75,22 @@ describe('Pagination', () => {
 
       expect(pages()).toHaveLength(0);
     });
+
+    it('should change previous and next text when provided', () => {
+      render(
+        <Pagination
+          currentPage={1}
+          layout="navigation"
+          onPageChange={() => undefined}
+          totalPages={5}
+          previousText="Go back"
+          nextText="Go forward"
+        ></Pagination>,
+      );
+
+      expect(previousButton()).toHaveTextContent('Go back');
+      expect(nextButton()).toHaveTextContent('Go forward');
+    });
   });
 });
 

--- a/src/lib/components/Pagination/Pagination.spec.tsx
+++ b/src/lib/components/Pagination/Pagination.spec.tsx
@@ -83,8 +83,8 @@ describe('Pagination', () => {
           layout="navigation"
           onPageChange={() => undefined}
           totalPages={5}
-          previousText="Go back"
-          nextText="Go forward"
+          previousLabel="Go back"
+          nextLabel="Go forward"
         ></Pagination>,
       );
 

--- a/src/lib/components/Pagination/index.tsx
+++ b/src/lib/components/Pagination/index.tsx
@@ -12,8 +12,8 @@ interface Pagination extends Omit<ComponentProps<'nav'>, 'className'> {
   onPageChange: (page: number) => void;
   showIcons?: boolean;
   totalPages: number;
-  previousText?: string;
-  nextText?: string;
+  previousLabel?: string;
+  nextLabel?: string;
 }
 
 export const Pagination: FC<PaginationProps> = ({
@@ -22,8 +22,8 @@ export const Pagination: FC<PaginationProps> = ({
   onPageChange,
   showIcons: showIcon = false,
   totalPages,
-  previousText = 'Previous',
-  nextText = 'Next',
+  previousLabel = 'Previous',
+  nextLabel = 'Next',
   ...props
 }): JSX.Element => {
   const firstPage = Math.max(1, currentPage - 3);
@@ -56,7 +56,7 @@ export const Pagination: FC<PaginationProps> = ({
             onClick={() => goToPreviousPage()}
           >
             {showIcon && <HiChevronLeft aria-hidden className={theme.pages.previous.icon} />}
-            {previousText}
+            {previousLabel}
           </button>
         </li>
         {layout === 'pagination' &&
@@ -79,7 +79,7 @@ export const Pagination: FC<PaginationProps> = ({
             className={classNames(theme.pages.next.base, showIcon && theme.pages.showIcon)}
             onClick={() => goToNextPage()}
           >
-            {nextText}
+            {nextLabel}
             {showIcon && <HiChevronRight aria-hidden className={theme.pages.next.icon} />}
           </button>
         </li>

--- a/src/lib/components/Pagination/index.tsx
+++ b/src/lib/components/Pagination/index.tsx
@@ -12,6 +12,8 @@ interface Pagination extends Omit<ComponentProps<'nav'>, 'className'> {
   onPageChange: (page: number) => void;
   showIcons?: boolean;
   totalPages: number;
+  previousText?: string;
+  nextText?: string;
 }
 
 export const Pagination: FC<PaginationProps> = ({
@@ -20,6 +22,8 @@ export const Pagination: FC<PaginationProps> = ({
   onPageChange,
   showIcons: showIcon = false,
   totalPages,
+  previousText = 'Previous',
+  nextText = 'Next',
   ...props
 }): JSX.Element => {
   const firstPage = Math.max(1, currentPage - 3);
@@ -52,7 +56,7 @@ export const Pagination: FC<PaginationProps> = ({
             onClick={() => goToPreviousPage()}
           >
             {showIcon && <HiChevronLeft aria-hidden className={theme.pages.previous.icon} />}
-            Previous
+            {previousText}
           </button>
         </li>
         {layout === 'pagination' &&
@@ -75,7 +79,7 @@ export const Pagination: FC<PaginationProps> = ({
             className={classNames(theme.pages.next.base, showIcon && theme.pages.showIcon)}
             onClick={() => goToNextPage()}
           >
-            Next
+            {nextText}
             {showIcon && <HiChevronRight aria-hidden className={theme.pages.next.icon} />}
           </button>
         </li>


### PR DESCRIPTION
+ Added test for changing pagination text.
+ Added an example on how change default Pagination text.

## Description

In this PR, I've added a new feature to change default `Previous` and `Next` text in the Pagination component. This was made possible by creating two new optional props called `previousText` and `nextText`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change contains documentation update

## Breaking changes
None.

## How Has This Been Tested?
I've ran the example pages and created an unit test exclusively for this new feature.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
