### PR TITLE
docs(component): fix missing DropdownComponent displayName property

### DIFF
--- a/src/lib/components/Dropdown/Dropdown.tsx
+++ b/src/lib/components/Dropdown/Dropdown.tsx
@@ -128,6 +128,7 @@ const DropdownComponent: FC<DropdownProps> = ({
   );
 };
 
+DropdownComponent.displayName = 'Dropdown';
 DropdownItem.displayName = 'Dropdown.Item';
 DropdownHeader.displayName = 'Dropdown.Header';
 DropdownDivider.displayName = 'Dropdown.Divider';


### PR DESCRIPTION
## Description

This PR fixes the **Dropdown** component documentation so that it runs as-is. A missing _displayName_ property caused the documentation to render an invalid name for the component.

Related to #616

## Type of change

- [x] This change contains documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
