### PR TITLE
fix(themecontext): fixing `ReferenceError: window is not defined` error with Next.js

### DIFF
--- a/src/lib/components/Flowbite/ThemeContext.tsx
+++ b/src/lib/components/Flowbite/ThemeContext.tsx
@@ -31,7 +31,7 @@ export function useTheme(): ThemeContextProps {
 }
 
 export const useThemeMode = (): [Mode, React.Dispatch<React.SetStateAction<Mode>>, () => void] => {
-  const userPreferenceIsDark = () => window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+  const userPreferenceIsDark = () => windowExists() && window.matchMedia?.('(prefers-color-scheme: dark)').matches;
   const getPrefersColorScheme = (): Mode => (userPreferenceIsDark() ? 'dark' : 'light');
   const onToggleMode = () => {
     const newMode = mode === 'dark' ? 'light' : 'dark';


### PR DESCRIPTION
## Description

The variable `userPreferenceIsDark` was initialized with a value from the window object. This was causing an error with Next because of SSR. I added the check of the window, if it's on the server side the value is set to `false`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change contains documentation update

## How Has This Been Tested?

On my Next.js project that was causing the error.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
