### PR TITLE
fix button outline with fullSized issue

### DIFF
--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -226,7 +226,7 @@ const theme: FlowbiteTheme = {
         light: '',
       },
       off: '',
-      on: 'bg-white text-gray-900 transition-all duration-75 ease-in group-hover:bg-opacity-0 group-hover:text-inherit dark:bg-gray-900 dark:text-white',
+      on: '!block bg-white text-gray-900 transition-all duration-75 ease-in group-hover:bg-opacity-0 group-hover:text-inherit dark:bg-gray-900 dark:text-white w-full',
       pill: {
         off: 'rounded-md',
         on: 'rounded-full',


### PR DESCRIPTION
## Description

`Button` with `outline={true}` and `fullSized={true}` creates a button as displayed below:

![image](https://user-images.githubusercontent.com/1465530/212833985-595ea8de-f04d-4997-a357-ac5994734292.png)

It should appear as the entire width of the inner section (span). 

<img width="568" alt="Screenshot 2023-01-17 at 12 55 17 PM" src="https://user-images.githubusercontent.com/1465530/212835106-3513c05a-899f-42fc-8631-af12130b9517.png">

Fixes #466

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Breaking changes

Please document the breaking changes if suitable.

## How Has This Been Tested?

- Create a `Button` with `outline={true}` and `fullSized={true}` and check.
- Open the `Button` component in the storybook and make both the properties (`outline` and `fullSized`) `true` and check.

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
