### PR TITLE
docs: add Theme section to each component's docs

### DIFF
--- a/app/docs/components/accordion/accordion.mdx
+++ b/app/docs/components/accordion/accordion.mdx
@@ -1,4 +1,4 @@
-import { Accordion } from '~/src/components/Accordion';
+import { Accordion, theme } from '~/src';
 import { CodePreview } from '~/app/components/code-preview';
 
 The accordion component from Flowbite React can be used to toggle the visibility of the content of each accordion panel tab by expanding the collapsing the trigger element based on multiple examples and styles.
@@ -162,6 +162,14 @@ Use this example to automatically collapse all of the accordion panels by passin
     </Accordion.Panel>
   </Accordion>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.accordion, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/alert/alert.mdx
+++ b/app/docs/components/alert/alert.mdx
@@ -1,7 +1,7 @@
-import { CodePreview } from '~/app/components/code-preview';
-import { ExampleAdditionalContent } from './additional-content.tsx';
 import { HiInformationCircle } from 'react-icons/hi';
-import { Alert } from '~/src';
+import { CodePreview } from '~/app/components/code-preview';
+import { Alert, theme } from '~/src';
+import { ExampleAdditionalContent } from './additional-content.tsx';
 
 The alert component can be used to show a contextual text to the user such as a success or error message after form validation inside an alert box where you can choose from multiple colors, sizes, and styles.
 
@@ -106,6 +106,14 @@ This is an example with all of the available options and props for the alert com
     </span>
   </Alert>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.alert, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/avatar/avatar.mdx
+++ b/app/docs/components/avatar/avatar.mdx
@@ -1,5 +1,5 @@
 import { CodePreview } from '~/app/components/code-preview';
-import { Avatar, Dropdown } from '~/src';
+import { Avatar, Dropdown, theme } from '~/src';
 import Image from 'next/image';
 
 The avatar component from Flowbite React can be used to show a visual representation of a user or team account for your application based on multiple examples, colors, sizes and shapes.
@@ -196,6 +196,14 @@ You can override the default image element by passing the `img` prop to the `<Av
     />
   </div>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.avatar, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/badge/badge.mdx
+++ b/app/docs/components/badge/badge.mdx
@@ -1,6 +1,6 @@
 import { HiCheck, HiClock } from 'react-icons/hi';
 import { CodePreview } from '~/app/components/code-preview';
-import { Badge } from '~/src';
+import { Badge, theme } from '~/src';
 
 The badge component can be used to show text, labels, and counters inside a small box or circle element which can be placed inside paragraphs, buttons, dropdowns, menu items, and more.
 
@@ -102,6 +102,14 @@ You can choose from `xs` and `sm` sizes.
     Pink
   </Badge>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.badge, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/breadcrumb/breadcrumb.mdx
+++ b/app/docs/components/breadcrumb/breadcrumb.mdx
@@ -1,6 +1,6 @@
-import { HiHome } from 'react-icons/hi';
 import { CodePreview } from '~/app/components/code-preview';
-import { Breadcrumb } from '~/src';
+import { Breadcrumb, theme } from '~/src';
+import { HiHome } from 'react-icons/hi';
 
 The breadcrumb component can be used to indicate the current page's location within a navigational hierarchy and you can choose from multiple examples, colors, and sizes built with React and based on the utility classes from Tailwind CSS.
 
@@ -41,6 +41,14 @@ You can add a solid background style to the breadcrumb component by adding the `
     <Breadcrumb.Item>Flowbite React</Breadcrumb.Item>
   </Breadcrumb>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.breadcrumb, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/button-group/button-group.mdx
+++ b/app/docs/components/button-group/button-group.mdx
@@ -1,6 +1,6 @@
-import { HiAdjustments, HiCloudDownload, HiUserCircle } from 'react-icons/hi';
 import { CodePreview } from '~/app/components/code-preview';
-import { Button } from '~/src';
+import { Button, theme } from '~/src';
+import { HiAdjustments, HiCloudDownload, HiUserCircle } from 'react-icons/hi';
 
 The button group component from Flowbite React can be used to stack multiple button elements and group them visually together. It can often be used to create a navigation menu or a toolbar.
 
@@ -160,6 +160,14 @@ Here's an example on how you can use both the outline and icon props together.
     </Button>
   </Button.Group>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.buttonGroup, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/button/button.mdx
+++ b/app/docs/components/button/button.mdx
@@ -1,6 +1,6 @@
-import { HiOutlineArrowRight, HiShoppingCart } from 'react-icons/hi';
 import { CodePreview } from '~/app/components/code-preview';
