### PR TITLE
Updated license link in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,4 +386,4 @@ If you need the Figma files for the components you can check out our website for
 
 The Flowbite name and logos are trademarks of Crafty Dwarf Inc.
 
-📝 [Read about the licensing terms](https://flowbite.com/getting-started/license/)
+📝 [Read about the licensing terms](https://flowbite.com/docs/getting-started/license/)


### PR DESCRIPTION
## Description

I updated the "Read about the licensing terms" link in the README file. The link was directing users to https://flowbite.com/getting-started/license/, which gives a 404 error. The updated link is https://flowbite.com/docs/getting-started/license/

Fixes # 371

## Type of change

- [x] This change contains documentation update

## Breaking changes

Please document the breaking changes if suitable.

N/A

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I tested the new URL to ensure that it takes the user to the correct License page on the Flowbite site.

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
