### PR TITLE
fix(component): fix Label component disabled property not applying theme styles

### DIFF
--- a/src/lib/components/Label/Label.spec.tsx
+++ b/src/lib/components/Label/Label.spec.tsx
@@ -1,9 +1,10 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { HiGlobe, HiLockClosed } from 'react-icons/hi';
 import { describe, expect, it } from 'vitest';
 import { Button } from '../Button';
 import { Checkbox } from '../Checkbox';
 import { FileInput } from '../FileInput';
+import { Flowbite } from '../Flowbite';
 import { Radio } from '../Radio';
 import { RangeSlider } from '../RangeSlider';
 import { Select } from '../Select';
@@ -30,8 +31,30 @@ describe.concurrent('Components / Label', () => {
 
       inputLabels.forEach((label) => expect(getByLabelText(label)).toHaveAccessibleName(label));
     });
+
+    describe('Theme', () => {
+      it('should use `disabled` classes', () => {
+        const theme = {
+          label: {
+            root: {
+              disabled: 'opacity-50',
+            },
+          },
+        };
+
+        render(
+          <Flowbite theme={{ theme }}>
+            <Label disabled />
+          </Flowbite>,
+        );
+
+        expect(label()).toHaveClass('opacity-50');
+      });
+    });
   });
 });
+
+const label = () => screen.getByTestId('flowbite-label');
 
 const TestForm = (): JSX.Element => (
   <form>

--- a/src/lib/components/Label/Label.tsx
+++ b/src/lib/components/Label/Label.tsx
@@ -40,7 +40,8 @@ export const Label: FC<LabelProps> = ({
 
   return (
     <label
-      className={classNames(theme.root.base, theme.root.colors[color], disabled ?? theme.root.disabled, className)}
+      className={classNames(theme.root.base, theme.root.colors[color], disabled && theme.root.disabled, className)}
+      data-testid="flowbite-label"
       {...props}
     >
       {value ?? children ?? ''}


### PR DESCRIPTION
fixes #762

## Description
fix not applying `disabled` state styles on `Label` component and add a component test to make sure it doesn't get broken

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Breaking changes
None

## How Has This Been Tested?
- component test
- manual check using the browser

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