-import { Button } from '~/src';
+import { Button, theme } from '~/src';
+import { HiOutlineArrowRight, HiShoppingCart } from 'react-icons/hi';
 
 The button component is a common UI component found on the web that allows users to trigger certain actions on your website such as submitting a form, navigating to a new page, or downloading a file.
 
@@ -202,6 +202,14 @@ You can disable the button by adding the `disabled` property to the `<Button>` c
 <CodePreview title="Disabled">
   <Button disabled>Disabled button</Button>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.button, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/card/card.mdx
+++ b/app/docs/components/card/card.mdx
@@ -1,5 +1,5 @@
 import { CodePreview } from '~/app/components/code-preview';
-import { Button, Card, Checkbox, Dropdown, Label, TextInput } from '~/src';
+import { Button, Card, Checkbox, Dropdown, Label, TextInput, theme } from '~/src';
 import Image from 'next/image';
 
 The card component can be used to show a wide variety of content such as previews of blog posts, user profiles, pricing plans, and more. Choose from one of the many examples built with React and the utility classes from Tailwind CSS.
@@ -792,6 +792,14 @@ This component can be used for crypto and web3 related projects where you can ch
     </div>
   </Card>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.card, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/carousel/carousel.mdx
+++ b/app/docs/components/carousel/carousel.mdx
@@ -1,5 +1,5 @@
 import { CodePreview } from '~/app/components/code-preview';
-import { Carousel } from '~/src';
+import { Carousel, theme } from '~/src';
 
 Use the responsive carousel component to allow users to slide through multiple items and navigate between them using the control buttons and indicators.
 
@@ -101,6 +101,14 @@ Instead of images you can also use any type of markup and content inside the car
     <div className="flex h-full items-center justify-center bg-gray-400 dark:bg-gray-700 dark:text-white">Slide 3</div>
   </Carousel>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.carousel, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/dropdown/dropdown.mdx
+++ b/app/docs/components/dropdown/dropdown.mdx
@@ -1,6 +1,6 @@
-import { HiCog, HiCurrencyDollar, HiLogout, HiViewGrid } from 'react-icons/hi';
 import { CodePreview } from '~/app/components/code-preview';
-import { Dropdown } from '~/src';
+import { Dropdown, theme } from '~/src';
+import { HiCog, HiCurrencyDollar, HiLogout, HiViewGrid } from 'react-icons/hi';
 
 The dropdown component is a UI component built with React that allows you to show a list of items when clicking on a trigger element (ie. a button) that you can use to build dropdown menus, lists, and more.
 
@@ -175,6 +175,14 @@ Add a custom `onClick` event handler to the `<Dropdown.Item>` component to handl
     <Dropdown.Item onClick={() => alert('Sign out!')}>Sign out</Dropdown.Item>
   </Dropdown>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.dropdown, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/footer/footer.mdx
+++ b/app/docs/components/footer/footer.mdx
@@ -1,6 +1,6 @@
-import { BsDribbble, BsFacebook, BsGithub, BsInstagram, BsTwitter } from 'react-icons/bs';
 import { CodePreview } from '~/app/components/code-preview';
-import { Footer } from '~/src';
+import { Footer, theme } from '~/src';
+import { BsDribbble, BsFacebook, BsGithub, BsInstagram, BsTwitter } from 'react-icons/bs';
 
 The footer component is an important section of a website where you should provide content such as sitemap links, copyright text, logo of your brand, social media account links, and more.
 
@@ -177,6 +177,14 @@ Add sitemap links to the footer component by using the `<Footer.LinkGroup>` and 
     </div>
   </Footer>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.footer, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/forms/forms.mdx
+++ b/app/docs/components/forms/forms.mdx
@@ -12,6 +12,7 @@ import {
   Textarea,
   TextInput,
   ToggleSwitch,
+  theme,
 } from '~/src';
 
 The form elements from Flowbite React can help you to collect input data from your website visitors by using input field elements, checkboxes, radios, file upload elements, and more based on React and Tailwind CSS.
@@ -494,6 +495,26 @@ The `<RangeSlider>` component ca be used to allow users to select a number based
     </div>
   </div>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>
+    {JSON.stringify(
+      Object.fromEntries(
+        Object.entries(theme).filter(([key]) =>
+          ['checkbox', 'fileInput', 'label', 'radio', 'rangeSlider', 'textarea', 'textInput', 'toggleSwitch'].includes(
+            key,
+          ),
+        ),
+      ),
+      null,
+      2,
+    )}
+  </code>
+</pre>
 
 ## References
 

--- a/app/docs/components/list-group/list-group.mdx
+++ b/app/docs/components/list-group/list-group.mdx
@@ -1,6 +1,6 @@
-import { HiCloudDownload, HiInbox, HiOutlineAdjustments, HiUserCircle } from 'react-icons/hi';
 import { CodePreview } from '~/app/components/code-preview';
