### PR TITLE
feat(RangeSlider): range slider with custom theme, storybook, unit test and docs

### DIFF
--- a/src/docs/pages/FormsPage.tsx
+++ b/src/docs/pages/FormsPage.tsx
@@ -6,6 +6,7 @@ import { Checkbox } from '../../lib/components/Checkbox';
 import { FileInput } from '../../lib/components/FileInput';
 import { Label } from '../../lib/components/Label';
 import { Radio } from '../../lib/components/Radio';
+import { RangeSlider } from '../../lib/components/RangeSlider';
 import { Select } from '../../lib/components/Select';
 import { Textarea } from '../../lib/components/Textarea';
 import { TextInput } from '../../lib/components/TextInput';
@@ -384,6 +385,43 @@ const FormsPage: FC = () => {
           <ToggleSwitch checked={switch1} label="Toggle me" onChange={setSwitch1} />
           <ToggleSwitch checked={switch2} label="Toggle me (checked)" onChange={setSwitch2} />
           <ToggleSwitch checked={false} disabled label="Toggle me (disabled)" onChange={() => undefined} />
+        </div>
+      ),
+    },
+    {
+      title: 'Range Slider',
+      code: (
+        <div className="flex flex-col gap-4">
+          <div>
+            <div className="mb-1 block">
+              <Label htmlFor="default-range" value="Default" />
+            </div>
+            <RangeSlider id="default-range" />
+          </div>
+          <div>
+            <div className="mb-1 block">
+              <Label htmlFor="disbaled-range" value="Disabled" />
+            </div>
+            <RangeSlider id="disabled-range" disabled={true} />
+          </div>
+          <div>
+            <div className="mb-1 block">
+              <Label htmlFor="sm-range" value="Small" />
+            </div>
+            <RangeSlider id="sm-range" sizing="sm" />
+          </div>
+          <div>
+            <div className="mb-1 block">
+              <Label htmlFor="md-range" value="Medium" />
+            </div>
+            <RangeSlider id="md-range" sizing="md" />
+          </div>
+          <div>
+            <div className="mb-1 block">
+              <Label htmlFor="lg-range" value="Large" />
+            </div>
+            <RangeSlider id="lg-range" sizing="lg" />
+          </div>
         </div>
       ),
     },

--- a/src/lib/components/Flowbite/FlowbiteTheme.ts
+++ b/src/lib/components/Flowbite/FlowbiteTheme.ts
@@ -20,6 +20,7 @@ import { FlowbiteNavbarTheme } from '../Navbar';
 import { FlowbitePaginationTheme } from '../Pagination';
 import { FlowbiteProgressTheme } from '../Progress';
 import { FlowbiteRadioTheme } from '../Radio';
+import { FlowbiteRangeSliderTheme } from '../RangeSlider';
 import { FlowbiteRatingTheme } from '../Rating';
 import { FlowbiteSelectTheme } from '../Select';
 import { FlowbiteSidebarTheme } from '../Sidebar';
