### PR TITLE
feat(Avatar): Support overriding the Avatar img element. Fixes #482

### DIFF
--- a/src/docs/pages/AvatarPage.tsx
+++ b/src/docs/pages/AvatarPage.tsx
@@ -61,6 +61,66 @@ const AvatarPage: FC = () => {
       ),
     },
     {
+      title: 'Override Image Element',
+      code: (
+        <div className="flex flex-wrap gap-2">
+          <Avatar
+            img={(props) => (
+              <img
+                referrerPolicy="no-referrer"
+                src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
+                {...props}
+              />
+            )}
+          />
+          <Avatar
+            img={(props) => (
+              <picture>
+                <source
+                  media="(min-width: 900px)"
+                  srcSet="https://flowbite.com/docs/images/people/profile-picture-3.jpg"
+                />
+                <source
+                  media="(min-width: 480px)"
+                  srcSet="https://flowbite.com/docs/images/people/profile-picture-4.jpg"
+                />
+                <img src="https://flowbite.com/docs/images/people/profile-picture-5.jpg" {...props} />
+              </picture>
+            )}
+          />
+        </div>
+      ),
+      rawCode: `<div className="flex flex-wrap gap-2">
+  <Avatar
+    img={(props) => (
+      <img
+        referrerPolicy="no-referrer"
+        src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
+        {...props}
+      />
+    )}
+  />
+  <Avatar
+    img={(props) => (
+      <picture>
+        <source
+          media="(min-width: 900px)"
+          srcSet="https://flowbite.com/docs/images/people/profile-picture-3.jpg"
+        />
+        <source
+          media="(min-width: 480px)"
+          srcSet="https://flowbite.com/docs/images/people/profile-picture-4.jpg"
+        />
+        <img 
+          src="https://flowbite.com/docs/images/people/profile-picture-5.jpg" 
+          {...props} 
+        />
+      </picture>
+    )}
+  />
+</div>`,
+    },
+    {
       title: 'Placeholder',
       code: (
         <div className="flex flex-wrap gap-2">

--- a/src/docs/pages/DemoPage.tsx
+++ b/src/docs/pages/DemoPage.tsx
@@ -12,6 +12,7 @@ export type CodeExample = {
   title: string;
   content?: ReactNode;
   code: ReactNode;
+  rawCode?: string;
   showCode?: boolean;
   codeClassName?: string;
   codeStringifierOptions?: Options;
@@ -24,27 +25,30 @@ export type DemoPageProps = {
 export const DemoPage: FC<DemoPageProps> = ({ examples }) => {
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-8 dark:text-white">
-      {examples.map(({ title, content, code, showCode = true, codeClassName, codeStringifierOptions }, index) => (
-        <div key={index} className="flex flex-col gap-2">
-          <span className="text-2xl font-bold">{title}</span>
-          {content && <div className="py-4">{content}</div>}
-          <div className={codeClassName}>
-            <Card>
-              {showCode && code}
-              <SyntaxHighlighter language="tsx" style={dracula}>
-                {reactElementToJSXString(code, {
-                  showFunctions: true,
-                  functionValue: (fn) => fn.name,
-                  sortProps: false,
-                  useBooleanShorthandSyntax: false,
-                  useFragmentShortSyntax: false,
-                  ...codeStringifierOptions,
-                })}
-              </SyntaxHighlighter>
-            </Card>
+      {examples.map(
+        ({ title, content, code, rawCode, showCode = true, codeClassName, codeStringifierOptions }, index) => (
+          <div key={index} className="flex flex-col gap-2">
+            <span className="text-2xl font-bold">{title}</span>
+            {content && <div className="py-4">{content}</div>}
+            <div className={codeClassName}>
+              <Card>
+                {showCode && code}
+                <SyntaxHighlighter language="tsx" style={dracula}>
+                  {rawCode ||
+                    reactElementToJSXString(code, {
+                      showFunctions: true,
+                      functionValue: (fn) => fn.name,
+                      sortProps: false,
+                      useBooleanShorthandSyntax: false,
+                      useFragmentShortSyntax: false,
+                      ...codeStringifierOptions,
+                    })}
+                </SyntaxHighlighter>
+              </Card>
+            </div>
           </div>
-        </div>
-      ))}
+        ),
+      )}
     </div>
   );
 };

--- a/src/lib/components/Avatar/Avatar.spec.tsx
+++ b/src/lib/components/Avatar/Avatar.spec.tsx
@@ -56,6 +56,17 @@ describe('Components / Avatar', () => {
       expect(initialsPlaceholder()).toHaveTextContent('RR');
     });
   });
+  describe('Image', () => {
+    it('should support custom image elements', () => {
+      render(
+        <Flowbite>
+          <Avatar img={(props) => <img referrerPolicy="no-referrer" {...props} />} />
+        </Flowbite>,
+      );
+
+      expect(img()).toHaveAttribute('referrerpolicy', 'no-referrer');
+    });
+  });
 });
 
 const img = () => screen.getByTestId('flowbite-avatar-img');

