### PR TITLE
feat: allow using initials as `Avatar` placeholder

### DIFF
--- a/src/docs/pages/AvatarPage.tsx
+++ b/src/docs/pages/AvatarPage.tsx
@@ -33,6 +33,14 @@ const AvatarPage: FC = () => {
       ),
     },
     {
+      title: 'Placeholder Initials',
+      code: (
+        <div className="flex flex-wrap gap-2">
+          <Avatar placeholderInitials="RR" />
+        </div>
+      ),
+    },
+    {
       title: 'Dot indicator',
       code: (
         <div className="flex flex-wrap gap-2">

--- a/src/lib/components/Avatar/Avatar.spec.tsx
+++ b/src/lib/components/Avatar/Avatar.spec.tsx
@@ -4,8 +4,8 @@ import { Avatar } from '.';
 import { Flowbite } from '../Flowbite';
 import type { CustomFlowbiteTheme } from '../Flowbite/FlowbiteTheme';
 
-describe.concurrent('Components / Avatar', () => {
-  describe.concurrent('Theme', () => {
+describe('Components / Avatar', () => {
+  describe('Theme', () => {
     it('should use custom classes', () => {
       const theme: CustomFlowbiteTheme = {
         avatar: {
@@ -23,6 +23,18 @@ describe.concurrent('Components / Avatar', () => {
       expect(img()).toHaveClass('h-64 w-64');
     });
   });
+  describe('Placeholder', () => {
+    it('should display placeholder initials', () => {
+      render(
+        <Flowbite>
+          <Avatar placeholderInitials="RR" />
+        </Flowbite>,
+      );
+
+      expect(initialsPlaceholder()).toHaveTextContent('RR');
+    });
+  });
 });
 
 const img = () => screen.getByTestId('flowbite-avatar-img');
+const initialsPlaceholder = () => screen.getByTestId('flowbite-avatar-initials-placeholder');

--- a/src/lib/components/Avatar/index.tsx
+++ b/src/lib/components/Avatar/index.tsx
@@ -55,8 +55,16 @@ const AvatarComponent: FC<AvatarProps> = ({
             src={img}
           />
         ) : placeholderInitials ? (
-          <div className="inline-flex overflow-hidden relative justify-center items-center w-10 h-10 bg-gray-100 rounded-full dark:bg-gray-600">
-            <span className="font-medium text-gray-600 dark:text-gray-300">{placeholderInitials}</span>
+          <div
+            className={classNames(
+              theme.img.off,
+              theme.initials.base,
+              rounded && theme.rounded,
+              stacked && theme.stacked,
+              bordered && theme.bordered,
+            )}
+          >
+            <span className={classNames(theme.initials.text)}>{placeholderInitials}</span>
           </div>
         ) : (
           <div

--- a/src/lib/components/Avatar/index.tsx
+++ b/src/lib/components/Avatar/index.tsx
@@ -15,6 +15,7 @@ export interface AvatarProps extends PropsWithChildren<Omit<ComponentProps<'div'
   stacked?: boolean;
   status?: 'away' | 'busy' | 'offline' | 'online';
   statusPosition?: keyof FlowbitePositions;
+  placeholderInitials?: string;
 }
 
 export interface AvatarSizes extends Pick<FlowbiteSizes, 'xs' | 'sm' | 'md' | 'lg' | 'xl'> {
@@ -31,6 +32,7 @@ const AvatarComponent: FC<AvatarProps> = ({
   stacked = false,
   status,
   statusPosition = 'top-left',
+  placeholderInitials = '',
   ...props
 }) => {
   const theirProps = excludeClassName(props);
@@ -52,6 +54,10 @@ const AvatarComponent: FC<AvatarProps> = ({
             data-testid="flowbite-avatar-img"
             src={img}
           />
+        ) : placeholderInitials ? (
+          <div className="inline-flex overflow-hidden relative justify-center items-center w-10 h-10 bg-gray-100 rounded-full dark:bg-gray-600">
+            <span className="font-medium text-gray-600 dark:text-gray-300">{placeholderInitials}</span>
+          </div>
         ) : (
           <div
             className={classNames(

--- a/src/lib/components/Avatar/index.tsx
+++ b/src/lib/components/Avatar/index.tsx
@@ -64,7 +64,9 @@ const AvatarComponent: FC<AvatarProps> = ({
               bordered && theme.bordered,
             )}
           >
-            <span className={classNames(theme.initials.text)}>{placeholderInitials}</span>
+            <span className={classNames(theme.initials.text)} data-testid="flowbite-avatar-initials-placeholder">
+              {placeholderInitials}
+            </span>
           </div>
         ) : (
           <div

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -80,6 +80,10 @@ export interface FlowbiteTheme extends Record<string, unknown> {
       online: string;
     };
     statusPosition: FlowbitePositions;
+    initials: {
+      base: string;
+      text: string;
+    };
   };
   badge: {
     base: string;
@@ -556,4 +560,8 @@ export interface FlowbiteSizes {
   '5xl': string;
   '6xl': string;
   '7xl': string;
+}
+
+export interface FlowbiteContentPositions {
+  center: string;
 }

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -90,6 +90,10 @@ const theme: FlowbiteTheme = {
       center: 'center center',
       'center-left': 'center -left-1',
     },
+    initials: {
+      text: 'font-medium text-gray-600 dark:text-gray-300',
+      base: 'inline-flex overflow-hidden relative justify-center items-center w-10 h-10 bg-gray-100 dark:bg-gray-600',
+    },
   },
   badge: {
     base: 'flex h-fit items-center gap-1 font-semibold',


### PR DESCRIPTION
Refs: #357

## Description

This PR adds a new prop, `placeholderInitials`, to the `Avatar` component. String passed in this prop will be displayed as `Avatar`'s placeholder, if image is not provided.

Fixes #357 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change contains documentation update

## Breaking changes

No breaking changes

## How Has This Been Tested?

Just checked visually

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

[Screencast from 10-10-22 01:57:39 AM IST.webm](https://user-images.githubusercontent.com/51338731/194778097-ea0ceee2-d2be-4763-8267-54231c806110.webm)