### PR TITLE
fix(dropdown): close dropdown when item is selected

### DIFF
--- a/src/lib/components/Dropdown/Dropdown.spec.tsx
+++ b/src/lib/components/Dropdown/Dropdown.spec.tsx
@@ -27,6 +27,17 @@ describe('Components / Dropdown', () => {
       expect(dropdown()).toHaveClass('invisible');
     });
   });
+  describe('Mouse interactions', () => {
+    it('should collapse if item is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TestDropdown />);
+
+      await user.click(button());
+      await userEvent.click(screen.getByText('Dashboard'));
+
+      expect(dropdown()).toHaveClass('invisible');
+    })
+  })
 });
 
 const TestDropdown: FC = () => (

--- a/src/lib/components/Dropdown/Dropdown.spec.tsx
+++ b/src/lib/components/Dropdown/Dropdown.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FC } from 'react';
 import { describe, expect, it } from 'vitest';
@@ -32,8 +32,10 @@ describe('Components / Dropdown', () => {
       const user = userEvent.setup();
       render(<TestDropdown />);
 
-      await user.click(button());
-      await userEvent.click(screen.getByText('Dashboard'));
+      act(() => {
+        user.click(button());
+        userEvent.click(dropdownItem());
+      });
 
       expect(dropdown()).toHaveClass('invisible');
     });
