### PR TITLE
 fix(src/components/navbar): fix wrong type on <Navbar theme>

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -90,11 +90,9 @@ const DocsNavbar: FC<DocsLayoutState> = ({ isCollapsed, setCollapsed }) => {
     <Navbar
       fluid
       theme={{
-        root: {
-          base: 'sticky top-0 z-40 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between w-full mx-auto py-2.5 px-4',
-          inner: {
-            base: 'mx-auto flex flex-wrap justify-between items-center w-full',
-          },
+        base: 'sticky top-0 z-40 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between w-full mx-auto py-2.5 px-4',
+        inner: {
+          base: 'mx-auto flex flex-wrap justify-between items-center w-full',
         },
       }}
     >

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -90,11 +90,9 @@ const HomeNavbar: FC = () => {
   return (
     <Navbar
       theme={{
-        root: {
-          base: 'sticky top-0 z-40 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between w-full mx-auto py-4',
-          inner: {
-            base: 'mx-auto flex flex-wrap justify-between items-center w-full max-w-8xl px-4 lg:px-20',
-          },
+        base: 'sticky top-0 z-40 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between w-full mx-auto py-4',
+        inner: {
+          base: 'mx-auto flex flex-wrap justify-between items-center w-full max-w-8xl px-4 lg:px-20',
         },
       }}
     >

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -37,7 +37,7 @@ export interface NavbarComponentProps extends PropsWithChildren, ComponentProps<
   fluid?: boolean;
   rounded?: boolean;
   border?: boolean;
-  theme?: DeepPartial<FlowbiteNavbarTheme>;
+  theme?: DeepPartial<FlowbiteNavbarRootTheme>;
 }
 
 const NavbarComponent: FC<NavbarComponentProps> = ({


### PR DESCRIPTION
## Description

You should only put the contents of `useTheme().theme.navbar.root` here, not
`useTheme().theme.navbar` as a whole. To migrate if you use `<Navbar theme={}`, remove `root: { ..
}` from your custom theme. If you customized child components here, you'll need to move those
changes to each child's `theme={}` attribute.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Breaking changes

TODO

## How Has This Been Tested?

- [x] Vercel deployment

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
