### PR TITLE
fix/dropdown-input

### DIFF
--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -5,8 +5,6 @@ import { describe, expect, it } from 'vitest';
 import type { DropdownProps } from './Dropdown';
 import { Dropdown } from './Dropdown';
 
-const delay = async (delayTime: number) => await new Promise((r) => setTimeout(r, delayTime));
-
 describe('Components / Dropdown', () => {
   describe('A11y', async () => {
     it('should use `role="menu"` in menu container', async () => {
@@ -74,20 +72,6 @@ describe('Components / Dropdown', () => {
 
       await act(() => fireEvent.keyDown(button(), { key: 'ArrowDown', code: 'ArrowDown' }));
       expect(dropdown()).toBeInTheDocument();
-    });
-
-    it('should focus matching item when user types the first option char and dropdown is open', async () => {
-      const user = userEvent.setup();
-      render(<TestDropdown />);
-
-      await act(() => user.click(button()));
-      expect(dropdown()).toBeInTheDocument();
-
-      await act(() => fireEvent.keyDown(button(), { key: 'S', code: 'KeyS' }));
-      await delay(20);
-
-      const item = screen.getByText('Settings');
-      expect(item).toHaveFocus();
     });
   });
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,5 +1,5 @@
 import type { ExtendedRefs, useInteractions } from '@floating-ui/react';
-import { FloatingFocusManager, FloatingList, useListNavigation, useTypeahead } from '@floating-ui/react';
+import { FloatingFocusManager, FloatingList, useListNavigation } from '@floating-ui/react';
 import type {
   ComponentProps,
   Dispatch,
@@ -155,17 +155,6 @@ const DropdownComponent: FC<DropdownProps> = ({
     setOpen(false);
   }, []);
 
-  const handleTypeaheadMatch = useCallback(
-    (index: number | null) => {
-      if (open) {
-        setActiveIndex(index);
-      } else {
-        handleSelect(index);
-      }
-    },
-    [open, handleSelect],
-  );
-
   const { context, floatingStyles, refs } = useBaseFloating<HTMLButtonElement>({
     open,
     setOpen,
@@ -179,18 +168,18 @@ const DropdownComponent: FC<DropdownProps> = ({
     onNavigate: setActiveIndex,
   });
 
-  const typeahead = useTypeahead(context, {
-    listRef: labelsRef,
-    activeIndex,
-    selectedIndex,
-    onMatch: handleTypeaheadMatch,
-  });
+  // const typeahead = useTypeahead(context, {
+  //   listRef: labelsRef,
+  //   activeIndex,
+  //   selectedIndex,
+  //   onMatch: handleTypeaheadMatch,
+  // });
 
   const { getReferenceProps, getFloatingProps, getItemProps } = useFloatingInteractions({
     context,
     role: 'menu',
     trigger,
-    interactions: [listNav, typeahead],
+    interactions: [listNav],
   });
 
   const Icon = useMemo(() => {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -26,7 +26,7 @@ import type { FlowbiteDropdownItemTheme } from './DropdownItem';
 import { DropdownItem } from './DropdownItem';
 
 import { twMerge } from 'tailwind-merge';
-import { useBaseFLoating, useFloatingInteractions } from '../../helpers/use-floating';
+import { useBaseFloating, useFloatingInteractions } from '../../helpers/use-floating';
 
 export interface FlowbiteDropdownFloatingTheme
   extends FlowbiteFloatingTheme,
@@ -166,7 +166,7 @@ const DropdownComponent: FC<DropdownProps> = ({
     [open, handleSelect],
   );
 
-  const { context, floatingStyles, refs } = useBaseFLoating<HTMLButtonElement>({
+  const { context, floatingStyles, refs } = useBaseFloating<HTMLButtonElement>({
     open,
     setOpen,
     placement,

--- a/src/components/Floating/Floating.tsx
+++ b/src/components/Floating/Floating.tsx
@@ -4,7 +4,7 @@ import type { ComponentProps, FC, PropsWithChildren, ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { getArrowPlacement } from '../../helpers/floating';
-import { useBaseFLoating, useFloatingInteractions } from '../../helpers/use-floating';
+import { useBaseFloating, useFloatingInteractions } from '../../helpers/use-floating';
 
 export interface FlowbiteFloatingTheme {
   arrow: FlowbiteFloatingArrowTheme;
@@ -62,7 +62,7 @@ export const Floating: FC<FloatingProps> = ({
   const arrowRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
 
-  const floatingProperties = useBaseFLoating({
+  const floatingProperties = useBaseFloating({
     open,
     placement,
     arrowRef,

--- a/src/helpers/use-floating.ts
+++ b/src/helpers/use-floating.ts
@@ -21,7 +21,7 @@ export type UseBaseFloatingParams = {
   setOpen: Dispatch<SetStateAction<boolean>>;
 };
 
-export const useBaseFLoating = <Type extends ReferenceType>({
+export const useBaseFloating = <Type extends ReferenceType>({
   open,
   arrowRef,
   placement = 'top',


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.
This pull request removes Floating-UI's `useTypeahead` from the `Dropdown`. The typeahead functionality is causing unexpected behaviour for dropdowns containing `<input>` elements or other UI expecting user keyboard events, as the feature stops the keydown event from propagating.

Reference related issues using `#` followed by the issue number.
fix #916

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.
There are no breaking changes.
