### PR TITLE
feat(/lib/components/modal): change open/close callbacks to components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ cypress/videos
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.yarn
 
 .eslintcache

--- a/src/docs/pages/ModalPage.tsx
+++ b/src/docs/pages/ModalPage.tsx
@@ -17,37 +17,35 @@ const ModalPage: FC = () => {
     {
       title: 'Default modal',
       code: (
-        <>
-          <Modal>
-            <Modal.Trigger>
-              <Button>Toggle modal</Button>
-            </Modal.Trigger>
-            <Modal.Content>
-              <Modal.Header>Terms of Service</Modal.Header>
-              <Modal.Body>
-                <div className="space-y-6">
-                  <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
-                    With less than a month to go before the European Union enacts new consumer privacy laws for its
-                    citizens, companies around the world are updating their terms of service agreements to comply.
-                  </p>
-                  <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
-                    The European Union’s General Data Protection Regulation (G.D.P.R.) goes into effect on May 25 and is
-                    meant to ensure a common set of data rights in the European Union. It requires organizations to
-                    notify users as soon as possible of high-risk data breaches that could personally affect them.
-                  </p>
-                </div>
-              </Modal.Body>
-              <Modal.Footer>
-                <Modal.Close>
-                  <Button>I accept</Button>
-                </Modal.Close>
-                <Modal.Close>
-                  <Button color="gray">Decline</Button>
-                </Modal.Close>
-              </Modal.Footer>
-            </Modal.Content>
-          </Modal>
-        </>
+        <Modal>
+          <Modal.Trigger>
+            <Button>Toggle modal</Button>
+          </Modal.Trigger>
+          <Modal.Content>
+            <Modal.Header>Terms of Service</Modal.Header>
+            <Modal.Body>
+              <div className="space-y-6">
+                <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                  With less than a month to go before the European Union enacts new consumer privacy laws for its
+                  citizens, companies around the world are updating their terms of service agreements to comply.
+                </p>
+                <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                  The European Union’s General Data Protection Regulation (G.D.P.R.) goes into effect on May 25 and is
+                  meant to ensure a common set of data rights in the European Union. It requires organizations to notify
+                  users as soon as possible of high-risk data breaches that could personally affect them.
+                </p>
+              </div>
+            </Modal.Body>
+            <Modal.Footer>
+              <Modal.Close>
+                <Button>I accept</Button>
+              </Modal.Close>
+              <Modal.Close>
+                <Button color="gray">Decline</Button>
+              </Modal.Close>
+            </Modal.Footer>
+          </Modal.Content>
+        </Modal>
       ),
     },
     {
@@ -100,8 +98,12 @@ const ModalPage: FC = () => {
                   Are you sure you want to delete this product?
                 </h3>
                 <div className="flex justify-center gap-4">
-                  <Button color="failure">{"Yes, I'm sure"}</Button>
-                  <Button color="gray">No, cancel</Button>
+                  <Modal.Close>
+                    <Button color="failure">{"Yes, I'm sure"}</Button>
+                  </Modal.Close>
+                  <Modal.Close>
+                    <Button color="gray">No, cancel</Button>
+                  </Modal.Close>
                 </div>
               </div>
             </Modal.Body>
@@ -176,10 +178,11 @@ const ModalPage: FC = () => {
                 <option value="7xl">7xl</option>
               </Select>
             </div>
+            <Modal.Trigger>
+              <Button>Toggle modal</Button>
+            </Modal.Trigger>
           </div>
-          <Modal.Trigger>
-            <Button>Toggle modal</Button>
-          </Modal.Trigger>
+
           <Modal.Content size={modalSize}>
             <Modal.Header>Small modal</Modal.Header>
             <Modal.Body>
@@ -196,8 +199,12 @@ const ModalPage: FC = () => {
               </div>
             </Modal.Body>
             <Modal.Footer>
-              <Button>I accept</Button>
-              <Button color="gray">Decline</Button>
+              <Modal.Close>
+                <Button>I accept</Button>
+              </Modal.Close>
+              <Modal.Close>
+                <Button color="gray">Decline</Button>
+              </Modal.Close>
             </Modal.Footer>
           </Modal.Content>
         </Modal>
@@ -221,10 +228,11 @@ const ModalPage: FC = () => {
                 <option value="bottom-left">Bottom left</option>
               </Select>
             </div>
+            <Modal.Trigger>
+              <Button>Toggle modal</Button>
+            </Modal.Trigger>
           </div>
-          <Modal.Trigger>
-            <Button>Toggle modal</Button>
-          </Modal.Trigger>
+
           <Modal.Content position={modalPlacement}>
             <Modal.Header>Small modal</Modal.Header>
             <Modal.Body>
@@ -241,8 +249,12 @@ const ModalPage: FC = () => {
               </div>
             </Modal.Body>
             <Modal.Footer>
-              <Button>I accept</Button>
-              <Button color="gray">Decline</Button>
+              <Modal.Close>
+                <Button>I accept</Button>
+              </Modal.Close>
+              <Modal.Close>
+                <Button color="gray">Decline</Button>
+              </Modal.Close>
             </Modal.Footer>
           </Modal.Content>
         </Modal>

--- a/src/docs/pages/ModalPage.tsx
+++ b/src/docs/pages/ModalPage.tsx
@@ -10,7 +10,6 @@ import type { CodeExample } from './DemoPage';
 import { DemoPage } from './DemoPage';
 
 const ModalPage: FC = () => {
-  const [openModal, setOpenModal] = useState<string | undefined>();
   const [modalSize, setModalSize] = useState<string>('md');
   const [modalPlacement, setModalPlacement] = useState<string>('center');
 
@@ -19,28 +18,34 @@ const ModalPage: FC = () => {
       title: 'Default modal',
       code: (
         <>
-          <Button onClick={() => setOpenModal('default')}>Toggle modal</Button>
-          <Modal show={openModal === 'default'} onClose={() => setOpenModal(undefined)}>
-            <Modal.Header>Terms of Service</Modal.Header>
-            <Modal.Body>
-              <div className="space-y-6">
-                <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
-                  With less than a month to go before the European Union enacts new consumer privacy laws for its
-                  citizens, companies around the world are updating their terms of service agreements to comply.
-                </p>
-                <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
-                  The European Union’s General Data Protection Regulation (G.D.P.R.) goes into effect on May 25 and is
-                  meant to ensure a common set of data rights in the European Union. It requires organizations to notify
-                  users as soon as possible of high-risk data breaches that could personally affect them.
-                </p>
-              </div>
-            </Modal.Body>
-            <Modal.Footer>
-              <Button onClick={() => setOpenModal(undefined)}>I accept</Button>
-              <Button color="gray" onClick={() => setOpenModal(undefined)}>
-                Decline
-              </Button>
-            </Modal.Footer>
+          <Modal>
+            <Modal.Trigger>
+              <Button>Toggle modal</Button>
+            </Modal.Trigger>
+            <Modal.Content>
+              <Modal.Header>Terms of Service</Modal.Header>
+              <Modal.Body>
+                <div className="space-y-6">
+                  <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                    With less than a month to go before the European Union enacts new consumer privacy laws for its
+                    citizens, companies around the world are updating their terms of service agreements to comply.
+                  </p>
+                  <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                    The European Union’s General Data Protection Regulation (G.D.P.R.) goes into effect on May 25 and is
+                    meant to ensure a common set of data rights in the European Union. It requires organizations to
+                    notify users as soon as possible of high-risk data breaches that could personally affect them.
+                  </p>
+                </div>
+              </Modal.Body>
+              <Modal.Footer>
+                <Modal.Close>
+                  <Button>I accept</Button>
+                </Modal.Close>
+                <Modal.Close>
+                  <Button color="gray">Decline</Button>
+                </Modal.Close>
+              </Modal.Footer>
+            </Modal.Content>
           </Modal>
         </>
       ),
@@ -48,9 +53,11 @@ const ModalPage: FC = () => {
     {
       title: 'Dismissable modal',
       code: (
-        <>
-          <Button onClick={() => setOpenModal('dismissible')}>Toggle modal</Button>
-          <Modal dismissible show={openModal === 'dismissible'} onClose={() => setOpenModal(undefined)}>
+        <Modal>
+          <Modal.Trigger>
+            <Button>Toggle modal</Button>
+          </Modal.Trigger>
+          <Modal.Content dismissible>
             <Modal.Header>Terms of Service</Modal.Header>
             <Modal.Body>
               <div className="space-y-6">
@@ -66,21 +73,25 @@ const ModalPage: FC = () => {
               </div>
             </Modal.Body>
             <Modal.Footer>
-              <Button onClick={() => setOpenModal(undefined)}>I accept</Button>
-              <Button color="gray" onClick={() => setOpenModal(undefined)}>
-                Decline
-              </Button>
+              <Modal.Close>
+                <Button>I accept</Button>
+              </Modal.Close>
+              <Modal.Close>
+                <Button color="gray">Decline</Button>
+              </Modal.Close>
             </Modal.Footer>
-          </Modal>
-        </>
+          </Modal.Content>
+        </Modal>
       ),
     },
     {
       title: 'Pop-up modal',
       code: (
-        <>
-          <Button onClick={() => setOpenModal('pop-up')}>Toggle modal</Button>
-          <Modal show={openModal === 'pop-up'} size="md" popup onClose={() => setOpenModal(undefined)}>
+        <Modal popup>
+          <Modal.Trigger>
+            <Button>Toggle modal</Button>
+          </Modal.Trigger>
+          <Modal.Content size="md">
             <Modal.Header />
             <Modal.Body>
               <div className="text-center">
@@ -89,25 +100,23 @@ const ModalPage: FC = () => {
                   Are you sure you want to delete this product?
                 </h3>
                 <div className="flex justify-center gap-4">
-                  <Button color="failure" onClick={() => setOpenModal(undefined)}>
-                    {"Yes, I'm sure"}
-                  </Button>
-                  <Button color="gray" onClick={() => setOpenModal(undefined)}>
-                    No, cancel
-                  </Button>
+                  <Button color="failure">{"Yes, I'm sure"}</Button>
+                  <Button color="gray">No, cancel</Button>
                 </div>
               </div>
             </Modal.Body>
-          </Modal>
-        </>
+          </Modal.Content>
+        </Modal>
       ),
     },
     {
       title: 'Form elements',
       code: (
-        <>
-          <Button onClick={() => setOpenModal('form-elements')}>Toggle modal</Button>
-          <Modal show={openModal === 'form-elements'} size="md" popup onClose={() => setOpenModal(undefined)}>
+        <Modal popup>
+          <Modal.Trigger>
+            <Button>Toggle modal</Button>
+          </Modal.Trigger>
+          <Modal.Content size="md">
             <Modal.Header />
             <Modal.Body>
               <div className="space-y-6 px-6 pb-4 sm:pb-6 lg:px-8 xl:pb-8">
@@ -144,14 +153,14 @@ const ModalPage: FC = () => {
                 </div>
               </div>
             </Modal.Body>
-          </Modal>
-        </>
+          </Modal.Content>
+        </Modal>
       ),
     },
     {
       title: 'Sizing',
       code: (
-        <>
+        <Modal>
           <div className="flex flex-wrap gap-4">
             <div className="w-40">
               <Select defaultValue="md" onChange={(event) => setModalSize(event.target.value)}>
@@ -167,9 +176,11 @@ const ModalPage: FC = () => {
                 <option value="7xl">7xl</option>
               </Select>
             </div>
-            <Button onClick={() => setOpenModal('size')}>Toggle modal</Button>
           </div>
-          <Modal show={openModal === 'size'} size={modalSize} onClose={() => setOpenModal(undefined)}>
+          <Modal.Trigger>
+            <Button>Toggle modal</Button>
+          </Modal.Trigger>
+          <Modal.Content size={modalSize}>
             <Modal.Header>Small modal</Modal.Header>
             <Modal.Body>
               <div className="space-y-6 p-6">
@@ -185,19 +196,17 @@ const ModalPage: FC = () => {
               </div>
             </Modal.Body>
             <Modal.Footer>
-              <Button onClick={() => setOpenModal(undefined)}>I accept</Button>
-              <Button color="gray" onClick={() => setOpenModal(undefined)}>
-                Decline
-              </Button>
+              <Button>I accept</Button>
+              <Button color="gray">Decline</Button>
             </Modal.Footer>
-          </Modal>
-        </>
+          </Modal.Content>
+        </Modal>
       ),
     },
     {
       title: 'Placement',
       code: (
-        <>
+        <Modal>
           <div className="flex flex-wrap gap-4">
             <div className="w-40">
               <Select defaultValue="center" onChange={(event) => setModalPlacement(event.target.value)}>
@@ -212,9 +221,11 @@ const ModalPage: FC = () => {
                 <option value="bottom-left">Bottom left</option>
               </Select>
             </div>
-            <Button onClick={() => setOpenModal('placement')}>Toggle modal</Button>
           </div>
-          <Modal show={openModal === 'placement'} position={modalPlacement} onClose={() => setOpenModal(undefined)}>
+          <Modal.Trigger>
+            <Button>Toggle modal</Button>
+          </Modal.Trigger>
+          <Modal.Content position={modalPlacement}>
             <Modal.Header>Small modal</Modal.Header>
             <Modal.Body>
               <div className="space-y-6 p-6">
@@ -230,13 +241,11 @@ const ModalPage: FC = () => {
               </div>
             </Modal.Body>
             <Modal.Footer>
-              <Button onClick={() => setOpenModal(undefined)}>I accept</Button>
-              <Button color="gray" onClick={() => setOpenModal(undefined)}>
-                Decline
-              </Button>
+              <Button>I accept</Button>
+              <Button color="gray">Decline</Button>
             </Modal.Footer>
-          </Modal>
-        </>
+          </Modal.Content>
+        </Modal>
       ),
     },
   ];

--- a/src/lib/components/Modal/Modal.stories.tsx
+++ b/src/lib/components/Modal/Modal.stories.tsx
@@ -85,7 +85,6 @@ PopUp.args = {
 };
 
 export const FormElements = Template.bind({});
-FormElements.storyName = 'Form elements';
 FormElements.args = {
   children: (
     <>

--- a/src/lib/components/Modal/Modal.stories.tsx
+++ b/src/lib/components/Modal/Modal.stories.tsx
@@ -46,7 +46,9 @@ Default.args = {
         </div>
       </Modal.Body>
       <Modal.Footer>
-        <Button>I accept</Button>
+        <Modal.Close>
+          <Button>I accept</Button>
+        </Modal.Close>
         <Modal.Close>
           <Button color="gray">Decline</Button>
         </Modal.Close>
@@ -72,9 +74,9 @@ PopUp.args = {
           Are you sure you want to delete this product?
         </h3>
         <div className="flex justify-center gap-4">
-          <Button color="failure" onClick={action('close')}>
-            {"Yes, I'm sure"}
-          </Button>
+          <Modal.Close>
+            <Button color="failure">{"Yes, I'm sure"}</Button>
+          </Modal.Close>
           <Modal.Close>
             <Button color="gray">No, cancel</Button>
           </Modal.Close>

--- a/src/lib/components/Modal/Modal.stories.tsx
+++ b/src/lib/components/Modal/Modal.stories.tsx
@@ -16,14 +16,14 @@ export default {
   },
 } as Meta;
 
-const Template: Story<ModalProps> = ({ children, ...rest }): JSX.Element => {
+const Template: Story<ModalProps> = ({ children, show, ...rest }): JSX.Element => {
   return (
-    <>
-      <Button onClick={action('open')}>Toggle modal</Button>
-      <Modal onClose={action('close')} {...rest}>
-        {children}
-      </Modal>
-    </>
+    <Modal show={show} onClose={action('handleModalCloseCallback')}>
+      <Modal.Trigger>
+        <Button>Toggle modal</Button>
+      </Modal.Trigger>
+      <Modal.Content {...rest}>{children}</Modal.Content>
+    </Modal>
   );
 };
 
@@ -46,13 +46,19 @@ Default.args = {
         </div>
       </Modal.Body>
       <Modal.Footer>
-        <Button onClick={action('close')}>I accept</Button>
-        <Button color="gray" onClick={action('close')}>
-          Decline
-        </Button>
+        <Button>I accept</Button>
+        <Modal.Close>
+          <Button color="gray">Decline</Button>
+        </Modal.Close>
       </Modal.Footer>
     </>
   ),
+};
+
+export const InitialyOpened = Template.bind({});
+InitialyOpened.args = {
+  ...Default.args,
+  show: true,
 };
 
 export const PopUp = Template.bind({});
@@ -66,12 +72,12 @@ PopUp.args = {
           Are you sure you want to delete this product?
         </h3>
         <div className="flex justify-center gap-4">
-          <Button color="red" onClick={action('close')}>
+          <Button color="failure" onClick={action('close')}>
             {"Yes, I'm sure"}
           </Button>
-          <Button color="gray" onClick={action('close')}>
-            No, cancel
-          </Button>
+          <Modal.Close>
+            <Button color="gray">No, cancel</Button>
+          </Modal.Close>
         </div>
       </div>
     </Modal.Body>

--- a/src/lib/components/Modal/Modal.tsx
+++ b/src/lib/components/Modal/Modal.tsx
@@ -1,135 +1,26 @@
-import classNames from 'classnames';
-import { ComponentProps, FC, MouseEvent, PropsWithChildren, useEffect, useRef } from 'react';
-import { createPortal } from 'react-dom';
-import { useKeyDown } from '../../hooks';
-import type { FlowbiteBoolean, FlowbitePositions, FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
-import { useTheme } from '../Flowbite/ThemeContext';
 import { ModalBody } from './ModalBody';
-import { ModalContext } from './ModalContext';
+import { ModalClose } from './ModalClose';
+import { ModalContent } from './ModalContent';
+import { ModalContextProvider, ModalContextProviderProps } from './ModalContext';
 import { ModalFooter } from './ModalFooter';
 import { ModalHeader } from './ModalHeader';
+import { ModalTrigger } from './ModalTrigger';
 
-export interface FlowbiteModalTheme {
-  base: string;
-  show: FlowbiteBoolean;
-  content: {
-    base: string;
-    inner: string;
-  };
-  body: {
-    base: string;
-    popup: string;
-  };
-  header: {
-    base: string;
-    popup: string;
-    title: string;
-    close: {
-      base: string;
-      icon: string;
-    };
-  };
-  footer: {
-    base: string;
-    popup: string;
-  };
-  sizes: ModalSizes;
-  positions: ModalPositions;
-}
+export interface ModalProps extends ModalContextProviderProps {}
 
-export interface ModalPositions extends FlowbitePositions {
-  [key: string]: string;
-}
-
-export interface ModalSizes extends Omit<FlowbiteSizes, 'xs'> {
-  [key: string]: string;
-}
-
-export interface ModalProps extends PropsWithChildren<ComponentProps<'div'>> {
-  onClose?: () => void;
-  position?: keyof ModalPositions;
-  popup?: boolean;
-  root?: HTMLElement;
-  show?: boolean;
-  size?: keyof ModalSizes;
-  dismissible?: boolean;
-}
-
-const ModalComponent: FC<ModalProps> = ({
-  children,
-  show,
-  root = document.body,
-  popup,
-  size = '2xl',
-  position = 'center',
-  dismissible = false,
-  onClose,
-  className,
-  ...props
-}) => {
-  const theme = useTheme().theme.modal;
-  // Declare a ref to store a reference to a div element.
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  // If the current value of the ref is falsy (e.g. null), set it to a new div
-  // element.
-  if (!containerRef.current) {
-    containerRef.current = document.createElement('div');
-  }
-
-  // If the current value of the ref is not already a child of the root element,
-  // append it or replace its parent.
-  if (containerRef.current.parentNode !== root) {
-    root.appendChild(containerRef.current);
-  }
-
-  useEffect(() => {
-    return () => {
-      const container = containerRef.current;
-
-      // If a container exists on unmount, it is removed from the DOM and
-      // garbage collected.
-      if (container) {
-        container.parentNode?.removeChild(container);
-        containerRef.current = null;
-      }
-    };
-  }, []);
-
-  useKeyDown('Escape', () => {
-    if (dismissible && onClose) {
-      onClose();
-    }
-  });
-
-  const handleOnClick = (e: MouseEvent<HTMLDivElement>) => {
-    if (dismissible && e.target === e.currentTarget && onClose) {
-      onClose();
-    }
-  };
-
-  return createPortal(
-    <ModalContext.Provider value={{ popup, onClose }}>
-      <div
-        aria-hidden={!show}
-        className={classNames(theme.base, theme.positions[position], show ? theme.show.on : theme.show.off, className)}
-        data-testid="modal"
-        role="dialog"
-        onClick={handleOnClick}
-        {...props}
-      >
-        <div className={classNames(theme.content.base, theme.sizes[size])}>
-          <div className={theme.content.inner}>{children}</div>
-        </div>
-      </div>
-    </ModalContext.Provider>,
-    containerRef.current,
-  );
-};
-
-ModalComponent.displayName = 'Modal';
+ModalContextProvider.displayName = 'Modal';
+ModalTrigger.displayName = 'Modal.Trigger';
+ModalClose.displayName = 'Modal.Close';
+ModalContent.displayName = 'Modal.Content';
 ModalHeader.displayName = 'Modal.Header';
 ModalBody.displayName = 'Modal.Body';
 ModalFooter.displayName = 'Modal.Footer';
 
-export const Modal = Object.assign(ModalComponent, { Header: ModalHeader, Body: ModalBody, Footer: ModalFooter });
+export const Modal = Object.assign(ModalContextProvider, {
+  Trigger: ModalTrigger,
+  Close: ModalClose,
+  Content: ModalContent,
+  Header: ModalHeader,
+  Body: ModalBody,
+  Footer: ModalFooter,
+});

--- a/src/lib/components/Modal/ModalClose.tsx
+++ b/src/lib/components/Modal/ModalClose.tsx
@@ -1,14 +1,9 @@
-import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 import { useModalContext } from './ModalContext';
+import { ProxyChild } from './ProxyChild';
 
-export type ModalHeaderProps = PropsWithChildren<ComponentProps<'div'>>;
+export const ModalClose: FC<PropsWithChildren> = ({ children }): JSX.Element => {
+  const { closeModal } = useModalContext();
 
-export const ModalClose: FC<ModalHeaderProps> = ({ children, ...props }): JSX.Element => {
-  const { close } = useModalContext();
-
-  return (
-    <div {...props} onClick={close}>
-      {children}
-    </div>
-  );
+  return <ProxyChild onClick={closeModal}>{children}</ProxyChild>;
 };

--- a/src/lib/components/Modal/ModalClose.tsx
+++ b/src/lib/components/Modal/ModalClose.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import { useModalContext } from './ModalContext';
+
+export type ModalHeaderProps = PropsWithChildren<ComponentProps<'div'>>;
+
+export const ModalClose: FC<ModalHeaderProps> = ({ children, ...props }): JSX.Element => {
+  const { close } = useModalContext();
+
+  return (
+    <div {...props} onClick={close}>
+      {children}
+    </div>
+  );
+};

--- a/src/lib/components/Modal/ModalContent.tsx
+++ b/src/lib/components/Modal/ModalContent.tsx
@@ -1,0 +1,97 @@
+import classNames from 'classnames';
+import { ComponentProps, FC, MouseEvent, PropsWithChildren } from 'react';
+import { useKeyDown } from '../../hooks';
+import type { FlowbiteBoolean, FlowbitePositions, FlowbiteSizes } from '../Flowbite/FlowbiteTheme';
+import { useTheme } from '../Flowbite/ThemeContext';
+import { useModalContext } from './ModalContext';
+import { ModalPortal } from './ModalPortal';
+
+export interface FlowbiteModalTheme {
+  base: string;
+  show: FlowbiteBoolean;
+  content: {
+    base: string;
+    inner: string;
+  };
+  body: {
+    base: string;
+    popup: string;
+  };
+  header: {
+    base: string;
+    popup: string;
+    title: string;
+    close: {
+      base: string;
+      icon: string;
+    };
+  };
+  footer: {
+    base: string;
+    popup: string;
+  };
+  sizes: ModalSizes;
+  positions: ModalPositions;
+}
+
+export interface ModalPositions extends FlowbitePositions {
+  [key: string]: string;
+}
+
+export interface ModalSizes extends Omit<FlowbiteSizes, 'xs'> {
+  [key: string]: string;
+}
+
+export interface ModalContentProps extends PropsWithChildren<ComponentProps<'div'>> {
+  position?: keyof ModalPositions;
+  root?: HTMLElement;
+  size?: keyof ModalSizes;
+  dismissible?: boolean;
+}
+
+export const ModalContent: FC<ModalContentProps> = ({
+  children,
+  root,
+  size = '2xl',
+  position = 'center',
+  dismissible = false,
+  className,
+  ...props
+}) => {
+  const { isOpen, close } = useModalContext();
+  const theme = useTheme().theme.modal;
+
+  useKeyDown('Escape', () => {
+    if (dismissible) {
+      close();
+    }
+  });
+
+  const handleOnClick = (e: MouseEvent<HTMLDivElement>) => {
+    if (dismissible && e.target === e.currentTarget) {
+      close();
+    }
+  };
+
+  return (
+    <ModalPortal root={root}>
+      <div
+        aria-hidden={!isOpen}
+        className={classNames(
+          theme.base,
+          theme.positions[position],
+          isOpen ? theme.show.on : theme.show.off,
+          className,
+        )}
+        data-testid="modal"
+        role="dialog"
+        onClick={handleOnClick}
+        {...props}
+      >
+        <div className={classNames(theme.content.base, theme.sizes[size])}>
+          <div className={theme.content.inner}>{children}</div>
+        </div>
+      </div>
+    </ModalPortal>
+  );
+};

--- a/src/lib/components/Modal/ModalContent.tsx
+++ b/src/lib/components/Modal/ModalContent.tsx
@@ -58,18 +58,18 @@ export const ModalContent: FC<ModalContentProps> = ({
   className,
   ...props
 }) => {
-  const { isOpen, close } = useModalContext();
+  const { isOpen, closeModal } = useModalContext();
   const theme = useTheme().theme.modal;
 
   useKeyDown('Escape', () => {
     if (dismissible) {
-      close();
+      closeModal();
     }
   });
 
   const handleOnClick = (e: MouseEvent<HTMLDivElement>) => {
     if (dismissible && e.target === e.currentTarget) {
-      close();
+      closeModal();
     }
   };
 

--- a/src/lib/components/Modal/ModalContext.tsx
+++ b/src/lib/components/Modal/ModalContext.tsx
@@ -2,8 +2,8 @@ import { createContext, FC, PropsWithChildren, useCallback, useContext, useMemo,
 type ModalContext = {
   popup: boolean;
   isOpen: boolean;
-  open: () => void;
-  close: () => void;
+  openModal: () => void;
+  closeModal: () => void;
 };
 
 const ModalContext = createContext<ModalContext | undefined>(undefined);
@@ -32,17 +32,19 @@ export const ModalContextProvider: FC<ModalContextProviderProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(show);
 
-  const close = useCallback(() => {
+  const closeModal = useCallback(() => {
     setIsOpen(false);
     onClose?.();
   }, [onClose]);
 
-  const open = useCallback(() => {
+  const openModal = useCallback(() => {
     setIsOpen(true);
   }, []);
 
   return (
-    <ModalContext.Provider value={useMemo(() => ({ isOpen, popup, close, open }), [isOpen, popup, close, open])}>
+    <ModalContext.Provider
+      value={useMemo(() => ({ isOpen, popup, closeModal, openModal }), [isOpen, popup, closeModal, openModal])}
+    >
       {children}
     </ModalContext.Provider>
   );

--- a/src/lib/components/Modal/ModalContext.tsx
+++ b/src/lib/components/Modal/ModalContext.tsx
@@ -1,18 +1,49 @@
-import { createContext, useContext } from 'react';
-
+import { createContext, FC, PropsWithChildren, useCallback, useContext, useMemo, useState } from 'react';
 type ModalContext = {
-  popup?: boolean;
-  onClose?: () => void;
+  popup: boolean;
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
 };
 
-export const ModalContext = createContext<ModalContext | undefined>(undefined);
+const ModalContext = createContext<ModalContext | undefined>(undefined);
 
 export function useModalContext(): ModalContext {
   const context = useContext(ModalContext);
 
   if (!context) {
-    throw new Error('useModalContext should be used within the ModalContext provider!');
+    throw new Error('useModalContext() should be used within the <ModalContextProvider />!');
   }
 
   return context;
 }
+
+export type ModalContextProviderProps = PropsWithChildren<{
+  popup?: boolean;
+  show?: boolean;
+  onClose?: () => void;
+}>;
+
+export const ModalContextProvider: FC<ModalContextProviderProps> = ({
+  popup = false,
+  show = false,
+  onClose,
+  children,
+}) => {
+  const [isOpen, setIsOpen] = useState(show);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    onClose?.();
+  }, [onClose]);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  return (
+    <ModalContext.Provider value={useMemo(() => ({ isOpen, popup, close, open }), [isOpen, popup, close, open])}>
+      {children}
+    </ModalContext.Provider>
+  );
+};

--- a/src/lib/components/Modal/ModalHeader.tsx
+++ b/src/lib/components/Modal/ModalHeader.tsx
@@ -2,12 +2,13 @@ import classNames from 'classnames';
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
 import { HiOutlineX } from 'react-icons/hi';
 import { useTheme } from '../Flowbite/ThemeContext';
+import { ModalClose } from './ModalClose';
 import { useModalContext } from './ModalContext';
 
 export type ModalHeaderProps = PropsWithChildren<ComponentProps<'div'>>;
 
 export const ModalHeader: FC<ModalHeaderProps> = ({ children, className, ...props }): JSX.Element => {
-  const { popup, onClose } = useModalContext();
+  const { popup } = useModalContext();
   const theme = useTheme().theme.modal.header;
 
   return (
@@ -22,9 +23,11 @@ export const ModalHeader: FC<ModalHeaderProps> = ({ children, className, ...prop
       {...props}
     >
       <h3 className={theme.title}>{children}</h3>
-      <button aria-label="Close" className={theme.close.base} type="button" onClick={onClose}>
-        <HiOutlineX aria-hidden className={theme.close.icon} />
-      </button>
+      <ModalClose>
+        <button aria-label="Close" className={theme.close.base} type="button">
+          <HiOutlineX aria-hidden className={theme.close.icon} />
+        </button>
+      </ModalClose>
     </div>
   );
 };

--- a/src/lib/components/Modal/ModalPortal.tsx
+++ b/src/lib/components/Modal/ModalPortal.tsx
@@ -1,0 +1,37 @@
+import { FC, PropsWithChildren, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+export type ModalPortalProps = PropsWithChildren<{
+  root?: HTMLElement;
+}>;
+
+export const ModalPortal: FC<ModalPortalProps> = ({ children, root = document.body }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  // If the current value of the ref is falsy (e.g. null), set it to a new div
+  // element.
+  if (!containerRef.current) {
+    containerRef.current = document.createElement('div');
+  }
+
+  // If the current value of the ref is not already a child of the root element,
+  // append it or replace its parent.
+  if (containerRef.current.parentNode !== root) {
+    root.appendChild(containerRef.current);
+  }
+
+  useEffect(() => {
+    return () => {
+      const container = containerRef.current;
+
+      // If a container exists on unmount, it is removed from the DOM and
+      // garbage collected.
+      if (container) {
+        container.parentNode?.removeChild(container);
+        containerRef.current = null;
+      }
+    };
+  }, []);
+
+  return createPortal(children, containerRef.current);
+};

--- a/src/lib/components/Modal/ModalTrigger.tsx
+++ b/src/lib/components/Modal/ModalTrigger.tsx
@@ -1,14 +1,9 @@
-import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import type { FC, PropsWithChildren } from 'react';
 import { useModalContext } from './ModalContext';
+import { ProxyChild } from './ProxyChild';
 
-export type ModalHeaderProps = PropsWithChildren<ComponentProps<'div'>>;
+export const ModalTrigger: FC<PropsWithChildren> = ({ children }): JSX.Element => {
+  const { openModal } = useModalContext();
 
-export const ModalTrigger: FC<ModalHeaderProps> = ({ children, ...props }): JSX.Element => {
-  const { open } = useModalContext();
-
-  return (
-    <div {...props} onClick={open}>
-      {children}
-    </div>
-  );
+  return <ProxyChild onClick={openModal}>{children}</ProxyChild>;
 };

--- a/src/lib/components/Modal/ModalTrigger.tsx
+++ b/src/lib/components/Modal/ModalTrigger.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import { useModalContext } from './ModalContext';
+
+export type ModalHeaderProps = PropsWithChildren<ComponentProps<'div'>>;
+
+export const ModalTrigger: FC<ModalHeaderProps> = ({ children, ...props }): JSX.Element => {
+  const { open } = useModalContext();
+
+  return (
+    <div {...props} onClick={open}>
+      {children}
+    </div>
+  );
+};

--- a/src/lib/components/Modal/ProxyChild.tsx
+++ b/src/lib/components/Modal/ProxyChild.tsx
@@ -1,0 +1,19 @@
+import React, { PropsWithChildren } from 'react';
+
+// Virtual component to which propagates the click handler to the children
+export const ProxyChild = ({ children, onClick }: PropsWithChildren<{ onClick: () => void }>) => {
+  if (React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      ...children.props,
+      // merge handler
+      onClick: children.props.onClick
+        ? (...args: unknown[]) => {
+            children.props.onClick(...args);
+            onClick();
+          }
+        : onClick,
+    });
+  }
+
+  return React.Children.count(children) > 1 ? React.Children.only(null) : null;
+};

--- a/src/lib/components/Modal/ProxyChild.tsx
+++ b/src/lib/components/Modal/ProxyChild.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 
-// Virtual component to which propagates the click handler to the children
+// Virtual component which propagates the click handler to the children
 export const ProxyChild = ({ children, onClick }: PropsWithChildren<{ onClick: () => void }>) => {
   if (React.isValidElement(children)) {
     return React.cloneElement(children, {

--- a/src/lib/components/Modal/index.ts
+++ b/src/lib/components/Modal/index.ts
@@ -1,4 +1,5 @@
 export * from './Modal';
 export type { ModalBodyProps } from './ModalBody';
+export type { FlowbiteModalTheme } from './ModalContent';
 export type { ModalFooterProps } from './ModalFooter';
 export type { ModalHeaderProps } from './ModalHeader';


### PR DESCRIPTION
## Description

Uncontrolled modal API. New `<Modal.Trigger />` and `<Modal.Close />` components with wired open/close handlers.

Simplifies usage to the point that modals don't require hook programming.

Existing docs & storybook code is vastly simplified as well.

Fixes #413 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change contains documentation update

## Breaking changes

The `<Modal />` component is now just a context, root holding the state.
New <Modal.Content />` is the previous modal, which behaves as the portal, backdrop, and dialog element.

Users will have to move the props from `Modal` to the `Modal.Content`.

To avoid moving, props, likely better naming will be to keep `Modal` behave as the `Modal.Content` and rename the `Modal` to `Modal.Root`. This way users will only wrap the existing modals with the root (context) component, and only move the `show` prop.

## How Has This Been Tested?

The modal has existing tests which pass.

Storybook preview is also a test method. Note that storybook modals were broken and now work.

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
