### PR TITLE
fix(button.tsx): Button `as` prop internal logic + TS props

### DIFF
--- a/app/docs/components/button/button.mdx
+++ b/app/docs/components/button/button.mdx
@@ -243,7 +243,7 @@ The `as` prop provides you the ability to transform the `<Button />` component i
     <Button as="span" className="cursor-pointer">Span Button</Button>
   </div>
   <div>
-    <Button as={Link} href="#">
+    <Button as={Link} href="/">
       Next Link Button
     </Button>
   </div>
@@ -256,7 +256,7 @@ The `as` prop provides you the ability to transform the `<Button />` component i
       </Button>
     </div>
     <div>
-      <Button as={Link} href="#">
+      <Button as={Link} href="/">
         Next Link Button
       </Button>
     </div>

--- a/app/docs/components/dropdown/dropdown.mdx
+++ b/app/docs/components/dropdown/dropdown.mdx
@@ -203,7 +203,7 @@ To customize the `Dropdown.Item` base element you can use the `as` property.
   <Dropdown.Item as={Link} href="/">
     Home
   </Dropdown.Item>
-  <Dropdown.Item href="https://flowbite.com/" target="_blank">
+  <Dropdown.Item as="a" href="https://flowbite.com/" target="_blank">
     External link
   </Dropdown.Item>
 </Dropdown>`}
@@ -212,7 +212,7 @@ To customize the `Dropdown.Item` base element you can use the `as` property.
     <Dropdown.Item as={Link} href="/">
       Home
     </Dropdown.Item>
-    <Dropdown.Item href="https://flowbite.com/" target="_blank">
+    <Dropdown.Item as="a" href="https://flowbite.com/" target="_blank">
       External link
     </Dropdown.Item>
   </Dropdown>

--- a/src/components/Button/Button.spec.tsx
+++ b/src/components/Button/Button.spec.tsx
@@ -125,10 +125,37 @@ describe('Components / Button', () => {
         expect(buttonLink()).toBeInTheDocument();
       });
 
-      it('should render an anchor `<a>` when `href=".."` even though `as` is defined', () => {
-        render(<Button href="#" as="label" label="Something or other" />);
+      it('should render component defined in `as`', () => {
+        const CustomComponent = ({ children }: PropsWithChildren<{ uniqueProp: boolean }>) => {
+          return <li>{children}</li>;
+        };
 
-        expect(buttonLink()).toBeInTheDocument();
+        render(
+          <ul>
+            <Button as={CustomComponent} uniqueProp>
+              Something or other
+            </Button>
+          </ul>,
+        );
+
+        const button = buttonListItem();
+
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveTextContent('Something or other');
+      });
+
+      it('should render component defined in `as` prop even though `href` is defined', () => {
+        const CustomComponent = ({ children }: PropsWithChildren) => {
+          return <li>{children}</li>;
+        };
+
+        render(
+          <ul>
+            <Button href="#" as={CustomComponent} label="Something or other" />
+          </ul>,
+        );
+
+        expect(buttonListItem()).toBeInTheDocument();
       });
 
       it('should render tag element defined in `as`', () => {
@@ -141,25 +168,12 @@ describe('Components / Button', () => {
         expect(buttonListItem()).toBeInTheDocument();
       });
 
-      it('should render component defined in `as`', () => {
-        const CustomComponent = ({ children }: PropsWithChildren) => {
-          return <li>{children}</li>;
-        };
-
+      it('should render as button `as={null}`', () => {
         render(
           <ul>
-            <Button as={CustomComponent} label="Something or other" />
+            <Button as={null} label="Something or other" />
           </ul>,
         );
-
-        const button = buttonListItem();
-
-        expect(button).toBeInTheDocument();
-        expect(button).toHaveTextContent('Something or other');
-      });
-
-      it('should render as button when `as`={null}', () => {
-        render(<Button as={null} label="Something or other" />);
 
         expect(button()).toBeInTheDocument();
       });

--- a/src/components/Button/Button.spec.tsx
+++ b/src/components/Button/Button.spec.tsx
@@ -171,7 +171,7 @@ describe('Components / Button', () => {
       it('should render as button `as={null}`', () => {
         render(
           <ul>
-            <Button as={null} label="Something or other" />
+            <Button as={null as any} label="Something or other" />
           </ul>,
         );
 

--- a/src/components/Button/ButtonBase.tsx
+++ b/src/components/Button/ButtonBase.tsx
@@ -1,17 +1,18 @@
-import { createElement, forwardRef, type ComponentProps, type ElementType } from 'react';
+import { createElement, type ComponentPropsWithoutRef, type ElementType, type ForwardedRef } from 'react';
+import genericForwardRef from '../../helpers/generic-forward-ref';
 
-export interface ButtonBaseProps extends Omit<ComponentProps<'button'>, 'color' | 'ref'> {
-  as?: ElementType;
+export type ButtonBaseProps<T extends ElementType = 'button'> = {
+  as?: T;
   href?: string;
-}
+} & ComponentPropsWithoutRef<T>;
 
-interface Props extends ButtonBaseProps, Record<string, unknown> {}
+const ButtonBaseComponent = <T extends ElementType = 'button'>(
+  { children, as: Component, href, type = 'button', ...props }: ButtonBaseProps<T>,
+  ref: ForwardedRef<T>,
+) => {
+  const BaseComponent = Component || (href ? 'a' : 'button');
 
-export const ButtonBase = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
-  ({ children, as: Component = 'button', type = 'button', href, ...props }, ref) => {
-    const BaseComponent = Component || (href ? 'a' : 'button');
+  return createElement(BaseComponent, { ref, href, type, ...props }, children);
+};
 
-    return createElement(BaseComponent, { ref, href, type, ...props }, children);
-  },
-);
-ButtonBase.displayName = 'ButtonBase';
+export const ButtonBase = genericForwardRef(ButtonBaseComponent);

--- a/src/components/Button/ButtonBase.tsx
+++ b/src/components/Button/ButtonBase.tsx
@@ -8,11 +8,10 @@ export interface ButtonBaseProps extends Omit<ComponentProps<'button'>, 'color' 
 interface Props extends ButtonBaseProps, Record<string, unknown> {}
 
 export const ButtonBase = forwardRef<HTMLButtonElement | HTMLAnchorElement, Props>(
-  ({ children, as: Component = 'button', href, ...props }, ref) => {
-    const BaseComponent = href ? 'a' : Component ?? 'button';
-    const type = Component === 'button' ? 'button' : undefined;
+  ({ children, as: Component = 'button', type = 'button', href, ...props }, ref) => {
+    const BaseComponent = Component || (href ? 'a' : 'button');
 
     return createElement(BaseComponent, { ref, href, type, ...props }, children);
   },
 );
-ButtonBase.displayName = 'Button';
+ButtonBase.displayName = 'ButtonBase';

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -93,7 +93,7 @@ CustomItem.args = {
       <Dropdown.Item>Default button</Dropdown.Item>
       <Dropdown.Item as="span">As span</Dropdown.Item>
       <Dropdown.Divider />
-      <Dropdown.Item href="https://flowbite.com/" target="_blank">
+      <Dropdown.Item as="a" href="https://flowbite.com/" target="_blank">
         As link
       </Dropdown.Item>
     </>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -9,6 +9,7 @@ import type {
   PropsWithChildren,
   ReactElement,
   ReactNode,
+  RefCallback,
   SetStateAction,
 } from 'react';
 import { cloneElement, createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -101,7 +102,13 @@ const Trigger = ({
       {children}
     </button>
   ) : (
-    <Button {...buttonProps} disabled={disabled} type="button" ref={refs.setReference} {...a11yProps}>
+    <Button
+      {...buttonProps}
+      disabled={disabled}
+      type="button"
+      ref={refs.setReference as RefCallback<'button'>}
+      {...a11yProps}
+    >
       {children}
     </Button>
   );
@@ -247,7 +254,6 @@ const DropdownComponent: FC<DropdownProps> = ({
 };
 
 DropdownComponent.displayName = 'Dropdown';
-DropdownItem.displayName = 'Dropdown.Item';
 DropdownHeader.displayName = 'Dropdown.Header';
 DropdownDivider.displayName = 'Dropdown.Divider';
 

--- a/src/components/Dropdown/DropdownItem.tsx
+++ b/src/components/Dropdown/DropdownItem.tsx
@@ -1,5 +1,5 @@
 import { useListItem } from '@floating-ui/react';
-import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import type { ComponentProps, ComponentPropsWithoutRef, ElementType, FC, RefCallback } from 'react';
 import { useContext } from 'react';
 import { twMerge } from 'tailwind-merge';
 import type { DeepPartial } from '../../';
@@ -15,32 +15,35 @@ export interface FlowbiteDropdownItemTheme {
   icon: string;
 }
 
-export interface DropdownItemProps extends PropsWithChildren, ButtonBaseProps, Record<string, unknown> {
+export type DropdownItemProps<T extends ElementType = 'button'> = {
+  as?: T;
+  href?: string;
   icon?: FC<ComponentProps<'svg'>>;
   onClick?: () => void;
   theme?: DeepPartial<FlowbiteDropdownItemTheme>;
-}
+} & ComponentPropsWithoutRef<T>;
 
-export const DropdownItem: FC<DropdownItemProps> = ({
+export const DropdownItem = <T extends ElementType = 'button'>({
   children,
   className,
   icon: Icon,
   onClick,
   theme: customTheme = {},
   ...props
-}) => {
+}: DropdownItemProps<T>) => {
   const { ref, index } = useListItem({ label: typeof children === 'string' ? children : undefined });
   const { activeIndex, dismissOnClick, getItemProps, handleSelect } = useContext(DropdownContext);
   const isActive = activeIndex === index;
-
   const theme = mergeDeep(useTheme().theme.dropdown.floating.item, customTheme);
+
+  const theirProps = props as ButtonBaseProps<T>;
 
   return (
     <li role="menuitem" className={theme.container}>
       <ButtonBase
-        ref={ref}
+        ref={ref as RefCallback<T>}
         className={twMerge(theme.base, className)}
-        {...props}
+        {...theirProps}
         {...getItemProps({
           onClick: () => {
             onClick && onClick();

--- a/src/helpers/generic-forward-ref.ts
+++ b/src/helpers/generic-forward-ref.ts
@@ -1,0 +1,13 @@
+import type React from 'react';
+import { forwardRef } from 'react';
+
+/** This allow the `forwardRef` to be used with generic components */
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type FixedForwardRef = <T, P = {}>(
+  render: (props: P, ref: React.Ref<T>) => React.ReactNode,
+) => (props: P & React.RefAttributes<T>) => React.ReactNode;
+
+const genericForwardRef = forwardRef as FixedForwardRef;
+
+export default genericForwardRef;


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.
This fixes the issue with Next `Link` component which also uses the `href` prop (which the internal logic was always rendering an anchor tag).

It also improves the TS props of Button and DropdownItem components to actually inherit the props of the tag/component  passed in the `as` prop, instead of using `extends Record<string, unknown>`. 

![as-prop](https://github.com/themesberg/flowbite-react/assets/14295280/b98c3776-fcfa-4929-89a0-f1b60816a203)

Reference related issues using `#` followed by the issue number.
Fix #865 
