### PR TITLE
fix(datepiker): incorrect names of days of the week in the datepicker

### DIFF
--- a/src/components/Datepicker/Views/Days.tsx
+++ b/src/components/Datepicker/Views/Days.tsx
@@ -43,7 +43,7 @@ export const DatepickerViewsDays: FC<DatepickerViewsDaysProps> = ({ theme: custo
       </div>
       <div className={theme.items.base}>
         {[...Array(42)].map((_date, index) => {
-          const currentDate = addDays(startDate, index);
+          const currentDate = addDays(startDate, index - 2);
           const day = getFormattedDate(language, currentDate, { day: 'numeric' });
 
           const isSelected = isDateEqual(selectedDate, currentDate);

--- a/src/components/Datepicker/Views/Days.tsx
+++ b/src/components/Datepicker/Views/Days.tsx
@@ -43,7 +43,7 @@ export const DatepickerViewsDays: FC<DatepickerViewsDaysProps> = ({ theme: custo
       </div>
       <div className={theme.items.base}>
         {[...Array(42)].map((_date, index) => {
-          const currentDate = addDays(startDate, index - 2);
+          const currentDate = addDays(startDate, index - 1);
           const day = getFormattedDate(language, currentDate, { day: 'numeric' });
 
           const isSelected = isDateEqual(selectedDate, currentDate);

--- a/src/components/Datepicker/helpers.ts
+++ b/src/components/Datepicker/helpers.ts
@@ -66,7 +66,7 @@ export const getWeekDays = (lang: string, weekStart: WeekStart): string[] => {
   const formatter = new Intl.DateTimeFormat(lang, { weekday: 'short' });
 
   for (let i = 0; i < 7; i++) {
-    const dayIndex = (i + weekStart) % 7; // Calculate the correct day index based on weekStart
+    const dayIndex = (i + weekStart + 1) % 7; // Calculate the correct day index based on weekStart
     date.setDate(dayIndex + 1);
     const formattedWeekday = formatter.format(date);
     weekdays.push(formattedWeekday.slice(0, 2).charAt(0).toUpperCase() + formattedWeekday.slice(1, 3));


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.
The weekdays index is based on the "currentDate" variable and it was representing the wrong value that is fixed now

Reference related issues using `#` followed by the issue number.
fixes: #960 
