### PR TITLE
fix(/src/components/avatar): enable explicit sizing of placeholder initials (#659)

### DIFF
--- a/src/docs/pages/AvatarPage.tsx
+++ b/src/docs/pages/AvatarPage.tsx
@@ -130,19 +130,22 @@ const AvatarPage: FC = () => {
       ),
     },
     {
-      title: 'Placeholder',
-      code: (
-        <div className="flex flex-wrap gap-2">
-          <Avatar />
-          <Avatar rounded />
-        </div>
-      ),
-    },
-    {
       title: 'Placeholder Initials',
       code: (
         <div className="flex flex-wrap gap-2">
           <Avatar placeholderInitials="RR" />
+        </div>
+      ),
+    },
+    {
+      title: 'Placeholder Initials - Sizing',
+      code: (
+        <div className="flex flex-wrap items-center gap-2">
+          <Avatar placeholderInitials="RR" size="xs" />
+          <Avatar placeholderInitials="RR" size="sm" />
+          <Avatar placeholderInitials="RR" size="md" />
+          <Avatar placeholderInitials="RR" size="lg" />
+          <Avatar placeholderInitials="RR" size="xl" />
         </div>
       ),
     },

--- a/src/lib/components/Avatar/Avatar.spec.tsx
+++ b/src/lib/components/Avatar/Avatar.spec.tsx
@@ -60,6 +60,15 @@ describe('Components / Avatar', () => {
       expect(initialsPlaceholderText()).toHaveTextContent('RR');
     });
 
+    it('should support explicit sizes with placeholder initials', () => {
+      render(
+        <Flowbite>
+          <Avatar placeholderInitials="RR" size="xl" />
+        </Flowbite>,
+      );
+
+      expect(initialsPlaceholder()).toHaveClass('h-36 w-36');
+    });
     it('should support border color with placeholder initials', () => {
       render(
         <Flowbite>

--- a/src/lib/components/Avatar/Avatar.tsx
+++ b/src/lib/components/Avatar/Avatar.tsx
@@ -124,6 +124,7 @@ const AvatarComponent: FC<AvatarProps> = ({
               stacked && theme.root.stacked,
               bordered && theme.root.bordered,
               bordered && theme.root.color[color],
+              theme.root.size[size],
             )}
             data-testid="flowbite-avatar-initials-placeholder"
           >

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -138,7 +138,7 @@ const theme: FlowbiteTheme = {
       },
       initials: {
         text: 'font-medium text-gray-600 dark:text-gray-300',
-        base: 'inline-flex overflow-hidden relative justify-center items-center w-10 h-10 bg-gray-100 dark:bg-gray-600',
+        base: 'inline-flex overflow-hidden relative justify-center items-center bg-gray-100 dark:bg-gray-600',
       },
     },
     group: {


### PR DESCRIPTION
## Description

This PR removes the hard-coding of width and height styling applied to any `Avatar` component using the `placeholderInitials` property, and adds in the size class when rendering so that it is rendered in the expected size.

Fixes: https://github.com/themesberg/flowbite-react/issues/659

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change contains documentation update

## Breaking changes

None.

## How Has This Been Tested?

Tested locally, tested in an external CRA via `link` and also tested via a previously failing unit test (included in PR).

**Test Configuration**:
N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
