### PR TITLE
Corrected syntax error on modal

### DIFF
--- a/src/lib/components/Modal/Modal.tsx
+++ b/src/lib/components/Modal/Modal.tsx
@@ -109,7 +109,7 @@ const ModalComponent: FC<ModalProps> = ({
   // If the current value of the ref is not already a child of the root element,
   // append it or replace its parent.
   if (containerRef.current.parentNode !== root && windowExists()) {
-    root ||= document.body;
+    root || document.body;
     root.appendChild(containerRef.current);
 
     // Prevent scrolling of the root element when the modal is shown


### PR DESCRIPTION
Fixed a typo, syntax error on Modal component. Breaks during build
