### PR TITLE
fix(toast): ToastToggle must have className

### DIFF
--- a/src/lib/components/Toast/ToastToggle.tsx
+++ b/src/lib/components/Toast/ToastToggle.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import type { ComponentProps, FC } from 'react';
 import { HiX } from 'react-icons/hi';
 import { useTheme } from '../Flowbite/ThemeContext';
@@ -7,7 +8,7 @@ type ToastToggleProps = ComponentProps<'button'> & {
   xIcon?: FC<ComponentProps<'svg'>>;
 };
 
-export const ToastToggle: FC<ToastToggleProps> = ({ xIcon: XIcon = HiX }) => {
+export const ToastToggle: FC<ToastToggleProps> = ({ className, xIcon: XIcon = HiX }) => {
   const { duration, isClosed, isRemoved, setIsClosed, setIsRemoved } = useToastContext();
   const theme = useTheme().theme.toast.toggle;
 
@@ -17,7 +18,7 @@ export const ToastToggle: FC<ToastToggleProps> = ({ xIcon: XIcon = HiX }) => {
   };
 
   return (
-    <button aria-label="Close" onClick={handleClick} type="button" className={theme.base}>
+    <button aria-label="Close" onClick={handleClick} type="button" className={classNames(theme.base, className)}>
       <XIcon className={theme.icon} />
     </button>
   );


### PR DESCRIPTION
## Description

Adds access to `className` to `ToastToggle` component.

Fixes #444 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Breaking changes

N/A

## How Has This Been Tested?

- [X] Unit test

**Test Configuration**:

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
