### PR TITLE
fix(theme): typo in bottom-center

### DIFF
--- a/src/lib/theme/default.ts
+++ b/src/lib/theme/default.ts
@@ -120,7 +120,7 @@ const theme: FlowbiteTheme = {
       stacked: 'ring-2 ring-gray-300 dark:ring-gray-500',
       statusPosition: {
         'bottom-left': '-bottom-1 -left-1',
-        'bottom-center': '-botton-1 center',
+        'bottom-center': '-bottom-1 center',
         'bottom-right': '-bottom-1 -right-1',
         'top-left': '-top-1 -left-1',
         'top-center': '-top-1 center',


### PR DESCRIPTION
Fixing a typo: botton -> bottom
