### PR TITLE
feat(avatar): adds color prop and test case for it

### DIFF
--- a/src/docs/pages/AvatarPage.tsx
+++ b/src/docs/pages/AvatarPage.tsx
@@ -24,6 +24,52 @@ const AvatarPage: FC = () => {
       ),
     },
     {
+      title: 'Colored Avatar',
+      code: (
+        <>
+          <div className="flex flex-wrap gap-2">
+            <Avatar img="https://flowbite.com/docs/images/people/profile-picture-5.jpg" rounded bordered color="gray" />
+            <Avatar
+              img="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
+              rounded
+              bordered
+              color="light"
+            />
+            <Avatar
+              img="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
+              rounded
+              bordered
+              color="purple"
+            />
+            <Avatar
+              img="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
+              rounded
+              bordered
+              color="success"
+            />
+            <Avatar img="https://flowbite.com/docs/images/people/profile-picture-5.jpg" rounded bordered color="pink" />
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Avatar img="https://flowbite.com/docs/images/people/profile-picture-5.jpg" bordered color="gray" />
+            <Avatar img="https://flowbite.com/docs/images/people/profile-picture-5.jpg" bordered color="light" />
+            <Avatar img="https://flowbite.com/docs/images/people/profile-picture-5.jpg" bordered color="purple" />
+            <Avatar img="https://flowbite.com/docs/images/people/profile-picture-5.jpg" bordered color="success" />
+            <Avatar img="https://flowbite.com/docs/images/people/profile-picture-5.jpg" bordered color="pink" />
+          </div>
+        </>
+      ),
+    },
+    {
+      title: 'Placeholder',
+      code: (
+        <div className="flex flex-wrap gap-2">
+          <Avatar />
+          <Avatar rounded />
+        </div>
+      ),
+    },
+    {
       title: 'Placeholder',
       code: (
         <div className="flex flex-wrap gap-2">

--- a/src/lib/components/Avatar/Avatar.spec.tsx
+++ b/src/lib/components/Avatar/Avatar.spec.tsx
@@ -6,7 +6,7 @@ import { Avatar } from './Avatar';
 
 describe('Components / Avatar', () => {
   describe('Theme', () => {
-    it('should use custom classes', () => {
+    it('should use custom sizes', () => {
       const theme: CustomFlowbiteTheme = {
         avatar: {
           size: {
@@ -21,6 +21,28 @@ describe('Components / Avatar', () => {
       );
 
       expect(img()).toHaveClass('h-64 w-64');
+    });
+
+    it('should use custom colors', () => {
+      const theme: CustomFlowbiteTheme = {
+        avatar: {
+          color: {
+            rose: 'ring-rose-500 dark:ring-rose-400',
+          },
+        },
+      };
+      render(
+        <Flowbite theme={{ theme }}>
+          <Avatar
+            bordered
+            color="rose"
+            img="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
+            alt="Your avatar"
+          />
+        </Flowbite>,
+      );
+
+      expect(img()).toHaveClass('ring-rose-500 dark:ring-rose-400');
     });
   });
   describe('Placeholder', () => {

--- a/src/lib/components/Avatar/Avatar.tsx
+++ b/src/lib/components/Avatar/Avatar.tsx
@@ -1,20 +1,26 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
-import type { FlowbitePositions, FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
+import type { FlowbiteColors, FlowbitePositions, FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
 import { useTheme } from '../Flowbite/ThemeContext';
 import AvatarGroup from './AvatarGroup';
 import AvatarGroupCounter from './AvatarGroupCounter';
 
-export interface AvatarProps extends PropsWithChildren<ComponentProps<'div'>> {
+export interface AvatarProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'color'>> {
   alt?: string;
   bordered?: boolean;
   img?: string;
+  color?: keyof AvatarColors;
   rounded?: boolean;
   size?: keyof AvatarSizes;
   stacked?: boolean;
   status?: 'away' | 'busy' | 'offline' | 'online';
   statusPosition?: keyof FlowbitePositions;
   placeholderInitials?: string;
+}
+
+export interface AvatarColors
+  extends Pick<FlowbiteColors, 'failure' | 'gray' | 'info' | 'pink' | 'purple' | 'success' | 'warning'> {
+  [key: string]: string;
 }
 
 export interface AvatarSizes extends Pick<FlowbiteSizes, 'xs' | 'sm' | 'md' | 'lg' | 'xl'> {
@@ -26,6 +32,7 @@ const AvatarComponent: FC<AvatarProps> = ({
   bordered = false,
   children,
   img,
+  color = 'light',
   rounded = false,
   size = 'md',
   stacked = false,
@@ -38,6 +45,7 @@ const AvatarComponent: FC<AvatarProps> = ({
   const theme = useTheme().theme.avatar;
   const imgClassName = classNames(
     bordered && theme.bordered,
+    bordered && theme.color[color],
     rounded && theme.rounded,
     stacked && theme.stacked,
     theme.img.on,

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -1,6 +1,6 @@
 import { DeepPartial } from '..';
 import type { AlertColors } from '../Alert/Alert';
-import type { AvatarSizes } from '../Avatar/Avatar';
+import type { AvatarColors, AvatarSizes } from '../Avatar/Avatar';
 import type { BadgeColors, BadgeSizes } from '../Badge';
 import type {
   ButtonColors,
@@ -72,6 +72,7 @@ export interface FlowbiteTheme extends Record<string, unknown> {
       on: string;
       placeholder: string;
     };
+    color: AvatarColors;
     rounded: string;
     size: AvatarSizes;
     stacked: string;

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -60,13 +60,24 @@ const theme: FlowbiteTheme = {
   },
   avatar: {
     base: 'flex justify-center items-center space-x-4',
-    bordered: 'p-1 ring-2 ring-gray-300 dark:ring-gray-500',
+    bordered: 'p-1 ring-2',
     img: {
       off: 'rounded relative overflow-hidden bg-gray-100 dark:bg-gray-600',
       on: 'rounded',
       placeholder: 'absolute w-auto h-auto text-gray-400 -bottom-1',
     },
     rounded: '!rounded-full',
+    color: {
+      dark: 'ring-gray-800 dark:ring-gray-800',
+      failure: 'ring-red-500 dark:ring-red-700',
+      gray: 'ring-gray-500 dark:ring-gray-400',
+      info: 'ring-blue-400 dark:ring-blue-800',
+      light: 'ring-gray-300 dark:ring-gray-500',
+      purple: 'ring-purple-500 dark:ring-purple-600',
+      success: 'ring-green-500 dark:ring-green-500',
+      warning: 'ring-yellow-300 dark:ring-yellow-500',
+      pink: 'ring-pink-500 dark:ring-pink-500',
+    },
     size: {
       xs: 'w-6 h-6',
       sm: 'w-8 h-8',


### PR DESCRIPTION
1. Adds color property to Avatar component to change image ring color. Works only if border property is true. 
2. Adds 'color' test case to the Avatar`s Theme test case

#409

## Description

Implements avatar component enhancement introduced by @tiagossa1 The component has ability to change image ring color via prop `color` if `bordered` prop is true.

Fixes #409

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`'should use custom colors'` case was added to `'Components / Avatar'` -> `'Theme'` in Avatar.spec.tsx 
Storybook story works correct without any updates.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
