### PR TITLE
feat(sidebar): add custom chevron icon to collapse

### DIFF
--- a/app/docs/components/sidebar/sidebar.mdx
+++ b/app/docs/components/sidebar/sidebar.mdx
@@ -1,5 +1,16 @@
 import { BiBuoy } from 'react-icons/bi';
-import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, HiViewBoards } from 'react-icons/hi';
+import {
+  HiOutlineMinusSm,
+  HiOutlinePlusSm,
+  HiArrowSmRight,
+  HiChartPie,
+  HiInbox,
+  HiShoppingBag,
+  HiTable,
+  HiUser,
+  HiViewBoards,
+} from 'react-icons/hi';
+import { twMerge } from 'tailwind-merge';
 import { CodePreview } from '~/app/components/code-preview';
 import { Badge, Sidebar, theme } from '~/src';
 
@@ -73,6 +84,93 @@ Use this example to learn how to stack multiple sidebar menu items inside one dr
           Dashboard
         </Sidebar.Item>
         <Sidebar.Collapse icon={HiShoppingBag} label="E-commerce">
+          <Sidebar.Item href="#">Products</Sidebar.Item>
+          <Sidebar.Item href="#">Sales</Sidebar.Item>
+          <Sidebar.Item href="#">Refunds</Sidebar.Item>
+          <Sidebar.Item href="#">Shipping</Sidebar.Item>
+        </Sidebar.Collapse>
+        <Sidebar.Item href="#" icon={HiInbox}>
+          Inbox
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiUser}>
+          Users
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiShoppingBag}>
+          Products
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiArrowSmRight}>
+          Sign In
+        </Sidebar.Item>
+        <Sidebar.Item href="#" icon={HiTable}>
+          Sign Up
+        </Sidebar.Item>
+      </Sidebar.ItemGroup>
+    </Sidebar.Items>
+  </Sidebar>
+</CodePreview>
+
+## Multi-level dropdown with custom chevron
+
+The `chevronIcon` property offers customization for the chevron icon. Alternatively, for more complex scenarios, the `renderChevronIcon` option can be utilized. Here's an example:
+
+<CodePreview
+  importExternal="import { twMerge } from 'tailwind-merge';
+    import { HiOutlineMinusSm, HiOutlinePlusSm, HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, HiViewBoards } from 'react-icons/hi';"
+  title="Multi-level dropdown custom chevronIcon"
+  importFlowbiteReact="Sidebar"
+  className="w-fit"
+  code={`<Sidebar aria-label="Sidebar with multi-level dropdown example">
+      <Sidebar.Items>
+        <Sidebar.ItemGroup>
+          <Sidebar.Item href="#" icon={HiChartPie}>
+            Dashboard
+          </Sidebar.Item>
+          <Sidebar.Collapse 
+            icon={HiShoppingBag} 
+            label="E-commerce"
+            renderChevronIcon={(theme, open) => {
+              const IconComponent =  open ? HiOutlineMinusSm : HiOutlinePlusSm; 
+              return <IconComponent aria-hidden className={twMerge(theme.label.icon.open[open ? 'on' : 'off'])} />
+            }}
+          >
+            <Sidebar.Item href="#">Products</Sidebar.Item>
+            <Sidebar.Item href="#">Sales</Sidebar.Item>
+            <Sidebar.Item href="#">Refunds</Sidebar.Item>
+            <Sidebar.Item href="#">Shipping</Sidebar.Item>
+          </Sidebar.Collapse>
+          <Sidebar.Item href="#" icon={HiInbox}>
+            Inbox
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiUser}>
+            Users
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiShoppingBag}>
+            Products
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiArrowSmRight}>
+            Sign In
+          </Sidebar.Item>
+          <Sidebar.Item href="#" icon={HiTable}>
+            Sign Up
+          </Sidebar.Item>
+        </Sidebar.ItemGroup>
+      </Sidebar.Items>
+    </Sidebar>`}
+>
+  <Sidebar aria-label="Sidebar with multi-level dropdown example">
+    <Sidebar.Items>
+      <Sidebar.ItemGroup>
+        <Sidebar.Item href="#" icon={HiChartPie}>
+          Dashboard
+        </Sidebar.Item>
+        <Sidebar.Collapse
+          icon={HiShoppingBag}
+          label="E-commerce"
+          renderChevronIcon={(theme, open) => {
+            const IconComponent = open ? HiOutlineMinusSm : HiOutlinePlusSm;
+            return <IconComponent aria-hidden className={twMerge(theme.label.icon.open[open ? 'on' : 'off'])} />;
+          }}
+        >
           <Sidebar.Item href="#">Products</Sidebar.Item>
           <Sidebar.Item href="#">Sales</Sidebar.Item>
           <Sidebar.Item href="#">Refunds</Sidebar.Item>

