### PR TITLE
fix(DarkThemeToggle): should toggle the theme with `usePreferences` is false (#417)

### DIFF
--- a/src/lib/components/DarkThemeToggle/DarkThemeToggle.spec.tsx
+++ b/src/lib/components/DarkThemeToggle/DarkThemeToggle.spec.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { Flowbite } from '../Flowbite';
 import { DarkThemeToggle } from './DarkThemeToggle';
 
-describe.concurrent('Dark theme toggle', () => {
+describe('Dark theme toggle', () => {
   it('should toggle the theme when `Space` is pressed', async () => {
     const user = userEvent.setup();
     render(
@@ -12,6 +12,24 @@ describe.concurrent('Dark theme toggle', () => {
         <DarkThemeToggle />
       </Flowbite>,
     );
+
+    await user.tab();
+    await user.keyboard('[Space]');
+
+    expect(screen.queryByLabelText('Currently light mode')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Currently dark mode')).toBeInTheDocument();
+  });
+
+  it('should toggle the theme with `usePreferences` is false', async () => {
+    const user = userEvent.setup();
+    render(
+      <Flowbite theme={{ usePreferences: false }}>
+        <DarkThemeToggle />
+      </Flowbite>,
+    );
+
+    expect(screen.queryByLabelText('Currently light mode')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Currently dark mode')).not.toBeInTheDocument();
 
     await user.tab();
     await user.keyboard('[Space]');


### PR DESCRIPTION
## Description

The DarkThemeToggle component's button is now working when `usePreferences=true`.

Fixes #417 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] it should toggle the theme with `usePreferences` is false

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
