### PR TITLE
Fix errors with modal when document is undefined

### DIFF
--- a/src/lib/components/Modal/Modal.tsx
+++ b/src/lib/components/Modal/Modal.tsx
@@ -110,9 +110,8 @@ const ModalComponent: FC<ModalProps> = ({
 
   // If the current value of the ref is not already a child of the root element,
   // append it or replace its parent.
-
   if (containerRef.current.parentNode !== rootUsed && windowExists()) {
-    (rootUsed || document.body).appendChild(containerRef.current);
+    rootUsed.appendChild(containerRef.current);
   }
 
   const handleOnClick = (e: MouseEvent<HTMLDivElement>) => {

--- a/src/lib/components/Modal/Modal.tsx
+++ b/src/lib/components/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import type { ComponentProps, FC, MouseEvent, PropsWithChildren } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { DeepPartial } from '..';
 import { mergeDeep } from '../../helpers/mergeDeep';
@@ -69,6 +69,13 @@ const ModalComponent: FC<ModalProps> = ({
   ...props
 }) => {
   const theme = mergeDeep(useTheme().theme.modal, customTheme);
+  const [rootUsed, setRootUsed] = useState(root);
+
+  useEffect(() => {
+    if (!rootUsed && document?.body) {
+      setRootUsed(document.body);
+    }
+  }, [rootUsed]);
 
   // Declare a ref to store a reference to a div element.
   const containerRef = useRef<HTMLDivElement | null>(null);

--- a/src/lib/components/Modal/Modal.tsx
+++ b/src/lib/components/Modal/Modal.tsx
@@ -70,28 +70,14 @@ const ModalComponent: FC<ModalProps> = ({
 }) => {
   const theme = mergeDeep(useTheme().theme.modal, customTheme);
   const [rootUsed, setRootUsed] = useState(root);
+  // Declare a ref to store a reference to a div element.
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!rootUsed && document?.body) {
       setRootUsed(document.body);
     }
   }, [rootUsed]);
-
-  // Declare a ref to store a reference to a div element.
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  // If the current value of the ref is falsy (e.g. null), set it to a new div
-  // element.
-  if (!containerRef.current) {
-    containerRef.current = document.createElement('div');
-  }
-
-  // If the current value of the ref is not already a child of the root element,
-  // append it or replace its parent.
-  if (containerRef.current.parentNode !== root && windowExists()) {
-    root = root || document.body;
-    root.appendChild(containerRef.current);
-  }
 
   useEffect(() => {
     return () => {
@@ -111,6 +97,23 @@ const ModalComponent: FC<ModalProps> = ({
       onClose();
     }
   });
+
+  if (!rootUsed) {
+    return null;
+  }
+
+  // If the current value of the ref is falsy (e.g. null), set it to a new div
+  // element.
+  if (!containerRef.current) {
+    containerRef.current = document.createElement('div');
+  }
+
+  // If the current value of the ref is not already a child of the root element,
+  // append it or replace its parent.
+
+  if (containerRef.current.parentNode !== rootUsed && windowExists()) {
+    (rootUsed || document.body).appendChild(containerRef.current);
+  }
 
   const handleOnClick = (e: MouseEvent<HTMLDivElement>) => {
     if (dismissible && e.target === e.currentTarget && onClose) {


### PR DESCRIPTION
Fixes #591 
Fixes #573

## Description

`document` is undefined when the component is first rendered and that creates an error. This checks for the existence of `document` before using it. 

Also, all hooks need to be executed before any other code in the component, so I have moved some hooks up.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Works for me when using the component. I didn't perform any actual tests except for usage.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
