### PR TITLE
feat(theme): add tests for alert component

### DIFF
--- a/src/docs/pages/ThemePage.tsx
+++ b/src/docs/pages/ThemePage.tsx
@@ -8,7 +8,7 @@ import { Flowbite } from '../../lib/components';
 import type { CustomFlowbiteTheme } from '../../lib/components/Flowbite/FlowbiteTheme';
 
 const ThemePage: FC = () => {
-  const theme: CustomFlowbiteTheme = { alert: { root: { color: { primary: 'bg-primary' } } } };
+  const theme: CustomFlowbiteTheme = { alert: { root: { color: { info : 'bg-primary' } } } };
 
   return (
     <div className="flex flex-col max-w-4xl gap-8 mx-auto dark:text-white">

--- a/src/docs/pages/ThemePage.tsx
+++ b/src/docs/pages/ThemePage.tsx
@@ -8,7 +8,7 @@ import { Flowbite } from '../../lib/components';
 import type { CustomFlowbiteTheme } from '../../lib/components/Flowbite/FlowbiteTheme';
 
 const ThemePage: FC = () => {
-  const theme: CustomFlowbiteTheme = { alert: { root: { color: { info : 'bg-primary' } } } };
+  const theme: CustomFlowbiteTheme = { alert: { root: { color: { info: 'bg-primary' } } } };
 
   return (
     <div className="flex flex-col max-w-4xl gap-8 mx-auto dark:text-white">

--- a/src/lib/components/Alert/Alert.spec.tsx
+++ b/src/lib/components/Alert/Alert.spec.tsx
@@ -1,9 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FC, useState } from 'react';
-import { HiEye, HiInformationCircle } from 'react-icons/hi';
+import { HiEye, HiHeart, HiInformationCircle } from 'react-icons/hi';
 import { describe, expect, it, vi } from 'vitest';
-import { Alert } from './Alert';
+import { Flowbite } from '../Flowbite';
+
+import { Alert, AlertProps } from './Alert';
 
 describe.concurrent('Components / Alert', () => {
   describe.concurrent('A11y', () => {
@@ -11,6 +13,122 @@ describe.concurrent('Components / Alert', () => {
       render(<TestAlert />);
 
       expect(alert()).toBeInTheDocument();
+    });
+
+    describe('Theme', () => {
+      it('should use custom `base` classes', () => {
+        const theme = {
+          alert: {
+            root: {
+              base: 'text-purple-100',
+            },
+          },
+        };
+        render(
+          <Flowbite theme={{ theme }}>
+            <TestAlert />
+          </Flowbite>,
+        );
+
+        expect(alert()).toHaveClass('text-purple-100');
+      });
+
+      it('should use custom `borderAccent` classes', () => {
+        const theme = {
+          alert: {
+            root: {
+              borderAccent: 'border-t-4 border-purple-500',
+            },
+          },
+        };
+        render(
+          <Flowbite theme={{ theme }}>
+            <TestAlert withBorderAccent />
+          </Flowbite>,
+        );
+
+        expect(alert()).toHaveClass('border-t-4 border-purple-500');
+      });
+
+      it('should use custom `wrapper` classes', () => {
+        const theme = {
+          alert: {
+            root: {
+              wrapper: 'flex items-center',
+            },
+          },
+        };
+        render(
+          <Flowbite theme={{ theme }}>
+            <TestAlert />
+          </Flowbite>,
+        );
+
+        expect(wrapper()).toHaveClass('flex items-center');
+      });
+
+      it('should use custom `color` classes', () => {
+        const theme = {
+          alert: {
+            root: {
+              color: {
+                info: 'text-purple-700 bg-purple-100 border-purple-500 dark:bg-purple-200 dark:text-purple-800',
+              },
+            },
+            closeButton: {
+              color: {
+                info: 'text-purple-500 hover:bg-purple-200 dark:text-purple-600 dark:hover:text-purple-300',
+              },
+            },
+          },
+        };
+        render(
+          <Flowbite theme={{ theme }}>
+            <TestAlert />
+          </Flowbite>,
+        );
+
+        expect(alert()).toHaveClass(
+          'text-purple-700 bg-purple-100 border-purple-500 dark:bg-purple-200 dark:text-purple-800',
+        );
+        expect(dismiss()).toHaveClass(
+          'text-purple-500 hover:bg-purple-200 dark:text-purple-600 dark:hover:text-purple-300',
+        );
+      });
+
+      it('should use custom `icon`', () => {
+        const theme = {
+          alert: {
+            root: {
+              icon: 'alert-custom-icon',
+            },
+          },
+        };
+        render(
+          <Flowbite theme={{ theme }}>
+            <TestAlert icon={HiHeart} />
+          </Flowbite>,
+        );
+
+        expect(icon()).toHaveClass('alert-custom-icon');
+      });
+
+      it('should show custom `rounded` class', () => {
+        const theme = {
+          alert: {
+            root: {
+              rounded: 'rounded',
+            },
+          },
+        };
+        render(
+          <Flowbite theme={{ theme }}>
+            <TestAlert />
+          </Flowbite>,
+        );
+
+        expect(alert()).toHaveClass('rounded');
+      });
     });
   });
 
@@ -45,11 +163,12 @@ describe.concurrent('Components / Alert', () => {
   });
 });
 
-const TestAlert: FC = () => {
+const TestAlert: FC<AlertProps> = (props: AlertProps) => {
   const [isDismissed, setDismissed] = useState(false);
 
   return (
     <Alert
+      {...props}
       additionalContent={
         <>
           <div className="mt-2 mb-4 text-sm text-blue-700 dark:text-blue-800">
@@ -85,5 +204,9 @@ const TestAlert: FC = () => {
 };
 
 const alert = () => screen.getByRole('alert');
+
+const wrapper = () => screen.getByTestId('flowbite-alert-wrapper');
+
+const icon = () => screen.getByTestId('flowbite-alert-icon');
 
 const dismiss = () => screen.getByLabelText('Dismiss');

--- a/src/lib/components/Alert/Alert.tsx
+++ b/src/lib/components/Alert/Alert.tsx
@@ -64,8 +64,8 @@ export const Alert: FC<AlertProps> = ({
       )}
       role="alert"
     >
-      <div className={theme.root.wrapper}>
-        {Icon && <Icon className={theme.root.icon} />}
+      <div className={theme.root.wrapper} data-testid="flowbite-alert-wrapper">
+        {Icon && <Icon className={theme.root.icon}  data-testid="flowbite-alert-icon"/>}
         <div>{children}</div>
         {typeof onDismiss === 'function' && (
           <button

--- a/src/lib/components/Alert/Alert.tsx
+++ b/src/lib/components/Alert/Alert.tsx
@@ -65,7 +65,7 @@ export const Alert: FC<AlertProps> = ({
       role="alert"
     >
       <div className={theme.root.wrapper} data-testid="flowbite-alert-wrapper">
-        {Icon && <Icon className={theme.root.icon}  data-testid="flowbite-alert-icon"/>}
+        {Icon && <Icon className={theme.root.icon} data-testid="flowbite-alert-icon" />}
         <div>{children}</div>
         {typeof onDismiss === 'function' && (
           <button


### PR DESCRIPTION
## Description

Adds tests for the`Alert` component. 
Fixes typo in the documentation pages (the default color for Alert is 'info', not 'primary'). In fact 'primary' does not exists in the FlowbiteColors -> `Pick<FlowbiteColors, 'failure' | 'gray' | 'info' | 'success' | 'warning'>`

Related to #500 

## Type of change

Please delete options that are not relevant.

- [x] This change contains documentation update

## Breaking changes

Please document the breaking changes if suitable.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests

**Test Configuration**:

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
