### PR TITLE
feat(dropdown): adding custom trigger

### DIFF
--- a/app/docs/components/dropdown/dropdown.mdx
+++ b/app/docs/components/dropdown/dropdown.mdx
@@ -178,8 +178,10 @@ Add a custom `onClick` event handler to the `<Dropdown.Item>` component to handl
 
 ## Custom trigger
 
+To customize the trigger element you can use `renderTrigger` property.
+
 <CodePreview title="Custom trigger dropdown">
-  <Dropdown dismissOnClick={false} renderTrigger={() => <button>Custom Dropdown button</button>}>
+  <Dropdown dismissOnClick={false} renderTrigger={() => <span>My custom trigger</span>}>
     <Dropdown.Item>Dashboard</Dropdown.Item>
     <Dropdown.Item>Settings</Dropdown.Item>
     <Dropdown.Item>Earnings</Dropdown.Item>

--- a/app/docs/components/dropdown/dropdown.mdx
+++ b/app/docs/components/dropdown/dropdown.mdx
@@ -176,6 +176,17 @@ Add a custom `onClick` event handler to the `<Dropdown.Item>` component to handl
   </Dropdown>
 </CodePreview>
 
+## Custom trigger
+
+<CodePreview title="Custom trigger dropdown">
+  <Dropdown dismissOnClick={false} CustomTrigger={<button>Custom Dropdown button</button>}>
+    <Dropdown.Item>Dashboard</Dropdown.Item>
+    <Dropdown.Item>Settings</Dropdown.Item>
+    <Dropdown.Item>Earnings</Dropdown.Item>
+    <Dropdown.Item>Sign out</Dropdown.Item>
+  </Dropdown>
+</CodePreview>
+
 ## Theme
 
 To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).

--- a/app/docs/components/dropdown/dropdown.mdx
+++ b/app/docs/components/dropdown/dropdown.mdx
@@ -179,7 +179,7 @@ Add a custom `onClick` event handler to the `<Dropdown.Item>` component to handl
 ## Custom trigger
 
 <CodePreview title="Custom trigger dropdown">
-  <Dropdown dismissOnClick={false} CustomTrigger={<button>Custom Dropdown button</button>}>
+  <Dropdown dismissOnClick={false} renderTrigger={() => <button>Custom Dropdown button</button>}>
     <Dropdown.Item>Dashboard</Dropdown.Item>
     <Dropdown.Item>Settings</Dropdown.Item>
     <Dropdown.Item>Earnings</Dropdown.Item>

--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -1,7 +1,8 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { FC } from 'react';
+import type { FC, ReactNode } from 'react';
 import { describe, expect, it } from 'vitest';
