### PR TITLE
fix(components/accordion): allow opened panel to be closed

### DIFF
--- a/src/lib/components/Accordion/Accordion.tsx
+++ b/src/lib/components/Accordion/Accordion.tsx
@@ -43,11 +43,22 @@ const AccordionComponent: FC<AccordionProps> = ({
   theme: customTheme = {},
   ...props
 }) => {
+
   const [isOpen, setOpen] = useState(collapseAll ? -1 : 0);
+  
+  const toggleOpen = (i: number) => {
+    if (isOpen === i) {
+      setOpen(-1);
+    } else {
+      setOpen(i);
+    }
+  }
+  
   const panels = useMemo(
     () =>
       Children.map(children, (child, i) =>
-        cloneElement(child, { alwaysOpen, arrowIcon, flush, isOpen: isOpen === i, setOpen: () => setOpen(i) }),
+
+        cloneElement(child, { alwaysOpen, arrowIcon, flush, isOpen: isOpen === i, setOpen: () => toggleOpen(i) }),
       ),
     [alwaysOpen, arrowIcon, children, flush, isOpen],
   );

--- a/src/lib/components/Accordion/Accordion.tsx
+++ b/src/lib/components/Accordion/Accordion.tsx
@@ -43,21 +43,19 @@ const AccordionComponent: FC<AccordionProps> = ({
   theme: customTheme = {},
   ...props
 }) => {
-
   const [isOpen, setOpen] = useState(collapseAll ? -1 : 0);
-  
+
   const toggleOpen = (i: number) => {
     if (isOpen === i) {
       setOpen(-1);
     } else {
       setOpen(i);
     }
-  }
-  
+  };
+
   const panels = useMemo(
     () =>
       Children.map(children, (child, i) =>
-
         cloneElement(child, { alwaysOpen, arrowIcon, flush, isOpen: isOpen === i, setOpen: () => toggleOpen(i) }),
       ),
     [alwaysOpen, arrowIcon, children, flush, isOpen],


### PR DESCRIPTION
## Description

setOpen function didn't allow for current value to be removed if the item being clicked on was already open. As a result, it was not possible to close an accordion drawer by toggling it. 

Added toggleOpen function to set out of range value for open if the current target was already open. 

Fixes #618 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

Please document the breaking changes if suitable.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: tested functionality locally. 
- [x] Test B: ran test suite to confirm no breaking changes. 


## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
