### PR TITLE
fix(sidebar): adds missing className

### DIFF
--- a/src/lib/components/Sidebar/Sidebar.tsx
+++ b/src/lib/components/Sidebar/Sidebar.tsx
@@ -41,6 +41,7 @@ const SidebarComponent: FC<SidebarProps> = ({
   collapseBehavior = 'collapse',
   collapsed: isCollapsed = false,
   theme: customTheme = {},
+  className,
   ...props
 }) => {
   const theme = mergeDeep(useTheme().theme.sidebar, customTheme);
@@ -50,7 +51,7 @@ const SidebarComponent: FC<SidebarProps> = ({
       <aside
         aria-label="Sidebar"
         hidden={isCollapsed && collapseBehavior === 'hide'}
-        className={classNames(theme.root.base, theme.root.collapsed[isCollapsed ? 'on' : 'off'])}
+        className={classNames(theme.root.base, theme.root.collapsed[isCollapsed ? 'on' : 'off'], className)}
         {...props}
       >
         <div className={theme.root.inner}>{children}</div>


### PR DESCRIPTION
## Description

`className` was present on Sidebar, 'cause it extends `div`, but it wasn't working properly. This PR, adds the `className` to the end of CSS classes, as we have in other components.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Breaking changes

No

## How Has This Been Tested?

- [X] Manual test

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
