### PR TITLE
fix: making ToggleSwitch color prop as keyof FlowbiteColors

### DIFF
--- a/src/lib/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/lib/components/ToggleSwitch/ToggleSwitch.tsx
@@ -26,7 +26,7 @@ export interface FlowbiteToggleSwitchToggleTheme {
 
 export type ToggleSwitchProps = Omit<ComponentProps<'button'>, 'onChange'> & {
   checked: boolean;
-  color?: FlowbiteColors;
+  color?: keyof FlowbiteColors;
   label: string;
   onChange: (checked: boolean) => void;
   theme?: DeepPartial<FlowbiteToggleSwitchTheme>;


### PR DESCRIPTION
## Description
Based on #736 , ToggleSwitch color prop was not defined as keyof FlowbiteColors which was causing a build error.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #736 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change contains documentation update

## Breaking changes

Please document the breaking changes if suitable.

## How Has This Been Tested?
Using a project test, I was able to navigete to the type definition and perform the modification on the fly. So the component itself was able to show whether it was working properly or not. After that I built the project and it worked as expected

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
