### PR TITLE
Fix inline dropdown bug

### DIFF
--- a/src/lib/components/Floating/Floating.tsx
+++ b/src/lib/components/Floating/Floating.tsx
@@ -85,13 +85,6 @@ export const Floating: FC<FloatingProps> = ({
     y,
   } = floatingTooltip;
 
-  // const { getFloatingProps, getReferenceProps } = useInteractions([
-  //   useClick(context, { enabled: trigger === 'click' }),
-  //   useFocus(context),
-  //   useHover(context, { enabled: trigger === 'hover' }),
-  //   useRole(context, { role: 'tooltip' }),
-  // ]);
-
   const { getFloatingProps, getReferenceProps } = useInteractions([
     useClick(context, { enabled: trigger === 'click' }),
     useFocus(context),

--- a/src/lib/components/Floating/Floating.tsx
+++ b/src/lib/components/Floating/Floating.tsx
@@ -1,6 +1,7 @@
 import type { Placement } from '@floating-ui/core';
 import {
   autoUpdate,
+  safePolygon,
   useClick,
   useFloating,
   useFocus,
@@ -84,10 +85,20 @@ export const Floating: FC<FloatingProps> = ({
     y,
   } = floatingTooltip;
 
+  // const { getFloatingProps, getReferenceProps } = useInteractions([
+  //   useClick(context, { enabled: trigger === 'click' }),
+  //   useFocus(context),
+  //   useHover(context, { enabled: trigger === 'hover' }),
+  //   useRole(context, { role: 'tooltip' }),
+  // ]);
+
   const { getFloatingProps, getReferenceProps } = useInteractions([
     useClick(context, { enabled: trigger === 'click' }),
     useFocus(context),
-    useHover(context, { enabled: trigger === 'hover' }),
+    useHover(context, {
+      enabled: trigger === 'hover',
+      handleClose: safePolygon(),
+    }),
     useRole(context, { role: 'tooltip' }),
   ]);
 


### PR DESCRIPTION
## Description

The dropdown component in the hover trigger mode mouse enter was working fine ok, but mouse leave, the dropdown items were not clickable, the dropdown would close too

Fixes #394  

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change contains documentation update

## Breaking changes

Please document the breaking changes if suitable.

## How Has This Been Tested?

I have visually checked the changes on the storybook on my local machine here is a recording of this working.

https://user-images.githubusercontent.com/75097551/199706925-269f46ba-617a-4647-b053-4f90742b00aa.mov


- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