@@ -57,3 +59,5 @@ const TestDropdown: FC = () => (
 const button = () => screen.getByRole('button');
 
 const dropdown = () => screen.getByTestId('flowbite-tooltip');
+
+const dropdownItem = () => screen.getByText('Dashboard');

--- a/src/lib/components/Dropdown/Dropdown.spec.tsx
+++ b/src/lib/components/Dropdown/Dropdown.spec.tsx
@@ -36,8 +36,8 @@ describe('Components / Dropdown', () => {
       await userEvent.click(screen.getByText('Dashboard'));
 
       expect(dropdown()).toHaveClass('invisible');
-    })
-  })
+    });
+  });
 });
 
 const TestDropdown: FC = () => (

--- a/src/lib/components/Dropdown/DropdownItem.tsx
+++ b/src/lib/components/Dropdown/DropdownItem.tsx
@@ -3,20 +3,14 @@ import { useTheme } from '../Flowbite/ThemeContext';
 
 export type DropdownItemProps = PropsWithChildren<{
   onClick?: () => void;
-  closeDropdown?: () => void;
   icon?: FC<ComponentProps<'svg'>>;
 }>;
 
-export const DropdownItem: FC<DropdownItemProps> = ({ children, onClick, icon: Icon, closeDropdown }) => {
+export const DropdownItem: FC<DropdownItemProps> = ({ children, onClick, icon: Icon }) => {
   const theme = useTheme().theme.dropdown.floating.item;
 
-  const handleClick = () => {
-    onClick?.();
-    closeDropdown?.();
-  };
-
   return (
-    <li className={theme.base} onClick={handleClick}>
+    <li className={theme.base} onClick={onClick}>
       {Icon && <Icon className={theme.icon} />}
       {children}
     </li>

--- a/src/lib/components/Dropdown/DropdownItem.tsx
+++ b/src/lib/components/Dropdown/DropdownItem.tsx
@@ -3,14 +3,20 @@ import { useTheme } from '../Flowbite/ThemeContext';
 
 export type DropdownItemProps = PropsWithChildren<{
   onClick?: () => void;
+  closeDropdown?: () => void;
   icon?: FC<ComponentProps<'svg'>>;
 }>;
 
-export const DropdownItem: FC<DropdownItemProps> = ({ children, onClick, icon: Icon }) => {
+export const DropdownItem: FC<DropdownItemProps> = ({ children, onClick, icon: Icon, closeDropdown }) => {
   const theme = useTheme().theme.dropdown.floating.item;
 
+  const handleClick = () => {
+    onClick?.();
+    closeDropdown?.();
+  };
+
   return (
-    <li className={theme.base} onClick={onClick}>
+    <li className={theme.base} onClick={handleClick}>
       {Icon && <Icon className={theme.icon} />}
       {children}
     </li>

--- a/src/lib/components/Dropdown/index.tsx
+++ b/src/lib/components/Dropdown/index.tsx
@@ -81,7 +81,12 @@ const DropdownComponent: FC<DropdownProps> = ({ children, ...props }) => {
   const attachCloseListener: any = (node: ReactNode) => {
     if (!React.isValidElement(node)) return node;
     if ((node as ReactElement).type === DropdownItem)
-      return React.cloneElement(node, { closeDropdown: () => setCloseRequestKey(uuid()) });
+      return React.cloneElement(node, {
+        onClick: () => {
+          node.props.onClick?.();
+          setCloseRequestKey(uuid());
+        },
+      });
     if (node.props.children && typeof node.props.children === 'object') {
       return React.cloneElement(node, { children: Children.map(node.props.children, attachCloseListener) });
     }

--- a/src/lib/components/Dropdown/index.tsx
+++ b/src/lib/components/Dropdown/index.tsx
@@ -74,6 +74,10 @@ const DropdownComponent: FC<DropdownProps> = ({ children, ...props }) => {
 
   const [closeRequestKey, setCloseRequestKey] = useState<string | undefined>(undefined);
 
+  /**
+   * Adds closeDropdown callback to DropdownItem instances that sends a close request to Floating when clicked.
+   * @param node current element being traversed
+   */
   const attachCloseListener: any = (node: ReactNode) => {
     if (!React.isValidElement(node)) return node;
     if ((node as ReactElement).type === DropdownItem)

--- a/src/lib/components/Dropdown/index.tsx
+++ b/src/lib/components/Dropdown/index.tsx
@@ -74,10 +74,7 @@ const DropdownComponent: FC<DropdownProps> = ({ children, ...props }) => {
 
   const [closeRequestKey, setCloseRequestKey] = useState<string | undefined>(undefined);
 
-  /**
-   * Adds closeDropdown callback to DropdownItem instances that sends a close request to Floating when clicked.
-   * @param node current element being traversed
-   */
+  // Extends DropdownItem's onClick to trigger a close request to the Floating component
   const attachCloseListener: any = (node: ReactNode) => {
     if (!React.isValidElement(node)) return node;
     if ((node as ReactElement).type === DropdownItem)

--- a/src/lib/components/Floating/index.tsx
+++ b/src/lib/components/Floating/index.tsx
@@ -45,6 +45,7 @@ export interface FloatingProps extends PropsWithChildren<Omit<ComponentProps<'di
   style?: 'dark' | 'light' | 'auto';
   animation?: false | `duration-${number}`;
   arrow?: boolean;
+  closeRequestKey?: string;
 }
 
 /**
@@ -59,6 +60,7 @@ export const Floating: FC<FloatingProps> = ({
   placement = 'top',
   style = 'dark',
   trigger = 'hover',
+  closeRequestKey,
   ...props
 }) => {
   const theirProps = excludeClassName(props);
@@ -96,6 +98,10 @@ export const Floating: FC<FloatingProps> = ({
       return autoUpdate(refs.reference.current, refs.floating.current, update);
     }
   }, [open, refs.floating, refs.reference, update]);
+
+  useEffect(() => {
+    if (closeRequestKey !== undefined) setOpen(false);
+  }, [closeRequestKey]);
 
   return (
     <>

--- a/src/lib/helpers/uuid.ts
+++ b/src/lib/helpers/uuid.ts
@@ -1,0 +1,7 @@
+export function uuid() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0,
+      v = c == 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
## Description

Closes the dropdown floating menu whenever a DropdownItem is clicked.

Inside `Dropdown/index.tsx`, a mapping function is executed that extends the `onClick` props of all instances of DropdownItem. The extended lines trigger a local state change to `closeRequestKey` that is passed to the `Floating/index.tsx` component.

`setOpen(false)` is called inside the Floating component whenever the closeRequestKey is changed to a unique string generated by the UUID helper function. 

This emulates the Dropdown component requesting Floating to close itself. This is the only workaround that I can think of due to how the component is designed. Floating is contained with Dropdown, preventing other ways of passing control of the `open` state to Dropdown and its child.

We can move this entirely in `Floating/index.tsx` to perform the mapping but since it is reused on other components, I opted to isolate most changes on the Dropdown components themselves.

Fixes #349 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual test through StoryBook

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
