### PR TITLE
fix(modal): clear modal container ref on unmount

### DIFF
--- a/src/lib/components/Modal/Modal.spec.tsx
+++ b/src/lib/components/Modal/Modal.spec.tsx
@@ -24,6 +24,16 @@ describe('Components / Modal', () => {
     waitFor(() => expect(input).toHaveFocus());
   });
 
+  it('should be removed from DOM and garbage collected', async () => {
+    const root = document.createElement('div');
+
+    const { unmount } = render(<TestModal root={root} />);
+
+    unmount();
+
+    await waitFor(() => expect(root.childNodes.length).toBe(0));
+  });
+
   describe('A11y', () => {
     it('should have `role="dialog"`', async () => {
       const user = userEvent.setup();

--- a/src/lib/components/Modal/Modal.tsx
+++ b/src/lib/components/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { ComponentProps, FC, PropsWithChildren, useRef } from 'react';
+import { ComponentProps, FC, PropsWithChildren, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import type { FlowbiteBoolean, FlowbitePositions, FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
 import { useTheme } from '../Flowbite/ThemeContext';
@@ -79,6 +79,21 @@ const ModalComponent: FC<ModalProps> = ({
   if (containerRef.current.parentNode !== root) {
     root.appendChild(containerRef.current);
   }
+
+  useEffect(() => {
+    return () => {
+      const container = containerRef.current;
+
+      if (!container) {
+        return;
+      }
+
+      // If a container exists on unmount, it is removed from the DOM and
+      // garbage collected.
+      container.parentNode?.removeChild(container);
+      containerRef.current = null;
+    };
+  }, []);
 
   return createPortal(
     <ModalContext.Provider value={{ popup, onClose }}>

--- a/src/lib/components/Modal/Modal.tsx
+++ b/src/lib/components/Modal/Modal.tsx
@@ -84,14 +84,12 @@ const ModalComponent: FC<ModalProps> = ({
     return () => {
       const container = containerRef.current;
 
-      if (!container) {
-        return;
-      }
-
       // If a container exists on unmount, it is removed from the DOM and
       // garbage collected.
-      container.parentNode?.removeChild(container);
-      containerRef.current = null;
+      if (container) {
+        container.parentNode?.removeChild(container);
+        containerRef.current = null;
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Description

This clears the modal container ref introduced here: #495

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