--- a/src/components/Sidebar/Sidebar.spec.tsx
+++ b/src/components/Sidebar/Sidebar.spec.tsx
@@ -169,7 +169,13 @@ describe('Theme', () => {
             },
             label: {
               base: 'text-gray-300',
-              icon: 'text-gray-400',
+              icon: {
+                base: 'text-gray-400',
+                open: {
+                  on: '',
+                  off: '',
+                },
+              },
             },
             list: 'bg-gray-300',
           },

--- a/src/components/Sidebar/SidebarCollapse.tsx
+++ b/src/components/Sidebar/SidebarCollapse.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, FC, PropsWithChildren } from 'react';
+import type { ComponentProps, FC, PropsWithChildren, ReactElement } from 'react';
 import { useEffect, useId, useState } from 'react';
 import { HiChevronDown } from 'react-icons/hi';
 import { twMerge } from 'tailwind-merge';
@@ -17,7 +17,10 @@ export interface FlowbiteSidebarCollapseTheme {
   };
   label: {
     base: string;
-    icon: string;
+    icon: {
+      base: string;
+      open: FlowbiteBoolean;
+    };
   };
   list: string;
 }
@@ -28,6 +31,8 @@ export interface SidebarCollapseProps
     ComponentProps<'button'> {
   onClick?: ComponentProps<'button'>['onClick'];
   open?: boolean;
+  chevronIcon?: FC<ComponentProps<'svg'>>;
+  renderChevronIcon?: (theme: DeepPartial<FlowbiteSidebarCollapseTheme>, open: boolean) => ReactElement;
   theme?: DeepPartial<FlowbiteSidebarCollapseTheme>;
 }
 
@@ -36,6 +41,8 @@ export const SidebarCollapse: FC<SidebarCollapseProps> = ({
   className,
   icon: Icon,
   label,
+  chevronIcon: ChevronIcon = HiChevronDown,
+  renderChevronIcon,
   open = false,
   theme: customTheme = {},
   ...props
@@ -83,7 +90,14 @@ export const SidebarCollapse: FC<SidebarCollapseProps> = ({
             <span data-testid="flowbite-sidebar-collapse-label" className={theme.label.base}>
               {label}
             </span>
-            <HiChevronDown aria-hidden className={theme.label.icon} />
+            {renderChevronIcon ? (
+              renderChevronIcon(theme, isOpen)
+            ) : (
+              <ChevronIcon
+                aria-hidden
+                className={twMerge(theme.label.icon.base, theme.label.icon.open[isOpen ? 'on' : 'off'])}
+              />
+            )}
           </>
         )}
       </button>

--- a/src/components/Sidebar/theme.ts
+++ b/src/components/Sidebar/theme.ts
@@ -21,7 +21,13 @@ export const sidebarTheme: FlowbiteSidebarTheme = {
     },
     label: {
       base: 'ml-3 flex-1 whitespace-nowrap text-left',
-      icon: 'h-6 w-6',
+      icon: {
+        base: 'h-6 w-6 transition ease-in-out delay-0',
+        open: {
+          on: 'rotate-180',
+          off: '',
+        },
+      },
     },
     list: 'space-y-2 py-2',
   },


### PR DESCRIPTION
- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Adds the `chevronIcon` and `renderChevronIcon` properties to `Sidebar.Collapse` component, allowing users to customize the chevron icon for collapsed sidebar items.

**BREAKING CHANGE:**

`FlowbiteSidebarCollapseTheme` signature changes:

```diff
label: {
    base: string;
-    icon: string;
+    icon: {
+      base: string;
+      open: FlowbiteBoolean;
+    };
}
```

Closes #888
