### PR TITLE
fix(select.tsx/badge.tsx): With icon classes preference

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -12,6 +12,10 @@ export default {
       options: Object.keys(theme.badge.root.color),
       control: { type: 'inline-radio' },
     },
+    size: {
+      options: Object.keys(theme.badge.root.size),
+      control: { type: 'inline-radio' },
+    },
   },
 } as Meta;
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -49,8 +49,8 @@ export const Badge: FC<BadgeProps> = ({
       className={twMerge(
         theme.root.base,
         theme.root.color[color],
-        theme.icon[Icon ? 'on' : 'off'],
         theme.root.size[size],
+        theme.icon[Icon ? 'on' : 'off'],
         className,
       )}
       data-testid="flowbite-badge"

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, Story } from '@storybook/react';
+import { BsFlagFill } from 'react-icons/bs';
 import type { SelectProps } from './Select';
 import { Select } from './Select';
 
@@ -13,6 +14,20 @@ export const DefaultSelect = Template.bind({});
 DefaultSelect.storyName = 'Select';
 DefaultSelect.args = {
   id: 'countries',
+  children: (
+    <>
+      <option>United States</option>
+      <option>Canada</option>
+      <option>France</option>
+      <option>Germany</option>
+    </>
+  ),
+};
+
+export const WithIcon = Template.bind({});
+WithIcon.args = {
+  id: 'countries',
+  icon: BsFlagFill,
   children: (
     <>
       <option>United States</option>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -74,10 +74,10 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             className={twMerge(
               theme.field.select.base,
               theme.field.select.colors[color],
+              theme.field.select.sizes[sizing],
               theme.field.select.withIcon[Icon ? 'on' : 'off'],
               theme.field.select.withAddon[addon ? 'on' : 'off'],
               theme.field.select.withShadow[shadow ? 'on' : 'off'],
-              theme.field.select.sizes[sizing],
             )}
             {...props}
             ref={ref}


### PR DESCRIPTION
- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.
`twMerge` is removing the padding classes for the `Select.tsx` component when an icon is passed.

I also checked if the issue was happening in other components too and I noticed tha the `Badge.tsx` component had the same problem. Even though it was not breaking visually when a Badge had an icon, if the user passes a `p-` class to the custom theme object it was not being applied due to the preference ordering in `twMerge`

Reference related issues using `#` followed by the issue number.
Fix #869 