--- a/src/lib/components/Avatar/Avatar.stories.tsx
+++ b/src/lib/components/Avatar/Avatar.stories.tsx
@@ -15,3 +15,21 @@ DefaultAvatar.args = {
   alt: 'Your avatar',
   img: 'https://flowbite.com/docs/images/people/profile-picture-5.jpg',
 };
+
+export const CustomImage: Story<AvatarProps> = (props) => (
+  <>
+    <Avatar
+      {...props}
+      img={(props) => (
+        <picture>
+          <source media="(min-width: 900px)" srcSet="https://flowbite.com/docs/images/people/profile-picture-3.jpg" />
+          <source media="(min-width: 480px)" srcSet="https://flowbite.com/docs/images/people/profile-picture-4.jpg" />
+          <img src="https://flowbite.com/docs/images/people/profile-picture-5.jpg" {...props} />
+        </picture>
+      )}
+    />
+    <small className="block text-center text-gray-500">Hint: Resize the viewport</small>
+  </>
+);
+
+CustomImage.storyName = 'Custom Image Element';

--- a/src/lib/components/Avatar/Avatar.tsx
+++ b/src/lib/components/Avatar/Avatar.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import type { ComponentProps, FC, PropsWithChildren, ReactElement } from 'react';
 import type { FlowbiteColors, FlowbitePositions, FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
 import { useTheme } from '../Flowbite/ThemeContext';
 import AvatarGroup from './AvatarGroup';
@@ -40,10 +40,16 @@ export interface AvatarSizes extends Pick<FlowbiteSizes, 'xs' | 'sm' | 'md' | 'l
   [key: string]: string;
 }
 
+export interface AvatarImageProps {
+  alt?: string;
+  className: string;
+  'data-testid': string;
+}
+
 export interface AvatarProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'color'>> {
   alt?: string;
   bordered?: boolean;
-  img?: string;
+  img?: string | ((props: AvatarImageProps) => ReactElement);
   color?: keyof AvatarColors;
   rounded?: boolean;
   size?: keyof AvatarSizes;
@@ -78,16 +84,16 @@ const AvatarComponent: FC<AvatarProps> = ({
     theme.size[size],
   );
 
+  const imgProps = { alt, className: classNames(imgClassName, theme.img.on), 'data-testid': 'flowbite-avatar-img' };
   return (
     <div className={classNames(theme.base, className)} data-testid="flowbite-avatar" {...props}>
       <div className="relative">
         {img ? (
-          <img
-            alt={alt}
-            className={classNames(imgClassName, theme.img.on)}
-            data-testid="flowbite-avatar-img"
-            src={img}
-          />
+          typeof img === 'string' ? (
+            <img {...imgProps} src={img} />
+          ) : (
+            img(imgProps)
+          )
         ) : placeholderInitials ? (
           <div
             className={classNames(


### PR DESCRIPTION
## Description

Changes the Avatar `img` prop to either be a string or a render prop that returns a React element. That makes it so any of the props can be overridden, or an entirely different element could be used in its place.

The docs site doesn't support the render prop syntax by default, so I added a small extension that allows the docs pages to provide a `rawCode` property which is passed directly to the syntax highlighter instead of generating the code sample from the `code` JSX.

Fixes #482

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change contains documentation update

## How Has This Been Tested?

- [x] Automated test that renders using the new render props and checks to see if a special attribute is included on the rendered <img> element.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
