### PR TITLE
fix(textarea): default font size should be `text-sm`

### DIFF
--- a/src/components/Textarea/theme.ts
+++ b/src/components/Textarea/theme.ts
@@ -1,7 +1,7 @@
 import type { FlowbiteTextareaTheme } from './Textarea';
 
 export const textareaTheme: FlowbiteTextareaTheme = {
-  base: 'block w-full rounded-lg border disabled:cursor-not-allowed disabled:opacity-50',
+  base: 'block w-full rounded-lg border disabled:cursor-not-allowed disabled:opacity-50 text-sm',
   colors: {
     gray: 'bg-gray-50 border-gray-300 text-gray-900 focus:border-cyan-500 focus:ring-cyan-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-cyan-500 dark:focus:ring-cyan-500',
     info: 'border-cyan-500 bg-cyan-50 text-cyan-900 placeholder-cyan-700 focus:border-cyan-500 focus:ring-cyan-500 dark:border-cyan-400 dark:bg-cyan-100 dark:focus:border-cyan-500 dark:focus:ring-cyan-500',


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Fixes an older design problem from the main library where the `Textarea` component had `text-base` font size instead of `text-sm` - this change applies `text-sm` by default to keep consistency.