### PR TITLE
fix(/lib/components/dropdown): set <Dropdown> width equal to trigger #(575)

### DIFF
--- a/src/lib/components/Dropdown/Dropdown.tsx
+++ b/src/lib/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { ComponentProps, FC, PropsWithChildren, ReactElement, ReactNode } from 'react';
-import React, { Children, useCallback, useMemo, useState } from 'react';
+import React, { Children, useCallback, useMemo, useRef, useState } from 'react';
 import { HiOutlineChevronDown, HiOutlineChevronLeft, HiOutlineChevronRight, HiOutlineChevronUp } from 'react-icons/hi';
 import type { DeepPartial } from '..';
 import { mergeDeep } from '../../helpers/mergeDeep';
@@ -75,6 +75,8 @@ const DropdownComponent: FC<DropdownProps> = ({
   }, [placement]);
 
   const [closeRequestKey, setCloseRequestKey] = useState<string | undefined>(undefined);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const buttonWidth = triggerRef.current?.offsetWidth;
 
   // Extends DropdownItem's onClick to trigger a close request to the Floating component
   const attachCloseListener = useCallback(
@@ -101,12 +103,24 @@ const DropdownComponent: FC<DropdownProps> = ({
   );
 
   const content = useMemo(
-    () => <ul className={theme.content}>{Children.map(children, attachCloseListener)}</ul>,
-    [attachCloseListener, children, theme.content],
+    () => (
+      <ul className={theme.content} style={{ minWidth: buttonWidth ? `${buttonWidth}px` : 'auto' }}>
+        {Children.map(children, attachCloseListener)}
+      </ul>
+    ),
+    [children, theme, triggerRef.current, attachCloseListener, buttonWidth],
   );
 
   const TriggerWrapper: FC<ButtonProps> = ({ children }) =>
-    inline ? <button className={theme.inlineWrapper}>{children}</button> : <Button {...buttonProps}>{children}</Button>;
+    inline ? (
+      <button ref={triggerRef} className={theme.inlineWrapper}>
+        {children}
+      </button>
+    ) : (
+      <Button ref={triggerRef} {...buttonProps}>
+        {children}
+      </Button>
+    );
 
   return (
     <Floating


### PR DESCRIPTION
## Description
Update the dropdown width to fit the button width

This is a copy of [Pull-583](https://github.com/themesberg/flowbite-react/pull/583), except it fixes the linter error.

Fixes #575

## Type of change
Please delete options that are not relevant.

* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ]  This change contains documentation update

## Breaking changes
Please document the breaking changes if suitable.

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

* [ ]  Test A
* [ ]  Test B

**Test Configuration**:

* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:
* [x]  My code follows the style guidelines of this project
* [x]  I have performed a self-review of my own code
* [ ]  I have commented my code, particularly in hard-to-understand areas
* [ ]  I have made corresponding changes to the documentation
* [x]  My changes generate no new warnings
* [ ]  I have added tests that prove my fix is effective or that my feature works
* [x]  New and existing unit tests pass locally with my changes
* [ ]  Any dependent changes have been merged and published in downstream modules
* [x]  I have checked my code and corrected any misspellings

