### PR TITLE
docs: migrate the Spinners to Hugo

### DIFF
--- a/docs/content/components/spinner.md
+++ b/docs/content/components/spinner.md
@@ -13,25 +13,109 @@ nextLink: components/toast/
 
 The spinner component can be used as a loading indicator which comes in multiple colors, sizes, and styles separately or inside elements such as buttons to improve the user experience whenever data is being fetched from your server.
 
-## Default spinner
+## Usage
 
-Use the following SVG element with the `animate-spin` animation class to show a loading animation:
+{{< example class="flex space-x-4 dark:bg-gray-800" github="docs/components/alerts.md" show_dark=true >}}
+import { Spinner } from 'flowbite-react'
 
-{{< example github="components/spinner.md" show_dark=true >}}
-<svg role="status" class="w-8 h-8 mr-2 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
+export default function App() {
+  return (
+    <>
+      <Spinner
+        color="info"
+        aria-label="Info spinner example"
+      />
+    </>
+  )
+}
+{{< /example >}}
+
+## Properties
+
+<div class="overflow-x-auto relative my-10 shadow-md sm:rounded-lg">
+  <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+    <thead class="bg-gray-50 dark:bg-gray-700">
+      <tr class="text-xs font-medium uppercase">
+        <th scope="col" class="py-3 px-6">
+          Parameter
+        </th>
+        <th scope="col" class="py-3 px-6">
+          Type
+        </th>
+        <th scope="col" class="py-3 px-6">
+          Required
+        </th>
+        <th scope="col" class="py-3 px-6">
+          Description
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="border-b dark:bg-gray-800 dark:border-gray-700">
+        <td class="py-4 px-6 font-medium">
+          <code class="text-blue-600 dark:text-blue-400">color</code>
+        </td>
+        <td class="py-4 px-6">
+          failure | gray | info | pink | purple | success | warning
+        </td>
+        <td class="py-4 px-6">
+          Optional
+        </td>
+        <td class="py-4 px-6">
+          The spinner color defined by the SpinnerColors interface (default: info)
+        </td>
+      </tr>
+      <tr class="border-b dark:bg-gray-800 dark:border-gray-700">
+        <td class="py-4 px-6 font-medium">
+          <code class="text-blue-600 dark:text-blue-400">light</code>
+        </td>
+        <td class="py-4 px-6">
+          boolean
+        </td>
+        <td class="py-4 px-6">
+          Optional
+        </td>
+        <td class="py-4 px-6">
+          Sets the spinner to light theme
+        </td>
+      </tr>
+      <tr class="border-b dark:bg-gray-800 dark:border-gray-700">
+        <td class="py-4 px-6 font-medium">
+          <code class="text-blue-600 dark:text-blue-400">size</code>
+        </td>
+        <td class="py-4 px-6">
+          xs | sm | md | lg | xl
+        </td>
+        <td class="py-4 px-6">
+          Optional
+        </td>
+        <td class="py-4 px-6">
+          The spinner size defined by the SpinnerSizes interface (default: md)
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+## Examples
+
+### Default Spinner
+
+Use the following examples of spinner components to show a loading animation.
+
+<svg role="status" class="inline w-8 h-8 mr-2 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
     <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
 </svg>
+
+{{< example github="components/spinner.md" show_dark=true >}}
+<Spinner aria-label="Default status example" />
 {{< /example >}}
 
-## Colors
+### Colors
 
-You can change the colors of the spinner element using the fill and color utility classes from Tailwind CSS:
+You can change the colors of the spinner element using the color property:
 
-- use `fill-{*}` to change the main colors
-- use `text-{*}` to change the background
-
-{{< example github="components/spinner.md" class="flex items-center" show_dark=true >}}
 <svg role="status" class="inline w-8 h-8 mr-2 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
     <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
@@ -60,13 +144,40 @@ You can change the colors of the spinner element using the fill and color utilit
     <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
     <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
 </svg>
