### PR TITLE
fix(textinput.tsx): TextInput padding when having right/left icons

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -87,10 +87,11 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
               className={twMerge(
                 theme.field.input.base,
                 theme.field.input.colors[color],
+                theme.field.input.sizes[sizing],
                 theme.field.input.withIcon[Icon ? 'on' : 'off'],
+                theme.field.input.withRightIcon[RightIcon ? 'on' : 'off'],
                 theme.field.input.withAddon[addon ? 'on' : 'off'],
                 theme.field.input.withShadow[shadow ? 'on' : 'off'],
-                theme.field.input.sizes[sizing],
               )}
               {...props}
               ref={ref}


### PR DESCRIPTION
## Description

Fixes #828

<img width="900" alt="image" src="https://github.com/themesberg/flowbite-react/assets/14295280/7835ff61-f0a4-44e8-8c31-04c7eb8fb9ad">


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Visible in the Documentation app

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
