### PR TITLE
flowbit-tooltip is behind card issue fixed

### DIFF
--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -856,7 +856,7 @@ const theme: FlowbiteTheme = {
   },
   tooltip: {
     target: 'w-fit',
-    base: 'absolute inline-block rounded-lg py-2 px-3 text-sm font-medium shadow-sm',
+    base: 'absolute inline-block z-10 rounded-lg py-2 px-3 text-sm font-medium shadow-sm',
     animation: 'transition-opacity',
     hidden: 'invisible opacity-0',
     style: {


### PR DESCRIPTION
## Description
Fixed the flowbite tooltip which appears on the hover of the sidebar. The tooltip goes behind a card which is fixed now.

Before:
![image](https://user-images.githubusercontent.com/83518670/196784709-157945c3-6793-46f3-b8e5-81bc7da6e5d4.png)

After:
![image](https://user-images.githubusercontent.com/83518670/196784853-ef38be0a-a077-4803-a1ea-f22d4bc23f71.png)\

Fixes #359 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an 


## Breaking changes


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
