### PR TITLE
docs(font): load Inter font from Next

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,14 @@
 import type { Metadata, NextPage } from 'next/types';
 
+import { Inter } from 'next/font/google';
 import type { PropsWithChildren } from 'react';
 import '~/app/docs.css';
 import '~/app/style.css';
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+});
 
 export const metadata: Metadata = {
   icons: '/favicon.svg',
@@ -23,7 +29,7 @@ export const metadata: Metadata = {
 
 const RootLayout: NextPage<PropsWithChildren> = ({ children }) => {
   return (
-    <html lang="en">
+    <html lang="en" className={`${inter.variable} font-sans`}>
       <body>{children}</body>
     </html>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,6 +24,7 @@ module.exports = {
     },
     fontFamily: {
       sans: [
+        'var(--font-inter)',
         'Inter',
         'ui-sans-serif',
         'system-ui',
@@ -58,6 +59,7 @@ module.exports = {
         'Noto Color Emoji',
       ],
       mono: [
+        'var(--font-roboto-mono)',
         'ui-monospace',
         'SFMono-Regular',
         'Menlo',


### PR DESCRIPTION
## Description

Properly import the `Inter` font from Google Fonts via Next configuration.

Fixes # [(issue)](https://github.com/themesberg/flowbite-react/issues/789)

## Type of change

Please delete options that are not relevant.

- [x] This change contains documentation update

## Breaking changes

No breaking changes.

## How Has This Been Tested?

You can test via the browser and network tab.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
