### PR TITLE
fix(button.tsx): Adding back displayName

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -161,6 +161,8 @@ const ButtonComponentFn = <T extends ElementType = 'button'>(
   );
 };
 
+ButtonComponentFn.displayName = 'Button';
+
 const ButtonComponent = genericForwardRef(ButtonComponentFn);
 
 export const Button = Object.assign(ButtonComponent, {


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Due to a recent change with `<Button />`, the `displayName` was removed from the component. This had a downstream effect of causing the docs to report that the name for this component was "No Display Name".

This change simply adds back the display name.

<img width="856" alt="Screen Shot 2023-07-30 at 7 07 58 PM" src="https://github.com/themesberg/flowbite-react/assets/949494/1426c3bb-0dec-4d86-bcb0-fb6e45d9081a">

