### PR TITLE
feat(footercopyright): add target props to FooterCopyright

### DIFF
--- a/src/lib/components/Footer/FooterCopyright.tsx
+++ b/src/lib/components/Footer/FooterCopyright.tsx
@@ -13,6 +13,7 @@ export interface FlowbiteFooterCopyrightTheme {
 export interface CopyrightProps extends PropsWithChildren, ComponentProps<'div'> {
   by: string;
   href?: string;
+  target?: string;
   theme?: DeepPartial<FlowbiteFooterCopyrightTheme>;
   year?: number;
 }
@@ -21,6 +22,7 @@ export const FooterCopyright: FC<CopyrightProps> = ({
   by,
   className,
   href,
+  target,
   theme: customTheme = {},
   year,
   ...props
@@ -31,7 +33,7 @@ export const FooterCopyright: FC<CopyrightProps> = ({
     <div data-testid="flowbite-footer-copyright" className={classNames(theme.base, className)} {...props}>
       © {year}
       {href ? (
-        <a href={href} className={theme.href}>
+        <a href={href} target={target} className={theme.href}>
           {by}
         </a>
       ) : (


### PR DESCRIPTION
This adds the `target` property to the FooterCopyright Component. This enables to open the link in a new tab with `target="_blank"`

## Description

This ads the target property to the FooterCopyright props. It also use it when there a link, in the <a>

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

By adding `target="_blank"` like this : `<Footer.Copyright href="https://github.com" target="_blank" by="Microsoft™" year={2023} />`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
