### PR TITLE
fix(dropdown): add type button in dropdown

### DIFF
--- a/src/lib/components/Dropdown/Dropdown.spec.tsx
+++ b/src/lib/components/Dropdown/Dropdown.spec.tsx
@@ -55,10 +55,24 @@ describe('Components / Dropdown', () => {
       expect(dropdown()).not.toHaveClass('invisible');
     });
   });
+  describe('Type of button', async () => {
+    it('should be of type `button`', async () => {
+      render(<TestDropdown />);
+      expect(button()).toHaveAttribute('type', 'button');
+    });
+
+    it('should be of type `button` with inline', async () => {
+      render(<TestDropdown inline />);
+      expect(button()).toHaveAttribute('type', 'button');
+    });
+  });
 });
 
-const TestDropdown: FC<{ dismissOnClick?: boolean }> = ({ dismissOnClick = true }) => (
-  <Dropdown label="Dropdown button" placement="right" dismissOnClick={dismissOnClick}>
+const TestDropdown: FC<{ dismissOnClick?: boolean; inline?: boolean }> = ({
+  dismissOnClick = true,
+  inline = false,
+}) => (
+  <Dropdown label="Dropdown button" placement="right" dismissOnClick={dismissOnClick} inline={inline}>
     <Dropdown.Header>
       <span className="block text-sm">Bonnie Green</span>
       <span className="block truncate text-sm font-medium">name@flowbite.com</span>

--- a/src/lib/components/Dropdown/Dropdown.tsx
+++ b/src/lib/components/Dropdown/Dropdown.tsx
@@ -119,11 +119,11 @@ const DropdownComponent: FC<DropdownProps> = ({
     }, [ref]);
 
     return inline ? (
-      <button ref={ref} className={theme.inlineWrapper}>
+      <button type="button" ref={ref} className={theme.inlineWrapper}>
         {children}
       </button>
     ) : (
-      <Button ref={ref} {...buttonProps}>
+      <Button type="button" ref={ref} {...buttonProps}>
         {children}
       </Button>
     );


### PR DESCRIPTION
## Description
Adding the type button to be able to use the dropdown inside the form. 
Same as used in example from https://flowbite.com/docs/forms/select/#select-with-dropdown

Fixes #756

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change contains documentation update

## How Has This Been Tested?

Check that the form submission is being sent at the correct time and is working.
I checked if the button type was correct in the inspect element, and it's ok

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