+import type { FlowbiteDropdownTheme } from './Dropdown';
 import { Dropdown } from './Dropdown';
 
 describe('Components / Dropdown', () => {
@@ -39,6 +40,17 @@ describe('Components / Dropdown', () => {
 
       expect(dropdown()).toHaveClass('invisible');
     });
+    it('should collapse if CustomTriggerItem is clicked', async () => {
+      const user = userEvent.setup();
+      render(<TestDropdown renderTrigger={() => <button type="button"></button>} />);
+
+      act(() => {
+        user.click(button());
+        userEvent.click(dropdownItem());
+      });
+
+      expect(dropdown()).toHaveClass('invisible');
+    });
 
     it('should not collapse in case item is clicked if dismissOnClick = false', async () => {
       const user = userEvent.setup();
@@ -68,11 +80,18 @@ describe('Components / Dropdown', () => {
   });
 });
 
-const TestDropdown: FC<{ dismissOnClick?: boolean; inline?: boolean }> = ({
-  dismissOnClick = true,
-  inline = false,
-}) => (
-  <Dropdown label="Dropdown button" placement="right" dismissOnClick={dismissOnClick} inline={inline}>
+const TestDropdown: FC<{
+  dismissOnClick?: boolean;
+  inline?: boolean;
+  renderTrigger?: (theme: FlowbiteDropdownTheme) => ReactNode;
+}> = ({ dismissOnClick = true, inline = false, renderTrigger }) => (
+  <Dropdown
+    label="Dropdown button"
+    placement="right"
+    dismissOnClick={dismissOnClick}
+    inline={inline}
+    renderTrigger={renderTrigger}
+  >
     <Dropdown.Header>
       <span className="block text-sm">Bonnie Green</span>
       <span className="block truncate text-sm font-medium">name@flowbite.com</span>

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -72,6 +72,19 @@ Inline.args = {
   ),
 };
 
+export const CustomTrigger = Template.bind({});
+CustomTrigger.args = {
+  renderTrigger: () => <button>Custom button</button>,
+  children: (
+    <>
+      <Dropdown.Item>Dashboard</Dropdown.Item>
+      <Dropdown.Item>Settings</Dropdown.Item>
+      <Dropdown.Item>Earnings</Dropdown.Item>
+      <Dropdown.Item>Sign out</Dropdown.Item>
+    </>
+  ),
+};
+
 export const ItemClickHandler = Template.bind({});
 ItemClickHandler.storyName = 'Item click handlers';
 ItemClickHandler.args = {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -143,7 +143,9 @@ const DropdownComponent: FC<DropdownProps> = ({
       className={className}
       minWidth={buttonWidth}
     >
-      {renderTrigger?.(theme) ?? (
+      {renderTrigger ? (
+        renderTrigger(theme)
+      ) : (
         <TriggerWrapper setButtonWidth={setButtonWidth}>
           {label}
           {arrowIcon && <Icon className={theme.arrowIcon} />}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -40,6 +40,7 @@ export interface DropdownProps
   inline?: boolean;
   label: ReactNode;
   theme?: DeepPartial<FlowbiteDropdownTheme>;
+  CustomTrigger?: ReactNode;
 }
 
 export interface TriggerWrapperProps extends ButtonProps {
@@ -58,6 +59,7 @@ const DropdownComponent: FC<DropdownProps> = ({
   className,
   dismissOnClick = true,
   theme: customTheme = {},
+  CustomTrigger,
   ...props
 }) => {
   const id = useId();
@@ -141,10 +143,12 @@ const DropdownComponent: FC<DropdownProps> = ({
       className={className}
       minWidth={buttonWidth}
     >
-      <TriggerWrapper setButtonWidth={setButtonWidth}>
-        {label}
-        {arrowIcon && <Icon className={theme.arrowIcon} />}
-      </TriggerWrapper>
+      {CustomTrigger ?? (
+        <TriggerWrapper setButtonWidth={setButtonWidth}>
+          {label}
+          {arrowIcon && <Icon className={theme.arrowIcon} />}
+        </TriggerWrapper>
+      )}
     </Floating>
   );
 };

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -40,7 +40,7 @@ export interface DropdownProps
   inline?: boolean;
   label: ReactNode;
   theme?: DeepPartial<FlowbiteDropdownTheme>;
-  renderTrigger?: () => ReactNode;
+  renderTrigger?: (theme: FlowbiteDropdownTheme) => ReactNode;
 }
 
 export interface TriggerWrapperProps extends ButtonProps {
@@ -143,7 +143,7 @@ const DropdownComponent: FC<DropdownProps> = ({
       className={className}
       minWidth={buttonWidth}
     >
-      {renderTrigger?.() ?? (
+      {renderTrigger?.(theme) ?? (
         <TriggerWrapper setButtonWidth={setButtonWidth}>
           {label}
           {arrowIcon && <Icon className={theme.arrowIcon} />}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -40,7 +40,7 @@ export interface DropdownProps
   inline?: boolean;
   label: ReactNode;
   theme?: DeepPartial<FlowbiteDropdownTheme>;
-  CustomTrigger?: ReactNode;
+  renderTrigger?: () => ReactNode;
 }
 
 export interface TriggerWrapperProps extends ButtonProps {
@@ -59,7 +59,7 @@ const DropdownComponent: FC<DropdownProps> = ({
   className,
   dismissOnClick = true,
   theme: customTheme = {},
-  CustomTrigger,
+  renderTrigger,
   ...props
 }) => {
   const id = useId();
@@ -143,7 +143,7 @@ const DropdownComponent: FC<DropdownProps> = ({
       className={className}
       minWidth={buttonWidth}
     >
-      {CustomTrigger ?? (
+      {renderTrigger?.() ?? (
         <TriggerWrapper setButtonWidth={setButtonWidth}>
           {label}
           {arrowIcon && <Icon className={theme.arrowIcon} />}


### PR DESCRIPTION
## Description

Include the `renderTrigger` property to `Dropdown` component. It allows users to completely overwrite the `Dropdown` trigger element.

Fixes #624

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change contains a documentation update

## Breaking changes

None.

## How Has This Been Tested?

- [X] Existing unit tests and new unit test
- [X] Manual test (documentation example) 

**Test Configuration**:

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
