### PR TITLE
fix(button/carousel): added DeepPartial Typing

### DIFF
--- a/src/lib/components/Button/Button.tsx
+++ b/src/lib/components/Button/Button.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import { forwardRef, type ComponentProps, type ReactNode } from 'react';
+import type { DeepPartial } from '..';
 import { mergeDeep } from '../../helpers/mergeDeep';
 import type {
   FlowbiteBoolean,
@@ -70,7 +71,7 @@ export interface ButtonProps extends Omit<ComponentProps<'button'>, 'color' | 'r
   pill?: boolean;
   positionInGroup?: keyof PositionInButtonGroup;
   size?: keyof ButtonSizes;
-  theme?: FlowbiteButtonTheme;
+  theme?: DeepPartial<FlowbiteButtonTheme>;
 }
 
 const ButtonComponent = forwardRef<HTMLButtonElement | HTMLAnchorElement, ButtonProps>(

--- a/src/lib/components/Carousel/Carousel.tsx
+++ b/src/lib/components/Carousel/Carousel.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps, FC, PropsWithChildren, ReactElement, ReactNode } f
 import { Children, cloneElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { HiOutlineChevronLeft, HiOutlineChevronRight } from 'react-icons/hi';
 import ScrollContainer from 'react-indiana-drag-scroll';
+import type { DeepPartial } from '..';
 import { mergeDeep } from '../../helpers/mergeDeep';
 import windowExists from '../../helpers/window-exists';
 import type { FlowbiteBoolean } from '../Flowbite/FlowbiteTheme';
@@ -49,7 +50,7 @@ export interface CarouselProps extends PropsWithChildren<ComponentProps<'div'>> 
   rightControl?: ReactNode;
   slide?: boolean;
   slideInterval?: number;
-  theme?: FlowbiteCarouselTheme;
+  theme?: DeepPartial<FlowbiteCarouselTheme>;
 }
 
 export const Carousel: FC<CarouselProps> = ({


### PR DESCRIPTION
fix #646

## Description

This PR just adds the `DeepPartial` type to optional custom themes for two components (Button & Carousel) that were missing that. For both, deep merging with the base theme was already setup.

Fixes #646 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Breaking changes

None.

## How Has This Been Tested?

Just the regular tests with `yarn test`, and linting tests with prettier and eslint.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
