### PR TITLE
fix toggleswitch color when checked #542

### DIFF
--- a/src/lib/components/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/src/lib/components/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, Story } from '@storybook/react/types-6-0';
+import { useState } from 'react';
 import theme from '../../theme/default';
 import type { ToggleSwitchProps } from './ToggleSwitch';
 import { ToggleSwitch } from './ToggleSwitch';
@@ -10,7 +11,15 @@ export default {
   component: ToggleSwitch,
 } as Meta;
 
-const Template: Story<ToggleSwitchProps> = (args) => <ToggleSwitch {...args} />;
+const Template: Story<ToggleSwitchProps> = ({ checked, onChange, ...args }) => {
+  const [switchChecked, setSwitchChecked] = useState(checked);
+
+  const handleChange = () => {
+    setSwitchChecked((currentCheck) => !currentCheck);
+  };
+
+  return <ToggleSwitch checked={switchChecked} onChange={handleChange} {...args} />;
+};
 
 export const DefaultToggleSwitch = Template.bind({});
 DefaultToggleSwitch.storyName = 'Toggle switch';

--- a/src/lib/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/lib/components/ToggleSwitch/ToggleSwitch.tsx
@@ -71,7 +71,7 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
           className={classNames(
             theme.toggle.base,
             theme.toggle.checked[checked ? 'on' : 'off'],
-            !disabled && theme.toggle.checked.color[color],
+            !disabled && checked && theme.toggle.checked.color[color],
           )}
         />
         <span


### PR DESCRIPTION
## Description

Only add ToggleSwitch color classes when Toggle is checked (same behavior as in the [Flowbite Docs](https://flowbite.com/docs/forms/toggle/)).

Improved ToggleSwitch Story to make the Toggle clickable.

Fixes #542 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested Component in Storybook.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