-import { ListGroup } from '~/src';
+import { ListGroup, theme } from '~/src';
+import { HiCloudDownload, HiInbox, HiOutlineAdjustments, HiUserCircle } from 'react-icons/hi';
 
 The list group component can be used to show a list of items inside of an unordered list for website navigation, show a list of items inside of a card, and more.
 
@@ -75,6 +75,14 @@ Add icons to the list group items by using the `icon` prop on the `ListGroup.Ite
     <ListGroup.Item icon={HiCloudDownload}>Download</ListGroup.Item>
   </ListGroup>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.listGroup, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/modal/modal.mdx
+++ b/app/docs/components/modal/modal.mdx
@@ -1,7 +1,7 @@
-import { HiOutlineExclamationCircle } from 'react-icons/hi';
 import { CodePreview } from '~/app/components/code-preview';
-import { Button, Checkbox, Label, Modal, Select, TextInput } from '~/src';
+import { Button, Checkbox, Label, Modal, Select, TextInput, theme } from '~/src';
 import Link from 'next/link';
+import { HiOutlineExclamationCircle } from 'react-icons/hi';
 
 The modal component can be used to show any type of content such as text, form elements, and notifications to your website visitors by creating an off-canvas box on top of the main content area of your website.
 
@@ -476,6 +476,14 @@ To set the position of the modal component relative to the page you can use the 
     </Modal.Footer>
   </Modal>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.modal, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/navbar/navbar.mdx
+++ b/app/docs/components/navbar/navbar.mdx
@@ -1,6 +1,6 @@
-import Link from 'next/link';
 import { CodePreview } from '~/app/components/code-preview';
-import { Avatar, Button, Dropdown, Navbar } from '~/src';
+import { Avatar, Button, Dropdown, Navbar, theme } from '~/src';
+import Link from 'next/link';
 
 The navbar component is an important section of any website as it is the first section that appears on any page and it serves the purpose of allowing your users to navigate throughout your website.
 
@@ -110,6 +110,14 @@ Use this example to feature a dropdown menu when clicking on the user avatar ins
     </Navbar.Collapse>
   </Navbar>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.navbar, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/pagination/pagination.mdx
+++ b/app/docs/components/pagination/pagination.mdx
@@ -1,5 +1,5 @@
 import { CodePreview } from '~/app/components/code-preview';
-import { Pagination } from '~/src';
+import { Pagination, theme } from '~/src';
 
 The pagination component can be used to show a list of pages with numbers and links to allow the users to navigate through multiple pages, data from tables, and more.
 
@@ -139,6 +139,14 @@ Customize the text for the next and previous buttons by passing the `previousLab
     />
   </div>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.pagination, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/progress/progress.mdx
+++ b/app/docs/components/progress/progress.mdx
@@ -1,5 +1,5 @@
 import { CodePreview } from '~/app/components/code-preview';
-import { Progress } from '~/src';
+import { Progress, theme } from '~/src';
 
 Use the progress bar component from Flowbite React to show the percentage and completion rate of a given task using a visually friendly bar meter based on multiple styles and sizes.
 
@@ -84,6 +84,14 @@ Set your own custom colors for the progress bar component by using the `color` p
     <Progress progress={45} color="purple" />
   </div>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.progress, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/rating/rating.mdx
+++ b/app/docs/components/rating/rating.mdx
@@ -1,5 +1,5 @@
 import { CodePreview } from '~/app/components/code-preview';
-import { Rating } from '~/src';
+import { Rating, theme } from '~/src';
 
 The rating component can be used to show user reviews and testimonials in the form of stars, reviews, and labels based on multiple styles and layouts built with React and Tailwind CSS.
 
@@ -113,6 +113,14 @@ Use this component as an advanced layout for user ratings that include both the 
   </Rating.Advanced>
   <Rating.Advanced percentFilled={1}>1 star</Rating.Advanced>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.rating, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/sidebar/sidebar.mdx
+++ b/app/docs/components/sidebar/sidebar.mdx
@@ -1,7 +1,7 @@
 import { BiBuoy } from 'react-icons/bi';
 import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, HiViewBoards } from 'react-icons/hi';
 import { CodePreview } from '~/app/components/code-preview';
-import { Badge, Sidebar } from '~/src';
+import { Badge, Sidebar, theme } from '~/src';
 
 The sidebar component is an UI component that you can use for the navigation mechanism in your website or application that you would position to the left or right side of your page.
 
@@ -258,6 +258,14 @@ Feature the branded logo of your company on the top side of the sidebar using th
     </Sidebar.Items>
   </Sidebar>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.sidebar, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/spinner/spinner.mdx
+++ b/app/docs/components/spinner/spinner.mdx
@@ -1,5 +1,5 @@
 import { CodePreview } from '~/app/components/code-preview';
