### PR TITLE
docs(readme): refer to theme docs page in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,21 +57,19 @@ If you want to learn more about Flowbite, visit [Flowbite docs](https://flowbite
 
 ## Getting started
 
-To use `flowbite-react`, you just need to setup `flowbite` normally and install `flowbite-react` from `npm`.
+Make sure you have [Node.js](https://nodejs.org/en/) installed.
+
+To use `flowbite-react`, you need to setup [`flowbite`](https://github.com/themesberg/flowbite) and also install `flowbite-react` from `npm` or `yarn`.
 
 `flowbite` can be included as a plugin into an existing Tailwind CSS project.
-
-### Require via `npm`
-
-Make sure that you have <a href="https://nodejs.org/en/" rel="nofollow" >Node.js</a> and <a href="https://tailwindcss.com/" rel="nofollow" >Tailwind CSS</a> installed.
 
 1. Install `flowbite` as a dependency using `npm` by running the following command:
 
 ```bash
-npm i flowbite flowbite-react
+npm i flowbite flowbite-react # or yarn add flowbite flowbite-react
 ```
 
-2. Require `flowbite` as a plugin inside the `tailwind.config.js` file:
+2. Require `flowbite` as a plugin inside the `tailwind.config.js` file, and include content from `flowbite-react`:
 
 ```javascript
 module.exports = {
@@ -80,8 +78,15 @@ module.exports = {
     'node_modules/flowbite-react/**/*.{js,jsx,ts,tsx}'
   ],
   plugins: [..., require('flowbite/plugin')],
+  ...
 };
 ```
+
+## Customize components
+
+You can customize every component in `flowbite-react`. We've provided a few different methods so just about any use case you have should be covered for now. 
+
+See [https://flowbite-react.com/theme](https://flowbite-react.com/theme)
 
 ## Components
 


### PR DESCRIPTION
This information needs to be extremely accessible now.

## Description

- [x] docs(readme): refer to theme docs page in `README`

## Type of change

- [x] This change contains documentation update

## Breaking changes

None

## How Has This Been Tested?

- [x] Viewed README in VS Code preview

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
