### PR TITLE
feat(themecontext): exported theme hooks and updated docs

### DIFF
--- a/src/docs/pages/ThemePage.tsx
+++ b/src/docs/pages/ThemePage.tsx
@@ -58,6 +58,19 @@ const ThemePage: FC = () => {
           )}
         </SyntaxHighlighter>
       </Card>
+      <span className="text-xl font-bold">Get the theme</span>
+      <p>
+        For more customizations, there is the possibility to get the theme with the <strong>useTheme</strong> hook and
+        its mode with the <strong>useThemeMode</strong> hook.
+      </p>
+      <Card>
+        <SyntaxHighlighter language="tsx" style={dracula}>
+          const theme = useTheme().theme.button;
+        </SyntaxHighlighter>
+        <SyntaxHighlighter language="tsx" style={dracula}>
+          const [mode, setMode, toggleMode] = useThemeMode(usePreferences);
+        </SyntaxHighlighter>
+      </Card>
     </div>
   );
 };

--- a/src/lib/components/Flowbite/index.tsx
+++ b/src/lib/components/Flowbite/index.tsx
@@ -5,7 +5,7 @@ import { mergeDeep } from '../../helpers/mergeDeep';
 import windowExists from '../../helpers/window-exists';
 import defaultTheme from '../../theme/default';
 import type { FlowbiteTheme } from './FlowbiteTheme';
-import { ThemeContext, useThemeMode } from './ThemeContext';
+import { ThemeContext, useTheme, useThemeMode } from './ThemeContext';
 
 export interface ThemeProps {
   dark?: boolean;
@@ -49,3 +49,4 @@ export const Flowbite: FC<FlowbiteProps> = ({ children, theme = {} }) => {
 };
 
 export type { FlowbiteTheme } from './FlowbiteTheme';
+export { useTheme, useThemeMode };


### PR DESCRIPTION
Exported `useTheme` and `useThemeMode` hooks from `ThemeContext` and updated theme docs.

fix #389

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change contains documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
