### PR TITLE
Added defaultIsOpen prop to SidebarCollapse and updated Storybook component

### DIFF
--- a/src/lib/components/Sidebar/Sidebar.stories.tsx
+++ b/src/lib/components/Sidebar/Sidebar.stories.tsx
@@ -106,6 +106,44 @@ MultiLevelDropdown.args = {
   collapsed: false,
 };
 
+export const DefaultExpandedDropdown = Template.bind({});
+DefaultExpandedDropdown.storyName = 'Default Expanded Dropdown';
+DefaultExpandedDropdown.args = {
+  children: (
+    <>
+      <Sidebar.Items>
+        <Sidebar.ItemGroup>
+          <Sidebar.Item href="#" icon={HiChartPie}>
+            Dashboard
+          </Sidebar.Item>
+          <Sidebar.Collapse icon={HiShoppingBag} label="E-commerce">
+            <Sidebar.Item href="#">Products</Sidebar.Item>
+          </Sidebar.Collapse>
+          <Sidebar.Collapse icon={HiShoppingBag} label="Billing" defaultIsOpen>
+            <Sidebar.Item href="#">Usage Summary</Sidebar.Item>
+          </Sidebar.Collapse>
+          <Sidebar.Item href="#" icon={HiInbox}>
+            Inbox
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiUser}>
+            Users
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiShoppingBag}>
+            Products
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiArrowSmRight}>
+            Sign In
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiTable}>
+            Sign Up
+          </Sidebar.Item>
+        </Sidebar.ItemGroup>
+      </Sidebar.Items>
+    </>
+  ),
+  collapsed: false,
+};
+
 export const ContentSeparator = Template.bind({});
 ContentSeparator.storyName = 'Content separator';
 ContentSeparator.args = {

--- a/src/lib/components/Sidebar/SidebarCollapse.tsx
+++ b/src/lib/components/Sidebar/SidebarCollapse.tsx
@@ -11,7 +11,13 @@ import { SidebarItemContext } from './SidebarItemContext';
 
 export type SidebarCollapseProps = PropsWithChildren<ComponentProps<'button'> & SidebarItemProps>;
 
-const SidebarCollapse: FC<SidebarCollapseProps> = ({ children, icon: Icon, label, defaultIsOpen = false, ...props }): JSX.Element => {
+const SidebarCollapse: FC<SidebarCollapseProps> = ({
+  children,
+  icon: Icon,
+  label,
+  defaultIsOpen = false,
+  ...props
+}): JSX.Element => {
   const theirProps = excludeClassName(props);
 
   const id = useId();

--- a/src/lib/components/Sidebar/SidebarCollapse.tsx
+++ b/src/lib/components/Sidebar/SidebarCollapse.tsx
@@ -11,12 +11,12 @@ import { SidebarItemContext } from './SidebarItemContext';
 
 export type SidebarCollapseProps = PropsWithChildren<ComponentProps<'button'> & SidebarItemProps>;
 
-const SidebarCollapse: FC<SidebarCollapseProps> = ({ children, icon: Icon, label, ...props }): JSX.Element => {
+const SidebarCollapse: FC<SidebarCollapseProps> = ({ children, icon: Icon, label, defaultIsOpen = false, ...props }): JSX.Element => {
   const theirProps = excludeClassName(props);
 
   const id = useId();
   const { isCollapsed } = useSidebarContext();
-  const [isOpen, setOpen] = useState(false);
+  const [isOpen, setOpen] = useState(defaultIsOpen);
   const theme = useTheme().theme.sidebar.collapse;
 
   const Wrapper: FC<PropsWithChildren<unknown>> = ({ children }): JSX.Element => (


### PR DESCRIPTION
## Description

Added defaultIsOpen prop to SidebarCollapse; Added storybook component to demonstrate using defaultIsOpen

Fixes # (issue) N/A

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Breaking changes

N/A

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Import the `Sidebar.Collapse` into an existing `Sidebar` component
- Add the `defaultIsOpen` prop
- Verify the sidebar dropdown is expanded by default on page load
- Remove the flag and refresh
- Verify the dropdown is collapsed

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
