### PR TITLE
 feat(/components/sidebar): add Sidebar.Item label to theme 

### DIFF
--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -434,6 +434,7 @@ export interface FlowbiteTheme extends Record<string, unknown> {
       content: {
         base: string;
       };
+      label: string;
       icon: {
         base: string;
         active: string;

--- a/src/lib/components/Sidebar/SidebarItem.tsx
+++ b/src/lib/components/Sidebar/SidebarItem.tsx
@@ -80,7 +80,7 @@ const SidebarItem = forwardRef<Element, SidebarItemProps>(
           )}
           {!isCollapsed && <Children>{children}</Children>}
           {!isCollapsed && label && (
-            <Badge color={labelColor} data-testid="flowbite-sidebar-label" hidden={isCollapsed}>
+            <Badge color={labelColor} data-testid="flowbite-sidebar-label" hidden={isCollapsed} className={theme.label}>
               {label}
             </Badge>
           )}

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -759,6 +759,7 @@ const theme: FlowbiteTheme = {
         base: 'h-6 w-6 flex-shrink-0 text-gray-500 transition duration-75 group-hover:text-gray-900 dark:text-gray-400 dark:group-hover:text-white',
         active: 'text-gray-700 dark:text-gray-100',
       },
+      label: '',
     },
     items: '',
     itemGroup:


### PR DESCRIPTION
## Changes

- [x] [feat(/components/sidebar): add Sidebar.Item label to theme](https://github.com/themesberg/flowbite-react/pull/449/commits/6929871c9c968e051808bd3fc9145c22aaae798d)

## Description

Allows users to customize the `label` of a `Sidebar.Item` in the `<Flowbite theme={}>`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Breaking changes

N/A

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: Add a class, like `p-8`, to the default theme, `src/lib/theme/default.ts`, under `sidebar.item.label`, and observe the `Sidebar` example page.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
