### PR TITLE
feat(toast.tsx): Stateless Toast

### DIFF
--- a/app/docs/components/toast/index.tsx
+++ b/app/docs/components/toast/index.tsx
@@ -1,16 +1,25 @@
 'use client';
 
-import type { FC } from 'react';
+import { useState, type FC } from 'react';
 import { DocsContentLayout } from '~/app/components/docs-content-layout';
 import ToastDocs from './toast.mdx';
 
-const ToastPage: FC = () => (
-  <DocsContentLayout
-    title="React Toast - Flowbite"
-    description="Push notifications to your website visitors using the toast component and choose from multiple sizes, colors, styles, position and icons based on React and Tailwind CSS"
-  >
-    <ToastDocs />
-  </DocsContentLayout>
-);
+const ToastPage: FC = () => {
+  const [showToast, setShowToast] = useState(false);
+
+  const state = {
+    showToast,
+    setShowToast,
+  };
+
+  return (
+    <DocsContentLayout
+      title="React Toast - Flowbite"
+      description="Push notifications to your website visitors using the toast component and choose from multiple sizes, colors, styles, position and icons based on React and Tailwind CSS"
+    >
+      <ToastDocs {...state} />
+    </DocsContentLayout>
+  );
+};
 
 export default ToastPage;

--- a/app/docs/components/toast/toast.mdx
+++ b/app/docs/components/toast/toast.mdx
@@ -124,6 +124,41 @@ This component can be used to show more complex messages with buttons and other 
   </Toast>
 </CodePreview>
 
+## Custom dismissal handling
+
+By passing the `onDismiss` callback prop to the `<Toast.Toggle>` component, you gain the ability to define your preferred dismissal handling (ex: using other toast libraries like `react-toastfy`). When `onDismiss` is provided, the internal state of the `<Toast />` component will remain unchanged upon clicking `<Toast.Toggle>`.
+
+<CodePreview
+  importFlowbiteReact="Button, Toast"
+  title="Custom dismissal"
+  functionBody={['const [showToast, setShowToast] = useState(false);', 'const props = { showToast, setShowToast };']}
+  code={`<div className="space-y-4">
+  <Button onClick={() => props.setShowToast(!props.showToast)}>Toggle toast</Button>
+  {props.showToast && (
+    <Toast>
+      <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-cyan-100 text-cyan-500 dark:bg-cyan-800 dark:text-cyan-200">
+        <HiFire className="h-5 w-5" />
+      </div>
+      <div className="ml-3 text-sm font-normal">Set yourself free.</div>
+      <Toast.Toggle onDismiss={() => props.setShowToast(false)} />
+    </Toast>
+  )}
+</div>`}
+>
+  <div className="space-y-4">
+    <Button onClick={() => props.setShowToast(!props.showToast)}>Toggle toast</Button>
+    {props.showToast && (
+      <Toast>
+        <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-cyan-100 text-cyan-500 dark:bg-cyan-800 dark:text-cyan-200">
+          <HiFire className="h-5 w-5" />
+        </div>
+        <div className="ml-3 text-sm font-normal">Set yourself free.</div>
+        <Toast.Toggle onDismiss={() => props.setShowToast(false)} />
+      </Toast>
+    )}
+  </div>
+</CodePreview>
+
 ## Theme
 
 To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).

--- a/src/components/Toast/Toast.spec.tsx
+++ b/src/components/Toast/Toast.spec.tsx
@@ -60,6 +60,17 @@ describe('Components / Toast', () => {
     expect(toast()).toBeInTheDocument();
   });
 
