### PR TITLE
fix(modal): fixed a bug that disallowed users to set the position of a modal

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -543,7 +543,7 @@ export const theme: FlowbiteTheme = {
       },
     },
     content: {
-      base: 'relative h-full w-full m-auto p-4 md:h-auto',
+      base: 'relative h-full w-full p-4 md:h-auto',
       inner: 'relative rounded-lg bg-white shadow dark:bg-gray-700 flex flex-col max-h-[90vh]',
     },
     body: {


### PR DESCRIPTION
## Description

The modal's position property is handled by the parent of the actual content box using flex, align-items, and justify-content but was blocked by the content box's property of "margin: auto" (m-auto). This fix deletes that property so the parent can correctly handle the position of the modal correctly.

Fixes #760 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tested this change by running the documentation site locally and checking whether the property works correctly on the Modal component page.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
