### PR TITLE
feat(component): new pauseOnHover prop to <Carousel>, provide quick information with chance to pause

### DIFF
--- a/app/docs/components/carousel/carousel.mdx
+++ b/app/docs/components/carousel/carousel.mdx
@@ -92,6 +92,20 @@ Add custom indicators or disable them by passing the `indicators` prop to the `<
   </Carousel>
 </CodePreview>
 
+## Pause On Hover
+
+To conditionally pause the carousel on mouse hover (desktop), or touch and hold (mobile), you can use the `pauseOnHover` property on the `<Carousel>` component. Default value is `false`.
+
+<CodePreview title="Pause on hovering" className="h-56 sm:h-64 xl:h-80 2xl:h-96">
+  <Carousel pauseOnHover>
+    <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />
+    <img src="https://flowbite.com/docs/images/carousel/carousel-2.svg" alt="..." />
+    <img src="https://flowbite.com/docs/images/carousel/carousel-3.svg" alt="..." />
+    <img src="https://flowbite.com/docs/images/carousel/carousel-4.svg" alt="..." />
+    <img src="https://flowbite.com/docs/images/carousel/carousel-5.svg" alt="..." />
+  </Carousel>
+</CodePreview>
+
 ## Slider content
 
 Instead of images you can also use any type of markup and content inside the carousel such as simple text.


### PR DESCRIPTION
- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

A new property on the <Carousel> component, `pauseOnHover`, will improve accessibility, allow for a faster flow of information, and help users find desired information quicker. From the Web Accessibility Initiative in "What makes a carousel accessible?", they note: "Users must be able to pause carousel movement because it can be too fast or distracting, making text hard to read." (www.w3.org/WAI/tutorials/carousels/) Currently, there is no built in feature to accomplish this. Developers will either have to disable the `slide` property, or make the `slideInterval` property very long to allow users to read necessary information. With the `pauseOnHover` property, users will have a quick way, both on mobile and desktop, to pause on the desired slide. Furthermore, this allows developers to display more information at a faster pace to users because users have a choice at which slide to stop and read, but can still have a general understanding of information displayed on other slides.

For changes in code, added an additional parameter to `<Carousel>` and an additional state variable `isHovering` to check if the user is hovering on the root component. Also defined a few additional callback functions to use on the parent `<div>`. Works on desktop by hovering, works on mobile by touching and pressing.
![2023-08-18 13-01-53](https://github.com/themesberg/flowbite-react/assets/51296787/142f12fc-fffc-448b-afc9-5bd8496b84f1)


Reference related issues using `#` followed by the issue number.

#902 

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.