+  describe('A11y', () => {
+    it('should have `role=alert`', async () => {
+      render(
+        <Toast>
+          <Toast.Toggle />
+        </Toast>,
+      );
+      expect(toast()).toBeInTheDocument();
+    });
+  });
+
   describe('Keyboard interactions', () => {
     it('should close `Toast` when `Space` is pressed on `Toast.Toggle`', async () => {
       const user = userEvent.setup();
@@ -80,5 +91,5 @@ describe('Components / Toast', () => {
   });
 });
 
-const toast = () => screen.queryByTestId('flowbite-toast');
+const toast = () => screen.queryByRole('alert');
 const toggle = () => screen.getByRole('button');

--- a/src/components/Toast/Toast.spec.tsx
+++ b/src/components/Toast/Toast.spec.tsx
@@ -1,10 +1,66 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { Toast } from './Toast';
 
-describe.concurrent('Components / Toast', () => {
-  describe.concurrent('Keyboard interactions', () => {
+describe('Components / Toast', () => {
+  beforeAll(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    vi.clearAllTimers();
+  });
+
+  it('should remove `Toast` from DOM after give `duration` when `Toast.Toggle` is clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(
+      <Toast duration={200}>
+        <Toast.Toggle onClick={handleClick} />
+      </Toast>,
+    );
+
+    await user.click(toggle());
+    expect(toast()?.className).toContain('opacity-0');
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(toast()).not.toBeInTheDocument();
+  });
+
+  it('should convert `Toast` to stateless when `onDismiss` is given to `Toast.Toggle`', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    const handleDismiss = vi.fn();
+
+    render(
+      <Toast>
+        <Toast.Toggle onDismiss={handleDismiss} onClick={handleClick} />
+      </Toast>,
+    );
+
+    await user.click(toggle());
+    expect(toast()?.className).not.toContain('opacity-0');
+
+    expect(handleClick).toHaveBeenCalled();
+    expect(handleDismiss).toHaveBeenCalled();
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(toast()).toBeInTheDocument();
+  });
+
+  describe('Keyboard interactions', () => {
     it('should close `Toast` when `Space` is pressed on `Toast.Toggle`', async () => {
       const user = userEvent.setup();
       const handleClick = vi.fn();
@@ -18,11 +74,11 @@ describe.concurrent('Components / Toast', () => {
       await user.tab();
       await user.keyboard('[Space]');
 
-      expect(toast().className).toContain('opacity-0');
-
+      expect(toast()?.className).toContain('opacity-0');
       expect(handleClick).toHaveBeenCalled();
     });
   });
 });
 
-const toast = () => screen.getByTestId('flowbite-toast');
+const toast = () => screen.queryByTestId('flowbite-toast');
+const toggle = () => screen.getByRole('button');

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -49,6 +49,7 @@ const ToastComponent: FC<ToastProps> = ({ children, className, duration = 300, t
     <ToastContext.Provider value={{ duration, isClosed, isRemoved, setIsClosed, setIsRemoved }}>
       <div
         data-testid="flowbite-toast"
+        role="alert"
         className={twMerge(theme.root.base, durationClasses[duration], isClosed && theme.root.closed, className)}
         {...props}
       >

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -12,7 +12,6 @@ export interface FlowbiteToastTheme {
   root: {
     base: string;
     closed: string;
-    removed: string;
   };
   toggle: {
     base: string;
@@ -42,17 +41,15 @@ const ToastComponent: FC<ToastProps> = ({ children, className, duration = 300, t
 
   const theme = mergeDeep(useTheme().theme.toast, customTheme);
 
+  if (isRemoved) {
+    return null;
+  }
+
   return (
     <ToastContext.Provider value={{ duration, isClosed, isRemoved, setIsClosed, setIsRemoved }}>
       <div
         data-testid="flowbite-toast"
-        className={twMerge(
-          theme.root.base,
-          durationClasses[duration],
-          isClosed && theme.root.closed,
-          isRemoved && theme.root.removed,
-          className,
-        )}
+        className={twMerge(theme.root.base, durationClasses[duration], isClosed && theme.root.closed, className)}
         {...props}
       >
         {children}

--- a/src/components/Toast/ToastToggle.tsx
+++ b/src/components/Toast/ToastToggle.tsx
@@ -14,6 +14,7 @@ export interface FlowbiteToastToggleTheme {
 export interface ToastToggleProps extends ComponentProps<'button'> {
   theme?: DeepPartial<FlowbiteToastToggleTheme>;
   xIcon?: FC<ComponentProps<'svg'>>;
+  onDismiss?: () => void;
 }
 
 export const ToastToggle: FC<ToastToggleProps> = ({
@@ -21,6 +22,7 @@ export const ToastToggle: FC<ToastToggleProps> = ({
   onClick,
   theme: customTheme = {},
   xIcon: XIcon = HiX,
+  onDismiss,
   ...props
 }) => {
   const theme = mergeDeep(useTheme().theme.toast.toggle, customTheme);
@@ -28,6 +30,12 @@ export const ToastToggle: FC<ToastToggleProps> = ({
 
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     if (onClick) onClick(e);
+
+    if (onDismiss) {
+      onDismiss();
+      return;
+    }
+
     setIsClosed(!isClosed);
     setTimeout(() => setIsRemoved(!isRemoved), duration);
   };

--- a/src/components/Toast/theme.ts
+++ b/src/components/Toast/theme.ts
@@ -4,7 +4,6 @@ export const toastTheme: FlowbiteToastTheme = {
   root: {
     base: 'flex w-full max-w-xs items-center rounded-lg bg-white p-4 text-gray-500 shadow dark:bg-gray-800 dark:text-gray-400',
     closed: 'opacity-0 ease-out',
-    removed: 'hidden',
   },
   toggle: {
     base: '-mx-1.5 -my-1.5 ml-auto inline-flex h-8 w-8 rounded-lg bg-white p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-900 focus:ring-2 focus:ring-gray-300 dark:bg-gray-800 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-white',


### PR DESCRIPTION
- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.
This PR adds the ability to convert the `Toast` component into a stateless mode by providing `onDismiss` to `Toast.Toggle`.
It also changes the default hiding behaviour. Now the Toast is removed from the DOM when `isRemoved = true`. Finally, it adds by default `role="alert"` to the toast root

Reference related issues using `#` followed by the issue number.
Fix #848 

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.

The theme property `root.removed` has been removed as it will not be needed anymore. 
