### PR TITLE
feat(button): added forwardRef to button component

### DIFF
--- a/src/lib/components/Button/index.tsx
+++ b/src/lib/components/Button/index.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import type { ComponentProps, FC, ReactNode } from 'react';
+import { forwardRef, type ComponentProps, type ReactNode } from 'react';
 import { excludeClassName } from '../../helpers/exclude';
 import type {
   FlowbiteColors,
@@ -11,7 +11,7 @@ import { useTheme } from '../Flowbite/ThemeContext';
 import type { PositionInButtonGroup } from './ButtonGroup';
 import ButtonGroup from './ButtonGroup';
 
-export interface ButtonProps extends Omit<ComponentProps<'button'>, 'className' | 'color'> {
+export interface ButtonProps extends Omit<ComponentProps<'button'>, 'className' | 'color' | 'ref'> {
   color?: keyof ButtonColors;
   gradientDuoTone?: keyof ButtonGradientDuoToneColors;
   gradientMonochrome?: keyof ButtonGradientColors;
@@ -44,66 +44,72 @@ export interface ButtonSizes extends Pick<FlowbiteSizes, 'xs' | 'sm' | 'lg' | 'x
   [key: string]: string;
 }
 
-const ButtonComponent: FC<ButtonProps> = ({
-  children,
-  color = 'info',
-  disabled = false,
-  gradientDuoTone,
-  gradientMonochrome,
-  href,
-  label,
-  outline = false,
-  pill = false,
-  positionInGroup = 'none',
-  size = 'md',
-  ...props
-}): JSX.Element => {
-  const isLink = typeof href !== 'undefined';
-  const theirProps = excludeClassName(props);
+const ButtonComponent = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(
+  (
+    {
+      children,
+      color = 'info',
+      disabled = false,
+      gradientDuoTone,
+      gradientMonochrome,
+      href,
+      label,
+      outline = false,
+      pill = false,
+      positionInGroup = 'none',
+      size = 'md',
+      ...props
+    },
+    ref,
+  ): JSX.Element => {
+    const isLink = typeof href !== 'undefined';
+    const theirProps = excludeClassName(props);
 
-  const { buttonGroup: groupTheme, button: theme } = useTheme().theme;
+    const { buttonGroup: groupTheme, button: theme } = useTheme().theme;
 
-  const Component = isLink ? 'a' : 'button';
+    const Component = isLink ? 'a' : 'button';
 
-  return (
-    <Component
-      className={classNames(
-        disabled && theme.disabled,
-        !gradientDuoTone && !gradientMonochrome && theme.color[color],
-        gradientDuoTone && !gradientMonochrome && theme.gradientDuoTone[gradientDuoTone],
-        !gradientDuoTone && gradientMonochrome && theme.gradient[gradientMonochrome],
-        groupTheme.position[positionInGroup],
-        outline && (theme.outline.color[color] ?? theme.outline.color.default),
-        theme.base,
-        theme.pill[pill ? 'on' : 'off'],
-      )}
-      disabled={disabled}
-      href={href}
-      type={isLink ? undefined : 'button'}
-      {...theirProps}
-    >
-      <span
+    return (
+      <Component
         className={classNames(
-          theme.inner.base,
-          theme.inner.position[positionInGroup],
-          theme.outline[outline ? 'on' : 'off'],
-          theme.outline.pill[outline && pill ? 'on' : 'off'],
-          theme.size[size],
-          outline && !theme.outline.color[color] && theme.inner.outline,
+          disabled && theme.disabled,
+          !gradientDuoTone && !gradientMonochrome && theme.color[color],
+          gradientDuoTone && !gradientMonochrome && theme.gradientDuoTone[gradientDuoTone],
+          !gradientDuoTone && gradientMonochrome && theme.gradient[gradientMonochrome],
+          groupTheme.position[positionInGroup],
+          outline && (theme.outline.color[color] ?? theme.outline.color.default),
+          theme.base,
+          theme.pill[pill ? 'on' : 'off'],
         )}
+        disabled={disabled}
+        href={href}
+        type={isLink ? undefined : 'button'}
+        ref={ref as never}
+        {...theirProps}
       >
-        <>
-          {typeof children !== 'undefined' && children}
-          {typeof label !== 'undefined' && (
-            <span className={theme.label} data-testid="flowbite-button-label">
-              {label}
-            </span>
+        <span
+          className={classNames(
+            theme.inner.base,
+            theme.inner.position[positionInGroup],
+            theme.outline[outline ? 'on' : 'off'],
+            theme.outline.pill[outline && pill ? 'on' : 'off'],
+            theme.size[size],
+            outline && !theme.outline.color[color] && theme.inner.outline,
           )}
-        </>
-      </span>
-    </Component>
-  );
-};
+        >
+          <>
+            {typeof children !== 'undefined' && children}
+            {typeof label !== 'undefined' && (
+              <span className={theme.label} data-testid="flowbite-button-label">
+                {label}
+              </span>
+            )}
+          </>
+        </span>
+      </Component>
+    );
+  },
+);
 
 ButtonComponent.displayName = 'Button';
 export const Button = Object.assign(ButtonComponent, {


### PR DESCRIPTION
Added forwardRef to button component to work with Next.js' Link component.

fix #341

## Description

This PR adds `forwardRef` to Flowbite's `Button` component to ensure, that it works nicely with the `Link` component from Next.js.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
