### PR TITLE
chore(pre-commit): simplify pre-commit logic to only run on changed files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn prettier:fix && yarn lint && yarn test run && yarn build
+yarn lint-staged

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  '*.{js,jsx,ts,tsx}': [
+    'eslint --cache --fix',
+    'prettier --write',
+    'yarn test related --run',
+    () => 'tsc-files --noEmit',
+  ],
+  '*.{json,css}': ['prettier --write'],
+};

--- a/lint-staged.js
+++ b/lint-staged.js
@@ -1,8 +1,0 @@
-module.exports = {
-  '*.{js,jsx,ts,tsx}': [
-    'eslint --cache --fix',
-    'react-scripts test --bail --watchAll=false --findRelatedTests --passWithNoTests',
-    () => 'tsc -p tsconfig.json --noEmit',
-  ],
-  '*.{js,jsx,ts,tsx,json,css,js}': ['prettier --write'],
-};

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "start-server-and-test": "^2.0.0",
     "storybook-dark-mode": "^2.1.1",
     "tailwindcss": "^3.2.7",
+    "tsc-files": "^1.1.3",
     "typescript": "^4.9.5",
     "vite": "^4.1.4",
     "vitest": "^0.29.2",
@@ -169,7 +170,7 @@
       "/lib",
       "commitlint.config.js",
       "config-overrides.js",
-      "lint-staged.js",
+      "lint-staged.config.cjs",
       "postcss.config.js",
       "tailwind.config.js"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -16942,6 +16942,11 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+tsc-files@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/tsc-files/-/tsc-files-1.1.3.tgz#ef4cfcb7affc9b90577d707a879dc53bb105be83"
+  integrity sha512-G6uXkTNofGU9EE1fYBaCpR72x/aqXW4PDAuznWj4JYlDwhcaKnUn4CiCHBMc89lDxLmikK+hhaEWLoTPEKKvXg==
+
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"


### PR DESCRIPTION
Configure the project to use lint-staged for the pre-commit logic, instead of having lint-staged installed but not using it.

This should speed up development, and make it easier to commit changes to the project. There is less time waiting for the whole project to build or for all of the tests to run, when they are not related to your changes.

The new pre-commit workflow is:
- eslint and prettier will run one after another, instead of in parallel. This is to prevent race conditions with potentially modifying the same file: https://github.com/okonet/lint-staged#task-concurrency
- Recommended vitest options for lint-staged: https://vitest.dev/guide/cli.html#vitest-related
- tsc-files was added as a devDependency, in order to only run tsc against the changed files, instead of all files: https://github.com/gustavopch/tsc-files

Also the `lint-staged.js` file was renamed since it was not detectable by lint-staged so it did not work. The new name is the one suggested by lint-staged for use with the `module.exports` syntax: https://github.com/okonet/lint-staged#configuration

Fixes #671

## Type of change

Please delete options that are not relevant.

- [X] This change contains a build config change.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested commiting typescript files and running `yarn lint-staged` against them. Confirmed the linter, prettier, vitest, and tsc only targeted relevant files.
- [X] Tested commiting CSS files and running `yarn lint-staged` against them. Confirmed the linter, prettier, vitest, and tsc only targeted relevant files.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
