### PR TITLE
fix(Modal): modal scrollbar overflow style issue fixed

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -123,7 +123,7 @@ const ModalComponent: FC<ModalProps> = ({
     root.appendChild(containerRef.current);
 
     // Prevent scrolling of the root element when the modal is shown
-    root.style.overflow = show ? 'hidden' : 'auto';
+    root.style.overflow = show ? 'hidden' : '';
   }
 
   const handleOnClick = (e: MouseEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Description

Flowbite modal removes the scroll bar forever if I toggle it from Flowbite footer component.

Fixes # [761](https://github.com/themesberg/flowbite-react/issues/761)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tested this change by running the documentation site locally and toggling the Modal from the bottom works fine from my end the scrollbar doesn't remain hidden when I close the Modal 

## Checklist:

- [x] My code follows the style guidelines of this project
