### PR TITLE
fix(modal theme): fix modal vertical positioning

### DIFF
--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -541,7 +541,7 @@ const theme: FlowbiteTheme = {
       },
     },
     content: {
-      base: 'relative h-full w-full p-4',
+      base: 'relative h-full w-full p-4 md:h-auto',
       inner: 'relative rounded-lg bg-white shadow dark:bg-gray-700',
     },
     body: {


### PR DESCRIPTION
## Description

As of the changes of #601 (fixing #600), modals can no longer be positioned vertically. This is because the height of the modal is always 100% and thus `items-start`, `items-center` or `items-end` do not affect the flex items. This PR reverts the simple change made that broke this.

The bug can be observed in the docs [here](https://flowbite-react.com/modal) where positioning the item anywhere but the top does nothing.

In my opinion, the fix for overflowing modals seen in #601 and also suggested on #537 is not accurate. Setting a max height for your modal when using the component is more than sufficient to fix this issue on any given project, but eventually having a fix on this package could be ideal (some of this discussion overlaps with #520).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually adding `md:h-auto` to my own project and the docs' site.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
