### PR TITLE
fix(button): reduce the thickness of button outline

### DIFF
--- a/src/lib/components/Button/index.tsx
+++ b/src/lib/components/Button/index.tsx
@@ -73,7 +73,7 @@ const ButtonComponent: FC<ButtonProps> = ({
         gradientDuoTone && !gradientMonochrome && theme.gradientDuoTone[gradientDuoTone],
         !gradientDuoTone && gradientMonochrome && theme.gradient[gradientMonochrome],
         groupTheme.position[positionInGroup],
-        outline && theme.outline.color[color],
+        outline && (theme.outline.color[color] ?? theme.outline.color.default),
         theme.base,
         theme.pill[pill ? 'on' : 'off'],
       )}
@@ -89,6 +89,7 @@ const ButtonComponent: FC<ButtonProps> = ({
           theme.outline[outline ? 'on' : 'off'],
           theme.outline.pill[outline && pill ? 'on' : 'off'],
           theme.size[size],
+          outline && !theme.outline.color[color] && theme.inner.outline
         )}
       >
         <>

--- a/src/lib/components/Button/index.tsx
+++ b/src/lib/components/Button/index.tsx
@@ -89,7 +89,7 @@ const ButtonComponent: FC<ButtonProps> = ({
           theme.outline[outline ? 'on' : 'off'],
           theme.outline.pill[outline && pill ? 'on' : 'off'],
           theme.size[size],
-          outline && !theme.outline.color[color] && theme.inner.outline
+          outline && !theme.outline.color[color] && theme.inner.outline,
         )}
       >
         <>

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -113,6 +113,7 @@ export interface FlowbiteTheme extends Record<string, unknown> {
     inner: {
       base: string;
       position: PositionInButtonGroup;
+      outline: string;
     };
     label: string;
     outline: FlowbiteBoolean & {

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -190,12 +190,15 @@ const theme: FlowbiteTheme = {
         middle: '!rounded-none',
         end: 'rounded-l-none',
       },
+      outline: 'border border-transparent'
     },
     label:
       'ml-2 inline-flex h-4 w-4 items-center justify-center rounded-full bg-blue-200 text-xs font-semibold text-blue-800',
     outline: {
       color: {
         gray: 'border border-gray-900 dark:border-white',
+        default: 'border-0',
+        light: '',
       },
       off: '',
       on: 'bg-white text-gray-900 transition-all duration-75 ease-in group-hover:bg-opacity-0 group-hover:text-inherit dark:bg-gray-900 dark:text-white',

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -190,7 +190,7 @@ const theme: FlowbiteTheme = {
         middle: '!rounded-none',
         end: 'rounded-l-none',
       },
-      outline: 'border border-transparent'
+      outline: 'border border-transparent',
     },
     label:
       'ml-2 inline-flex h-4 w-4 items-center justify-center rounded-full bg-blue-200 text-xs font-semibold text-blue-800',


### PR DESCRIPTION
## Description

This PR reduces the thickness of the button outline when the outline prop is set to true.

Fixes [#361](https://github.com/themesberg/flowbite-react/issues/361)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change contains documentation update

## Breaking changes

No breaking changes

## How Has This Been Tested?
Manually (Visually)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
