### PR TITLE
fix(modal): backdrop height

### DIFF
--- a/src/components/Modal/theme.ts
+++ b/src/components/Modal/theme.ts
@@ -2,7 +2,7 @@ import type { FlowbiteModalTheme } from './Modal';
 
 export const modalTheme: FlowbiteModalTheme = {
   root: {
-    base: 'fixed top-0 right-0 left-0 z-50 h-modal overflow-y-auto overflow-x-hidden md:inset-0 md:h-full',
+    base: 'fixed top-0 right-0 left-0 z-50 h-modal h-screen overflow-y-auto overflow-x-hidden md:inset-0 md:h-full',
     show: {
       on: 'flex bg-gray-900 bg-opacity-50 dark:bg-opacity-80',
       off: 'hidden',


### PR DESCRIPTION
## Description

I noticed some weird behavior for the modal backdrop when trying to reproduce the #829, the modal's backdrop wasn't covering 100% of the screen height is some cases. This PR should fix this problem...

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Breaking changes

None

## How Has This Been Tested?

- [X] Unit testing
- [X] Manual testing

**Test Configuration**:

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
