### PR TITLE
fix: focus on load tabs #345

### DIFF
--- a/src/lib/components/Tab/Tabs.tsx
+++ b/src/lib/components/Tab/Tabs.tsx
@@ -119,6 +119,7 @@ export const TabsComponent = forwardRef<TabsRef, TabsProps>(
     const tabItemStyle = theme.tablist.tabitem.styles[style];
 
     useEffect(() => {
+      if (focusedTab === activeTab) return;
       tabRefs.current[focusedTab]?.focus();
     }, [focusedTab]);
 

--- a/src/lib/components/Tab/Tabs.tsx
+++ b/src/lib/components/Tab/Tabs.tsx
@@ -98,7 +98,6 @@ export const TabsComponent = forwardRef<TabsRef, TabsProps>(
 
     const handleClick = ({ target }: TabEventProps): void => {
       setActiveTabWithCallback(target);
-      setFocusedTab(target);
     };
 
     const handleKeyboard = ({ event, target }: TabKeyboardEventProps): void => {


### PR DESCRIPTION
Updated focus to check if the activetab is the same as focustab, if that is true, return focusing

## Fix for
Fixes #345 

## Type:
Bug fix 