+
+{{< example github="components/spinner.md" show_dark=true >}}
+<div className="flex flex-wrap gap-2">
+  <Spinner
+    color="info"
+    aria-label="Info spinner example"
+  />
+  <Spinner
+    color="success"
+    aria-label="Success spinner example"
+  />
+  <Spinner
+    color="failure"
+    aria-label="Failure spinner example"
+  />
+  <Spinner
+    color="warning"
+    aria-label="Warning spinner example"
+  />
+  <Spinner
+    color="pink"
+    aria-label="Pink spinner example"
+  />
+  <Spinner
+    color="purple"
+    aria-label="Purple spinner example"
+  />
+</div>
 {{< /example >}}
 
-## Sizes
+### Sizes
 
-Change the size of the spinner component using the `h-{*}` and `w-{*}` utility classes from Tailwind CSS:
+Change the size of the spinner component using the `size property:
 
-{{< example github="components/spinner.md" class="flex items-center" show_dark=true >}}
 <svg role="status" class="inline w-4 h-4 mr-2 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
     <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
@@ -83,13 +194,36 @@ Change the size of the spinner component using the `h-{*}` and `w-{*}` utility c
     <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
     <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
 </svg>
+
+{{< example github="components/spinner.md" show_dark=true >}}
+<div className="flex flex-wrap items-center gap-2">
+  <Spinner
+    aria-label="Extra small spinner example"
+    size="xs"
+  />
+  <Spinner
+    aria-label="Small spinner example"
+    size="sm"
+  />
+  <Spinner
+    aria-label="Medium sized spinner example"
+    size="md"
+  />
+  <Spinner
+    aria-label="Large spinner example"
+    size="lg"
+  />
+  <Spinner
+    aria-label="Extra large spinner example"
+    size="xl"
+  />
+</div>
 {{< /example >}}
 
 ## Alignment
 
 Because the spinner component is an inline HTML element it can easily be aligned on the left, center, or right side using the `text-{left|center|right}` utility classes:
 
-{{< example github="components/spinner.md" show_dark=true >}}
 <div class="text-left">
     <svg role="status" class="inline w-8 h-8 mr-2 text-gray-200 animate-spin dark:text-gray-600 fill-blue-600" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="currentColor"/>
@@ -108,13 +242,25 @@ Because the spinner component is an inline HTML element it can easily be aligned
         <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentFill"/>
     </svg>
 </div>
+
+{{< example github="components/spinner.md" show_dark=true >}}
+<div className="flex flex-col gap-2">
+  <div className="text-left">
+    <Spinner aria-label="Left-aligned spinner example" />
+  </div>
+  <div className="text-center">
+    <Spinner aria-label="Center-aligned spinner example" />
+  </div>
+  <div className="text-right">
+    <Spinner aria-label="Right-aligned spinner example" />
+  </div>
+</div>
 {{< /example >}}
 
-## Buttons
+### Buttons
 
 The spinner component can also be used inside elements such as buttons when submitting form data:
 
-{{< example github="components/spinner.md" show_dark=true >}}
 <button disabled type="button" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center mr-2 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 inline-flex items-center">
     <svg role="status" class="inline w-4 h-4 mr-3 text-white animate-spin" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="#E5E7EB"/>
@@ -129,4 +275,20 @@ The spinner component can also be used inside elements such as buttons when subm
     </svg>
     Loading...
 </button>
+
+{{< example github="components/spinner.md" show_dark=true >}}
+<div className="flex flex-row gap-3">
+  <Button>
+    <Spinner aria-label="Spinner button example" />
+    <span className="pl-3">
+      Loading...
+    </span>
+  </Button>
+  <Button color="gray">
+    <Spinner aria-label="Alternate spinner button example" />
+    <span className="pl-3">
+      Loading...
+    </span>
+  </Button>
+</div>
 {{< /example >}}


### PR DESCRIPTION
## Description

This PR moves the spinners documentation from the [current documentation page](https://flowbite-react.com/spinners) to Hugo. It looks similar to the alert example that can be found [here](https://github.com/themesberg/flowbite-react/blob/main/docs/content/components/alerts.md)

Fixes #291 and has no breaking changes.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change contains documentation update

## Breaking changes

N/A

## How Has This Been Tested?

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
