### PR TITLE
Fix sidebar border styles

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -154,7 +154,7 @@ const DocsSidebar: FC<DocsLayoutState> = ({ isCollapsed, setCollapsed }) => {
     <>
       <div
         className={twMerge(
-          'fixed inset-0 z-50 h-full w-64 flex-none lg:static lg:block lg:h-auto lg:overflow-y-visible lg:pt-6',
+          'fixed inset-0 z-50 h-full w-64 flex-none border-r border-gray-200 dark:border-gray-600 lg:static lg:block lg:h-auto lg:overflow-y-visible lg:pt-6',
           isCollapsed && 'hidden',
         )}
       >


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Fixes a missing piece of the border after adding the banner component:

<img width="574" alt="Screenshot 2023-08-23 at 09 08 28" src="https://github.com/themesberg/flowbite-react/assets/8052108/8410f3fd-ef04-4a15-b7e9-8a9d22107952">

How it looks after the fix:

<img width="649" alt="Screenshot 2023-08-23 at 09 08 45" src="https://github.com/themesberg/flowbite-react/assets/8052108/cb1356c0-4b9b-4e74-8e9e-23bf06ebe653">