### PR TITLE
fix(tabs): added tabs container div style and theme

### DIFF
--- a/src/components/Tab/Tabs.tsx
+++ b/src/components/Tab/Tabs.tsx
@@ -152,7 +152,7 @@ export const TabsComponent = forwardRef<TabsRef, TabsProps>(
             </button>
           ))}
         </div>
-        <div className={twMerge(theme.tablist.tabitemcontainer.base, tabItemContainerStyle)}>
+        <div className={twMerge(theme.tabitemcontainer.base, tabItemContainerStyle)}>
           {tabs.map((tab, index) => (
             <div
               key={index}

--- a/src/components/Tab/Tabs.tsx
+++ b/src/components/Tab/Tabs.tsx
@@ -152,7 +152,7 @@ export const TabsComponent = forwardRef<TabsRef, TabsProps>(
             </button>
           ))}
         </div>
-        <div className={twMerge(tabItemContainerStyle)}>
+        <div className={twMerge(theme.tablist.tabitemcontainer.base, tabItemContainerStyle)}>
           {tabs.map((tab, index) => (
             <div
               key={index}

--- a/src/components/Tab/Tabs.tsx
+++ b/src/components/Tab/Tabs.tsx
@@ -12,6 +12,10 @@ export interface FlowbiteTabTheme {
   tablist: {
     base: string;
     styles: TabStyles;
+    tabitemcontainer: {
+      base: string;
+      styles: TabStyles;
+    };
     tabitem: {
       base: string;
       styles: TabStyleItem<TabStyles>;
@@ -104,6 +108,7 @@ export const TabsComponent = forwardRef<TabsRef, TabsProps>(
     };
 
     const tabItemStyle = theme.tablist.tabitem.styles[style];
+    const tabItemContainerStyle = theme.tablist.tabitemcontainer.styles[style];
 
     useEffect(() => {
       tabRefs.current[focusedTab]?.focus();
@@ -146,7 +151,7 @@ export const TabsComponent = forwardRef<TabsRef, TabsProps>(
             </button>
           ))}
         </div>
-        <div>
+        <div className={twMerge(tabItemContainerStyle)}>
           {tabs.map((tab, index) => (
             <div
               key={index}

--- a/src/components/Tab/Tabs.tsx
+++ b/src/components/Tab/Tabs.tsx
@@ -12,15 +12,15 @@ export interface FlowbiteTabTheme {
   tablist: {
     base: string;
     styles: TabStyles;
-    tabitemcontainer: {
-      base: string;
-      styles: TabStyles;
-    };
     tabitem: {
       base: string;
       styles: TabStyleItem<TabStyles>;
       icon: string;
     };
+  };
+  tabitemcontainer: {
+    base: string;
+    styles: TabStyles;
   };
   tabpanel: string;
 }
@@ -108,7 +108,7 @@ export const TabsComponent = forwardRef<TabsRef, TabsProps>(
     };
 
     const tabItemStyle = theme.tablist.tabitem.styles[style];
-    const tabItemContainerStyle = theme.tablist.tabitemcontainer.styles[style];
+    const tabItemContainerStyle = theme.tabitemcontainer.styles[style];
 
     useEffect(() => {
       tabRefs.current[focusedTab]?.focus();

--- a/src/components/Tab/Tabs.tsx
+++ b/src/components/Tab/Tabs.tsx
@@ -145,6 +145,7 @@ export const TabsComponent = forwardRef<TabsRef, TabsProps>(
               ref={(element) => (tabRefs.current[index] = element as HTMLButtonElement)}
               role="tab"
               tabIndex={index === focusedTab ? 0 : -1}
+              style={{ zIndex: index === focusedTab ? 2 : 1 }}
             >
               {tab.icon && <tab.icon className={theme.tablist.tabitem.icon} />}
               {tab.title}

--- a/src/components/Tab/theme.ts
+++ b/src/components/Tab/theme.ts
@@ -11,15 +11,6 @@ export const tabTheme: FlowbiteTabTheme = {
       fullWidth:
         'w-full text-sm font-medium divide-x divide-gray-200 shadow grid grid-flow-col dark:divide-gray-700 dark:text-gray-400 rounded-none',
     },
-    tabitemcontainer: {
-      base: '',
-      styles: {
-        default: '',
-        underline: '',
-        pills: '',
-        fullWidth: '',
-      },
-    },
     tabitem: {
       base: 'flex items-center justify-center p-4 rounded-t-lg text-sm font-medium first:ml-0 disabled:cursor-not-allowed disabled:text-gray-400 disabled:dark:text-gray-500 focus:ring-4 focus:ring-cyan-300 focus:outline-none',
       styles: {
@@ -53,6 +44,15 @@ export const tabTheme: FlowbiteTabTheme = {
         },
       },
       icon: 'mr-2 h-5 w-5',
+    },
+  },
+  tabitemcontainer: {
+    base: '',
+    styles: {
+      default: '',
+      underline: '',
+      pills: '',
+      fullWidth: '',
     },
   },
   tabpanel: 'py-3',

--- a/src/components/Tab/theme.ts
+++ b/src/components/Tab/theme.ts
@@ -11,6 +11,15 @@ export const tabTheme: FlowbiteTabTheme = {
       fullWidth:
         'w-full text-sm font-medium divide-x divide-gray-200 shadow grid grid-flow-col dark:divide-gray-700 dark:text-gray-400 rounded-none',
     },
+    tabitemcontainer: {
+      base: '',
+      styles: {
+        default: '',
+        underline: '',
+        pills: '',
+        fullWidth: '',
+      },
+    },
     tabitem: {
       base: 'flex items-center justify-center p-4 rounded-t-lg text-sm font-medium first:ml-0 disabled:cursor-not-allowed disabled:text-gray-400 disabled:dark:text-gray-500 focus:ring-4 focus:ring-cyan-300 focus:outline-none',
       styles: {


### PR DESCRIPTION

- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

Tabs inside Tab component are wrapped in an unstyled div, and in no way this was possible to add any style to it. I added a now theme key "tabsitemcontainer" to let the div take in style. As it was possible to style the divs inside (the single tabs), it was kinda stupid not being able to add style to a div that contains them, as it brought issues with dimensions.

Reference related issues using `#` followed by the issue number.
#924

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.

Yes. I added a key to the theme of the tabs, the theme i added is completely empty and is done only for users to implement some custom styles if necessary.
```
    tabitemcontainer: {
      base: '',
      styles: {
        default: '',
        underline: '',
        pills: '',
        fullWidth: '',
      },
    }
```
Interface:
```
{
  base: string;
  tablist: {
    base: string;
    styles: TabStyles;
    tabitemcontainer: {
      base: string;
      styles: TabStyles;
    };
    tabitem: {
      base: string;
      styles: TabStyleItem<TabStyles>;
      icon: string;
    };
  };
  tabpanel: string;
}
```