-import { Button, Spinner } from '~/src';
+import { Button, Spinner, theme } from '~/src';
 
 The spinner component should be used to indicate a loading status of the content that you're fetching from your database and you can choose from multiple styles, colors, sizes, and animations based on React and Tailwind CSS.
 
@@ -74,6 +74,14 @@ Add the loading spinner inside a button to indicate fetching status directly ins
     <span className="pl-3">Loading...</span>
   </Button>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.spinner, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/table/table.mdx
+++ b/app/docs/components/table/table.mdx
@@ -1,5 +1,5 @@
 import { CodePreview } from '~/app/components/code-preview';
-import { Checkbox, Table } from '~/src';
+import { Checkbox, Table, theme } from '~/src';
 
 The table component is an important UI component that you can use to effectively show complex amounts of data in the form of numbers, text, images, buttons, and links inside a structured layout of rows and columns.
 
@@ -276,6 +276,14 @@ Use this example to show multiple checkbox form elements for each table row that
     </Table.Body>
   </Table>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.table, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/tabs/tabs.mdx
+++ b/app/docs/components/tabs/tabs.mdx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { HiAdjustments, HiClipboardList, HiUserCircle } from 'react-icons/hi';
 import { MdDashboard } from 'react-icons/md';
 import { CodePreview } from '~/app/components/code-preview';
-import { Button, Tabs } from '~/src';
+import { Button, Tabs, theme } from '~/src';
 
 The tabs component can be used to show a list of tab items that you can click on to change the content inside of the main tabs component using React state reactivity.
 
@@ -303,6 +303,14 @@ import { MdDashboard } from 'react-icons/md';"
     </Button>
   </Button.Group>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.tab, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/timeline/timeline.mdx
+++ b/app/docs/components/timeline/timeline.mdx
@@ -1,6 +1,6 @@
 import { HiArrowNarrowRight, HiCalendar } from 'react-icons/hi';
 import { CodePreview } from '~/app/components/code-preview';
-import { Button, Timeline } from '~/src';
+import { Button, Timeline, theme } from '~/src';
 
 The timeline component can be used to show a list of events and items in a chronological order with a vertical or horizontal alignment based on multiple examples, styles, layouts, and colors.
 
@@ -136,6 +136,14 @@ Use the `horizontal` prop to show the timeline component and the child component
     </Timeline.Item>
   </Timeline>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.timeline, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/toast/toast.mdx
+++ b/app/docs/components/toast/toast.mdx
@@ -1,9 +1,9 @@
 import { FaTelegramPlane } from 'react-icons/fa';
 import { HiCheck, HiExclamation, HiFire, HiX } from 'react-icons/hi';
 import { MdLoop } from 'react-icons/md';
-import { CodePreview } from '~/app/components/code-preview';
-import { Button, Toast } from '~/src';
 import Link from 'next/link';
+import { CodePreview } from '~/app/components/code-preview';
+import { Button, Toast, theme } from '~/src';
 
 The toast component can be used to show notifications to your users in a non-intrusive way by positioning it to the corner of the screen. It can be used to show simple messages or more complex ones with buttons and other elements.
 
@@ -121,6 +121,14 @@ This component can be used to show more complex messages with buttons and other 
     </div>
   </Toast>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.toast, null, 2)}</code>
+</pre>
 
 ## References
 

--- a/app/docs/components/tooltip/tooltip.mdx
+++ b/app/docs/components/tooltip/tooltip.mdx
@@ -1,5 +1,5 @@
 import { CodePreview } from '~/app/components/code-preview';
-import { Button, Tooltip } from '~/src';
+import { Button, Tooltip, theme } from '~/src';
 
 Use the tooltip component from Flowbite React to indicate helpful information when hovering over an element such as a button or link to improve the UI/UX of your website.
 
@@ -103,6 +103,14 @@ You can disable the arrow of the tooltip component by passing the `arrow` prop w
     <Button>Default tooltip</Button>
   </Tooltip>
 </CodePreview>
+
+## Theme
+
+To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
+
+<pre className="language-tsx">
+  <code>{JSON.stringify(theme.tooltip, null, 2)}</code>
+</pre>
 
 ## References
 


### PR DESCRIPTION
## Description

For now, we're just including the snippet of Tailwind CSS classes that are applied to each key in the component's theme. That makes it easy to figure out where you need to make tweaks to the theme. I'm not sure how we can make it more useful yet - we will want to get feedback on this.

Starts working toward #808

## Type of change

- [x] This change contains documentation update

## Breaking changes

None

## How Has This Been Tested?

- [x] Visual inspection of `yarn dev`
- [x] Visual inspection of Vercel deployment

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