@@ -65,6 +66,7 @@ export interface FlowbiteTheme extends Record<string, unknown> {
   fileInput: FlowbiteFileInputTheme;
   label: FlowbiteLabelTheme;
   radio: FlowbiteRadioTheme;
+  rangeSlider: FlowbiteRangeSliderTheme;
   select: FlowbiteSelectTheme;
   textInput: FlowbiteTextInputTheme;
   textarea: FlowbiteTextareaTheme;

--- a/src/lib/components/Label/Label.spec.tsx
+++ b/src/lib/components/Label/Label.spec.tsx
@@ -5,6 +5,7 @@ import { Button } from '../Button';
 import { Checkbox } from '../Checkbox';
 import { FileInput } from '../FileInput';
 import { Radio } from '../Radio';
+import { RangeSlider } from '../RangeSlider';
 import { Select } from '../Select';
 import { Textarea } from '../Textarea';
 import { TextInput } from '../TextInput';
@@ -22,6 +23,7 @@ describe.concurrent('Components / Label', () => {
         'Upload file',
         'United States',
         'Your message',
+        'Price',
       ];
 
       const { getByLabelText } = render(<TestForm />);
@@ -97,6 +99,10 @@ const TestForm = (): JSX.Element => (
       <div>
         <Label htmlFor="comment">Your message</Label>
         <Textarea id="comment" helperText="Leave a comment..." required rows={4} />
+      </div>
+      <div>
+        <Label htmlFor="price">Price</Label>
+        <RangeSlider id="price" min={0} max={100} />
       </div>
     </fieldset>
     <Button type="submit">Submit</Button>

--- a/src/lib/components/RangeSlider/RangeSlider.spec.tsx
+++ b/src/lib/components/RangeSlider/RangeSlider.spec.tsx
@@ -1,0 +1,274 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Flowbite } from '../Flowbite';
+import { RangeSlider } from './RangeSlider';
+
+describe('Components / Button', () => {
+  describe('A11y', () => {
+    it('should have `role="progressbar"` by default', () => {
+      render(<RangeSlider />);
+
+      expect(rangeSlider()).toBeInTheDocument();
+    });
+
+    it('should be able to use any other role permitted for `RangeSlider`', () => {
+      render(<RangeSlider role="rangeinput" />);
+
+      expect(rangeSlider('rangeinput')).toBeInTheDocument();
+    });
+  });
+
+  describe('Keyboard interactions', () => {
+    it('should focus when `Tab` is pressed', async () => {
+      const user = userEvent.setup();
+      render(<RangeSlider />);
+
+      await user.tab();
+
+      expect(rangeSlider()).toHaveFocus();
+    });
+
+    it('should be possible to `Tab` out', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <RangeSlider />
+          <RangeSlider />
+          <RangeSlider />
+        </>,
+      );
+
+      const rangeSliderElements = rangeSliders();
+
+      await user.tab();
+
+      expect(rangeSliderElements[0]).toHaveFocus();
+
+      await user.tab();
+
+      expect(rangeSliderElements[1]).toHaveFocus();
+
+      await user.tab();
+
+      expect(rangeSliderElements[2]).toHaveFocus();
+    });
+
+    it('should not trigger `onChange` when `Space` is pressed', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+
+      render(<RangeSlider onChange={handleChange} />);
+
+      await user.tab();
+
+      expect(rangeSlider()).toHaveFocus();
+
+      await user.keyboard('[Space]');
+
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    it('should not trigger `onChange` when `Enter` is pressed', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+
+      render(<RangeSlider onChange={handleChange} />);
+
+      await user.tab();
+
+      expect(rangeSlider()).toHaveFocus();
+
+      await user.keyboard('[Enter]');
+
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Test Name: Should trigger `onChange` when `Arrow` key pressed
+     *
+     * This test is not testable because there is no support for
+     * input[type="range"] in the user-event library.
+     *
+     * Issues:
+     * https://github.com/testing-library/user-event/issues/1067
+     * https://github.com/testing-library/user-event/issues/871
+     *
+     * TODO: Once these issues get fixed, we will add this test case.
+     *
+     */
+  });
+
+  describe('Props', () => {
+    it('should allow HTML attributes for `<input type="range">`s', () => {
+      render(<RangeSlider formAction="post.php" min={4} max={10} step={0.5} />);
+      const rangeSliderElement = rangeSlider();
+      expect(rangeSliderElement).toHaveAttribute('formAction', 'post.php');
+      expect(rangeSliderElement).toHaveAttribute('min', '4');
+      expect(rangeSliderElement).toHaveAttribute('max', '10');
+      expect(rangeSliderElement).toHaveAttribute('step', '0.5');
+    });
+
+    it('should be disabled when `disabled={true}`', () => {
+      render(<RangeSlider disabled />);
+
+      expect(rangeSlider()).toBeDisabled();
+    });
+
+    it('should be required when `required={true}`', () => {
+      render(<RangeSlider required={true} />);
+      expect(rangeSlider()).toHaveAttribute('required');
+    });
+
+    it('should allow ref as prop', () => {
+      const ref = createRef<HTMLInputElement>();
+      render(<RangeSlider ref={ref} name="range_slider_name" />);
+      expect(ref.current?.name).toBe('range_slider_name');
+    });
+  });
+
+  describe('Rendering', () => {
+    it('should render with no props', () => {
+      render(<RangeSlider />);
+      expect(rangeSlider()).toBeInTheDocument();
+    });
+  });
+
+  describe('Theme', () => {
+    it('should use `base` classes', () => {
+      const theme = {
+        rangeSlider: {
+          base: 'dummy-range-slider-base-classes',
+        },
+      };
+
+      render(
+        <Flowbite theme={{ theme }}>
+          <RangeSlider />
+        </Flowbite>,
+      );
+
+      expect(rangeSliderContainer()).toHaveClass('dummy-range-slider-base-classes');
+    });
+
+    it('should use `base` classes of field', () => {
+      const theme = {
+        rangeSlider: {
+          field: {
+            base: 'dummy-range-slider-field-base-classes',
+          },
+        },
+      };
+
+      render(
+        <Flowbite theme={{ theme }}>
+          <RangeSlider />
+        </Flowbite>,
+      );
+
+      expect(rangeSliderContainer().childNodes[0]).toHaveClass('dummy-range-slider-field-base-classes');
+    });
+
+    it('should use `base` classes of input', () => {
+      const theme = {
+        rangeSlider: {
+          field: {
+            input: {
+              base: 'dummy-range-slider-field-input-base-classes',
+            },
+          },
+        },
+      };
+
+      render(
+        <Flowbite theme={{ theme }}>
+          <RangeSlider />
+        </Flowbite>,
+      );
+
+      expect(rangeSlider()).toHaveClass('dummy-range-slider-field-input-base-classes');
+    });
+
+    it('should use `sizes` classes of input', () => {
+      const theme = {
+        rangeSlider: {
+          field: {
+            input: {
+              sizes: {
+                lg: 'dummy-range-slider-field-input-sizes-lg-classes',
+              },
+            },
+          },
+        },
+      };
+
+      render(
+        <Flowbite theme={{ theme }}>
+          <RangeSlider sizing="lg" />
+        </Flowbite>,
+      );
+
+      expect(rangeSlider()).toHaveClass('dummy-range-slider-field-input-sizes-lg-classes');
+    });
+  });
+
+  describe('Theme as a prop', () => {
+    it('should use `base` classes', () => {
+      const theme = {
+        base: 'dummy-range-slider-base-classes',
+      };
+
+      render(<RangeSlider theme={theme} />);
+
+      expect(rangeSliderContainer()).toHaveClass('dummy-range-slider-base-classes');
+    });
+
+    it('should use `base` classes of field', () => {
+      const theme = {
+        field: {
+          base: 'dummy-range-slider-field-base-classes',
+        },
+      };
+
+      render(<RangeSlider theme={theme} />);
+
+      expect(rangeSliderContainer().childNodes[0]).toHaveClass('dummy-range-slider-field-base-classes');
+    });
+
+    it('should use `base` classes of input', () => {
+      const theme = {
+        field: {
+          input: {
+            base: 'dummy-range-slider-field-input-base-classes',
+          },
+        },
+      };
+
+      render(<RangeSlider theme={theme} />);
+
+      expect(rangeSlider()).toHaveClass('dummy-range-slider-field-input-base-classes');
+    });
+
+    it('should use `sizes` classes of input', () => {
+      const theme = {
+        field: {
+          input: {
+            sizes: {
+              lg: 'dummy-range-slider-field-input-sizes-lg-classes',
+            },
+          },
+        },
+      };
+
+      render(<RangeSlider sizing="lg" theme={theme} />);
+
+      expect(rangeSlider()).toHaveClass('dummy-range-slider-field-input-sizes-lg-classes');
+    });
+  });
+});
+
+const rangeSliderContainer = () => screen.getByTestId('flowbite-range-slider');
+const rangeSlider = (role = 'slider') => screen.getByRole(role);
+const rangeSliders = (role = 'slider') => screen.getAllByRole(role);

--- a/src/lib/components/RangeSlider/RangeSlider.stories.tsx
+++ b/src/lib/components/RangeSlider/RangeSlider.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import theme from '../../theme/default';
+import type { RangeSliderProps } from './RangeSlider';
+import { RangeSlider } from './RangeSlider';
+
+export default {
+  title: 'Components/RangeSlider',
+  component: RangeSlider,
+  decorators: [
+    (Story): JSX.Element => (
+      <div className="flex flex-col w-1/2">
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    sizing: {
+      options: Object.keys(theme.rangeSlider.field.input.sizes),
+      control: { type: 'select' },
+    },
+    disabled: {
+      control: 'boolean',
+    },
+  },
+} as Meta;
+
+const Template: Story<RangeSliderProps> = (args) => <RangeSlider {...args} />;
+
+export const DefaultRangeSlider = Template.bind({});
+DefaultRangeSlider.storyName = 'RangeSlider';
+DefaultRangeSlider.args = {};

--- a/src/lib/components/RangeSlider/RangeSlider.tsx
+++ b/src/lib/components/RangeSlider/RangeSlider.tsx
@@ -1,0 +1,46 @@
+import classNames from 'classnames';
+import type { ComponentProps } from 'react';
+import { forwardRef } from 'react';
+import { DeepPartial } from '..';
+import { mergeDeep } from '../../helpers/mergeDeep';
+import { useTheme } from '../Flowbite/ThemeContext';
+import type { TextInputSizes } from '../TextInput';
+
+export interface FlowbiteRangeSliderTheme {
+  base: string;
+  field: {
+    base: string;
+    input: {
+      base: string;
+      sizes: TextInputSizes;
+    };
+  };
+}
+
+export interface RangeSliderProps extends Omit<ComponentProps<'input'>, 'type' | 'ref'> {
+  sizing?: keyof TextInputSizes;
+  theme?: DeepPartial<FlowbiteRangeSliderTheme>;
+}
+
+export const RangeSlider = forwardRef<HTMLInputElement, RangeSliderProps>(
+  ({ theme: customTheme = {}, sizing = 'md', className, ...props }, ref) => {
+    const theme = mergeDeep(useTheme().theme.rangeSlider, customTheme);
+
+    return (
+      <>
+        <div data-testid="flowbite-range-slider" className={classNames(theme.base, className)}>
+          <div className={theme.field.base}>
+            <input
+              className={classNames(theme.field.input.base, theme.field.input.sizes[sizing])}
+              {...props}
+              type="range"
+              ref={ref}
+            />
+          </div>
+        </div>
+      </>
+    );
+  },
+);
+
+RangeSlider.displayName = 'RangeSlider';

--- a/src/lib/components/RangeSlider/index.ts
+++ b/src/lib/components/RangeSlider/index.ts
@@ -1,0 +1,1 @@
+export * from './RangeSlider';

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -21,6 +21,7 @@ export * from './Navbar';
 export * from './Pagination';
 export * from './Progress';
 export * from './Radio';
+export * from './RangeSlider';
 export * from './Rating';
 export * from './Select';
 export * from './Sidebar/Sidebar';

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -421,6 +421,20 @@ const theme: FlowbiteTheme = {
   radio: {
     base: 'h-4 w-4 border border-gray-300 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:focus:bg-blue-600 dark:focus:ring-blue-600',
   },
+  rangeSlider: {
+    base: 'flex',
+    field: {
+      base: 'relative w-full',
+      input: {
+        base: 'w-full bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700',
+        sizes: {
+          sm: 'h-1 range-sm',
+          md: 'h-2',
+          lg: 'h-3 range-lg',
+        },
+      },
+    },
+  },
   select: {
     base: 'flex',
     addon:


### PR DESCRIPTION
## Description

Implemented the `RangeSlider` component as described in the core library.

This component has:

- Theme support
- Storybook
- Unit test
- Documentation

Fixes #188 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change contains documentation update

## Breaking changes

Please document the breaking changes if suitable.

## How Has This Been Tested?

- Create a `RangeSlider` with `sizing` and `theme` optional props.
- Allowed all the HTML attributes of `<input type="range" />`
- RangeSlider component in storybook
- Documentation in the Forms section (see the below screenshot)
<img width="1155" alt="Screenshot 2023-01-19 at 1 37 29 PM" src="https://user-images.githubusercontent.com/1465530/213420449-b48d0b78-01c0-4cd4-a294-e87f6b0ba198.png">

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
