### PR TITLE
feat(sidebar): Allow to customize the Sidebar component with 'as'

### DIFF
--- a/src/lib/components/Sidebar/Sidebar.tsx
+++ b/src/lib/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import type { ComponentProps, ElementType, FC, PropsWithChildren } from 'react';
 import type { DeepPartial } from '..';
 import { mergeDeep } from '../../helpers/mergeDeep';
 import type { FlowbiteBoolean } from '../Flowbite/FlowbiteTheme';
@@ -31,6 +31,7 @@ export interface FlowbiteSidebarTheme {
 }
 
 export interface SidebarProps extends PropsWithChildren, ComponentProps<'div'> {
+  as?: ElementType;
   collapseBehavior?: 'collapse' | 'hide';
   collapsed?: boolean;
   theme?: DeepPartial<FlowbiteSidebarTheme>;
@@ -38,6 +39,7 @@ export interface SidebarProps extends PropsWithChildren, ComponentProps<'div'> {
 
 const SidebarComponent: FC<SidebarProps> = ({
   children,
+  as: Component = 'aside',
   collapseBehavior = 'collapse',
   collapsed: isCollapsed = false,
   theme: customTheme = {},
@@ -48,14 +50,14 @@ const SidebarComponent: FC<SidebarProps> = ({
 
   return (
     <SidebarContext.Provider value={{ isCollapsed }}>
-      <aside
+      <Component
         aria-label="Sidebar"
         hidden={isCollapsed && collapseBehavior === 'hide'}
         className={classNames(theme.root.base, theme.root.collapsed[isCollapsed ? 'on' : 'off'], className)}
         {...props}
       >
         <div className={theme.root.inner}>{children}</div>
-      </aside>
+      </Component>
     </SidebarContext.Provider>
   );
 };

--- a/src/lib/components/Sidebar/Sidebar.tsx
+++ b/src/lib/components/Sidebar/Sidebar.tsx
@@ -39,7 +39,7 @@ export interface SidebarProps extends PropsWithChildren, ComponentProps<'div'> {
 
 const SidebarComponent: FC<SidebarProps> = ({
   children,
-  as: Component = 'aside',
+  as: Component = 'nav',
   collapseBehavior = 'collapse',
   collapsed: isCollapsed = false,
   theme: customTheme = {},


### PR DESCRIPTION
## Description

In some cases, the sidebar is the main navigation of an app and setting using

```
    <Sidebar as="nav">
       ...
    </Sidebar>
```

would be more appropriate.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

