### PR TITLE
fix(component/progressbar):  fix progressbar showing label when progress == 0

### DIFF
--- a/src/lib/components/Progress/Progress.tsx
+++ b/src/lib/components/Progress/Progress.tsx
@@ -54,26 +54,27 @@ export const Progress: FC<ProgressProps> = ({
     <>
       <div id={id} aria-label={textLabel} aria-valuenow={progress} role="progressbar" {...props}>
         {((textLabel && labelText && textLabelPosition === 'outside') ||
-          (progress && labelProgress && progressLabelPosition === 'outside')) && (
+          (progress && labelProgress && progressLabelPosition === 'outside')) ? (
           <div className={theme.label} data-testid="flowbite-progress-outer-label-container">
             {textLabel && labelText && textLabelPosition === 'outside' && (
               <span data-testid="flowbite-progress-outer-text-label">{textLabel}</span>
             )}
-            {progress && labelProgress && progressLabelPosition === 'outside' && (
+            {labelProgress && progressLabelPosition === 'outside' && (
               <span data-testid="flowbite-progress-outer-progress-label">{progress}%</span>
             )}
           </div>
-        )}
+        ) : null}
+
         <div className={classNames(theme.base, theme.size[size], className)}>
           <div
             style={{ width: `${progress}%` }}
             className={classNames(theme.bar, theme.color[color], theme.size[size])}
           >
             {textLabel && labelText && textLabelPosition === 'inside' && (
-              <span data-testid="flowbite-progress-inner-text-label">{textLabel}</span>
+              <span className='whitespace-nowrap' data-testid="flowbite-progress-inner-text-label">{textLabel}</span>
             )}
-            {progress && labelProgress && progressLabelPosition === 'inside' && (
-              <span data-testid="flowbite-progress-inner-progress-label">{progress}%</span>
+            {labelProgress && progressLabelPosition === 'inside' && (
+              <span className='whitespace-nowrap' data-testid="flowbite-progress-inner-progress-label">{progress}%</span>
             )}
           </div>
         </div>

--- a/src/lib/components/Progress/Progress.tsx
+++ b/src/lib/components/Progress/Progress.tsx
@@ -53,8 +53,8 @@ export const Progress: FC<ProgressProps> = ({
   return (
     <>
       <div id={id} aria-label={textLabel} aria-valuenow={progress} role="progressbar" {...props}>
-        {(textLabel && labelText && textLabelPosition === 'outside') ||
-        (progress && labelProgress && progressLabelPosition === 'outside') ? (
+        {((textLabel && labelText && textLabelPosition === 'outside') ||
+          (progress > 0 && labelProgress && progressLabelPosition === 'outside')) && (
           <div className={theme.label} data-testid="flowbite-progress-outer-label-container">
             {textLabel && labelText && textLabelPosition === 'outside' && (
               <span data-testid="flowbite-progress-outer-text-label">{textLabel}</span>
@@ -63,7 +63,7 @@ export const Progress: FC<ProgressProps> = ({
               <span data-testid="flowbite-progress-outer-progress-label">{progress}%</span>
             )}
           </div>
-        ) : null}
+        )}
 
         <div className={classNames(theme.base, theme.size[size], className)}>
           <div
@@ -71,14 +71,10 @@ export const Progress: FC<ProgressProps> = ({
             className={classNames(theme.bar, theme.color[color], theme.size[size])}
           >
             {textLabel && labelText && textLabelPosition === 'inside' && (
-              <span className="whitespace-nowrap" data-testid="flowbite-progress-inner-text-label">
-                {textLabel}
-              </span>
+              <span data-testid="flowbite-progress-inner-text-label">{textLabel}</span>
             )}
-            {labelProgress && progressLabelPosition === 'inside' && (
-              <span className="whitespace-nowrap" data-testid="flowbite-progress-inner-progress-label">
-                {progress}%
-              </span>
+            {progress > 0 && labelProgress && progressLabelPosition === 'inside' && (
+              <span data-testid="flowbite-progress-inner-progress-label">{progress}%</span>
             )}
           </div>
         </div>

--- a/src/lib/components/Progress/Progress.tsx
+++ b/src/lib/components/Progress/Progress.tsx
@@ -53,8 +53,8 @@ export const Progress: FC<ProgressProps> = ({
   return (
     <>
       <div id={id} aria-label={textLabel} aria-valuenow={progress} role="progressbar" {...props}>
-        {((textLabel && labelText && textLabelPosition === 'outside') ||
-          (progress && labelProgress && progressLabelPosition === 'outside')) ? (
+        {(textLabel && labelText && textLabelPosition === 'outside') ||
+        (progress && labelProgress && progressLabelPosition === 'outside') ? (
           <div className={theme.label} data-testid="flowbite-progress-outer-label-container">
             {textLabel && labelText && textLabelPosition === 'outside' && (
               <span data-testid="flowbite-progress-outer-text-label">{textLabel}</span>
@@ -71,10 +71,14 @@ export const Progress: FC<ProgressProps> = ({
             className={classNames(theme.bar, theme.color[color], theme.size[size])}
           >
             {textLabel && labelText && textLabelPosition === 'inside' && (
-              <span className='whitespace-nowrap' data-testid="flowbite-progress-inner-text-label">{textLabel}</span>
+              <span className="whitespace-nowrap" data-testid="flowbite-progress-inner-text-label">
+                {textLabel}
+              </span>
             )}
             {labelProgress && progressLabelPosition === 'inside' && (
-              <span className='whitespace-nowrap' data-testid="flowbite-progress-inner-progress-label">{progress}%</span>
+              <span className="whitespace-nowrap" data-testid="flowbite-progress-inner-progress-label">
+                {progress}%
+              </span>
             )}
           </div>
         </div>

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -491,12 +491,12 @@ const theme: FlowbiteTheme = {
   },
   listGroup: {
     root: {
-      base: 'list-none rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white text-left',
+      base: 'list-none rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white',
     },
     item: {
-      base: '[&>*]:first:rounded-t-lg [&>*]:last:rounded-b-lg [&>*]:last:border-b-0',
+      base: 'flex w-full cursor-pointer border-b border-gray-200 py-2 px-4 first:rounded-t-lg last:rounded-b-lg last:border-b-0 dark:border-gray-600',
       link: {
-        base: 'flex w-full border-b border-gray-200 py-2 px-4 dark:border-gray-600',
+        base: '',
         active: {
           off: 'hover:bg-gray-100 hover:text-blue-700 focus:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-700 dark:border-gray-600 dark:hover:bg-gray-600 dark:hover:text-white dark:focus:text-white dark:focus:ring-gray-500',
           on: 'bg-blue-700 text-white dark:bg-gray-800',
@@ -637,7 +637,7 @@ const theme: FlowbiteTheme = {
   progress: {
     base: 'w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700',
     label: 'mb-1 flex justify-between font-medium dark:text-white',
-    bar: 'items-center justify-center rounded-full text-center font-medium leading-none text-blue-100 space-x-2',
+    bar: 'items-center justify-center rounded-full text-center font-medium leading-none text-blue-300 dark:text-blue-100 space-x-2',
     color: {
       dark: 'bg-gray-600 dark:bg-gray-300',
       blue: 'bg-blue-600',

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -637,7 +637,7 @@ const theme: FlowbiteTheme = {
   progress: {
     base: 'w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700',
     label: 'mb-1 flex justify-between font-medium dark:text-white',
-    bar: 'flex items-center justify-center rounded-full text-center font-medium leading-none text-blue-100 space-x-2',
+    bar: 'items-center justify-center rounded-full text-center font-medium leading-none text-blue-100 space-x-2',
     color: {
       dark: 'bg-gray-600 dark:bg-gray-300',
       blue: 'bg-blue-600',

--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -491,12 +491,12 @@ const theme: FlowbiteTheme = {
   },
   listGroup: {
     root: {
-      base: 'list-none rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white',
+      base: 'list-none rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white text-left',
     },
     item: {
-      base: 'flex w-full cursor-pointer border-b border-gray-200 py-2 px-4 first:rounded-t-lg last:rounded-b-lg last:border-b-0 dark:border-gray-600',
+      base: '[&>*]:first:rounded-t-lg [&>*]:last:rounded-b-lg [&>*]:last:border-b-0',
       link: {
-        base: '',
+        base: 'flex w-full border-b border-gray-200 py-2 px-4 dark:border-gray-600',
         active: {
           off: 'hover:bg-gray-100 hover:text-blue-700 focus:text-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-700 dark:border-gray-600 dark:hover:bg-gray-600 dark:hover:text-white dark:focus:text-white dark:focus:ring-gray-500',
           on: 'bg-blue-700 text-white dark:bg-gray-800',
@@ -637,7 +637,7 @@ const theme: FlowbiteTheme = {
   progress: {
     base: 'w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700',
     label: 'mb-1 flex justify-between font-medium dark:text-white',
-    bar: 'items-center justify-center rounded-full text-center font-medium leading-none text-blue-300 dark:text-blue-100 space-x-2',
+    bar: 'rounded-full text-center font-medium leading-none text-blue-300 dark:text-blue-100 space-x-2',
     color: {
       dark: 'bg-gray-600 dark:bg-gray-300',
       blue: 'bg-blue-600',


### PR DESCRIPTION
## Description

Progress bar shows labels even when it is disabled at progress value is 0
The conditional rendering using the '&&' would return 0 on condition being false which would get displayed when progress value is 0. This was fixed using ternary operator instead. And also the label would get hidden at low progress values which is now 

Fixes #696

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?


Tested by trying to set the progress value to zero in the storybook.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
