### PR TITLE
Expose setActiveTab to ref

### DIFF
--- a/src/docs/pages/TabsPage.tsx
+++ b/src/docs/pages/TabsPage.tsx
@@ -1,11 +1,14 @@
-import type { FC } from 'react';
+import { FC, useRef, useState } from 'react';
 import { HiAdjustments, HiClipboardList, HiUserCircle } from 'react-icons/hi';
 import { MdDashboard } from 'react-icons/md';
-import { Tabs } from '../../lib';
+import { Button, Tabs, TabsRef } from '../../lib';
 import type { CodeExample } from './DemoPage';
 import { DemoPage } from './DemoPage';
 
 const TabsPage: FC = () => {
+  const [activeTab, setActiveTab] = useState<number>(0);
+  const tabsRef = useRef<TabsRef>(null);
+
   const examples: CodeExample[] = [
     {
       title: 'Default tabs',
@@ -91,6 +94,79 @@ const TabsPage: FC = () => {
           <Tabs.Item title="Invoice">Invoice content</Tabs.Item>
         </Tabs.Group>
       ),
+      codeClassName: 'dark:!bg-gray-900',
+    },
+    {
+      title: 'Set active tab programmatically',
+      code: (
+        <>
+          <Tabs.Group
+            aria-label="Default tabs"
+            style="default"
+            ref={tabsRef}
+            onActiveTabChange={(tab) => setActiveTab(tab)}
+          >
+            <Tabs.Item active title="Profile">
+              Profile content
+            </Tabs.Item>
+            <Tabs.Item title="Dashboard">Dashboard content</Tabs.Item>
+            <Tabs.Item title="Settings">Settings content</Tabs.Item>
+            <Tabs.Item title="Contacts">Contacts content</Tabs.Item>
+          </Tabs.Group>
+          <div>Active tab: {activeTab}</div>
+          <Button.Group>
+            <Button color="gray" onClick={() => tabsRef.current?.setActiveTab(0)}>
+              Profile
+            </Button>
+            <Button color="gray" onClick={() => tabsRef.current?.setActiveTab(1)}>
+              Dashboard
+            </Button>
+            <Button color="gray" onClick={() => tabsRef.current?.setActiveTab(2)}>
+              Settings
+            </Button>
+            <Button color="gray" onClick={() => tabsRef.current?.setActiveTab(3)}>
+              Contacts
+            </Button>
+          </Button.Group>
+        </>
+      ),
+      rawCode: `const Tabs: FC = () => {
+  const [activeTab, setActiveTab] = useState<number>(0);
+  const tabsRef = useRef<TabsRef>(null);
+
+  return (
+    <>
+      <Tabs.Group
+        aria-label="Default tabs"
+        style="default"
+        ref={tabsRef}
+        onActiveTabChange={tab => setActiveTab(tab)}
+      >
+        <Tabs.Item active title="Profile">
+          Profile content
+        </Tabs.Item>
+        <Tabs.Item title="Dashboard">Dashboard content</Tabs.Item>
+        <Tabs.Item title="Settings">Settings content</Tabs.Item>
+        <Tabs.Item title="Contacts">Contacts content</Tabs.Item>
+      </Tabs.Group>
+      <div>Active tab: {activeTab}</div>
+      <Button.Group>
+        <Button color="gray" onClick={() => tabsRef.current?.setActiveTab(0)}>
+          Profile
+        </Button>
+        <Button color="gray" onClick={() => tabsRef.current?.setActiveTab(1)}>
+          Dashboard
+        </Button>
+        <Button color="gray" onClick={() => tabsRef.current?.setActiveTab(2)}>
+          Settings
+        </Button>
+        <Button color="gray" onClick={() => tabsRef.current?.setActiveTab(3)}>
+          Contacts
+        </Button>
+      </Button.Group>
+    </>
+  );
+};`,
       codeClassName: 'dark:!bg-gray-900',
     },
   ];

--- a/src/lib/components/Tab/Tabs.tsx
+++ b/src/lib/components/Tab/Tabs.tsx
@@ -61,6 +61,7 @@ interface TabKeyboardEventProps extends TabEventProps {
 
 export interface TabsProps extends PropsWithChildren<Omit<ComponentProps<'div'>, 'style' | 'ref'>> {
   style?: keyof TabStyles;
+  onActiveTabChange?: (activeTab: number) => void;
 }
 
 export interface TabsRef {
@@ -68,7 +69,7 @@ export interface TabsRef {
 }
 
 export const TabsComponent = forwardRef<TabsRef, TabsProps>(
-  ({ children, style = 'default', className, ...rest }, ref: ForwardedRef<TabsRef>) => {
+  ({ children, style = 'default', className, onActiveTabChange, ...rest }, ref: ForwardedRef<TabsRef>) => {
     const theme = useTheme().theme.tab;
 
     const id = useId();
@@ -90,8 +91,13 @@ export const TabsComponent = forwardRef<TabsRef, TabsProps>(
       ),
     );
 
+    const setActiveTabWithCallback = (activeTab: number) => {
+      setActiveTab(activeTab);
+      if (onActiveTabChange) onActiveTabChange(activeTab);
+    };
+
     const handleClick = ({ target }: TabEventProps): void => {
-      setActiveTab(target);
+      setActiveTabWithCallback(target);
       setFocusedTab(target);
     };
 
@@ -105,7 +111,7 @@ export const TabsComponent = forwardRef<TabsRef, TabsProps>(
       }
 
       if (event.key === 'Enter') {
-        setActiveTab(target);
+        setActiveTabWithCallback(target);
         setFocusedTab(target);
       }
     };
@@ -117,7 +123,7 @@ export const TabsComponent = forwardRef<TabsRef, TabsProps>(
     }, [focusedTab]);
 
     useImperativeHandle(ref, () => ({
-      setActiveTab,
+      setActiveTab: setActiveTabWithCallback,
     }));
 
     return (


### PR DESCRIPTION
## Description

I have a use case where I'd like to switch to Tab 2 after a performed action on Tab 1, i.e. I'd either need `setActiveTab` exposed or props enabling the switch.

Playing around with `TabItemProps.active`, I got to a first iteration where `TabsComponent` has an extra `useEffect` that switches active tab reacting to `TabItemProps.active` changes. However, this approach presented one major bug, consider the following sequence of action and effects:
1. Tab 2 has `TabItemProps.active == true`
2. User switches to Tab 3 (using standard top buttons)
3. Parent component attempts to switch back to Tab 2, but Tab 2 still has `TabItemProps.active == true`, so `useEffect` is not called.

Syncing state and props to resolve that felt too complex and invasive.

Instead, I forwarded a ref that exposes `setActiveTab` back to the parent.

Let me know if you support such approach and I can update documentation.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change contains documentation update


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
```
import { useRef } from 'react';
import { Button, Tabs, TabsRef } from '../../lib';

const TabsPage = () => {
  const ref = useRef<TabsRef>(null);

  return (
    <>
      <Tabs.Group aria-label="Default tabs" style="default" ref={ref}>
        <Tabs.Item title="Profile">
          Profile content
        </Tabs.Item>
        <Tabs.Item title="Dashboard">Dashboard content</Tabs.Item>
        <Tabs.Item title="Settings">Settings content</Tabs.Item>
        <Tabs.Item title="Contacts">Contacts content</Tabs.Item>
        <Tabs.Item disabled title="Disabled">
          Disabled content
        </Tabs.Item>
      </Tabs.Group>
      <Button onClick={() => ref.current?.setActiveTab(0)}>Tab 0</Button>
      <Button onClick={() => ref.current?.setActiveTab(1)}>Tab 1</Button>
      <Button onClick={() => ref.current?.setActiveTab(2)}>Tab 2</Button>
    </>
  );
}

export default TabsPage;
```


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
