### PR TITLE
docs: story `@deprecated` Use `StoryFn` instead

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { HiEye, HiInformationCircle } from 'react-icons/hi';
 import { theme } from '../../';
 import type { AlertProps } from './Alert';
@@ -15,7 +15,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story<AlertProps> = (props) => <Alert {...props} />;
+const Template: StoryFn<AlertProps> = (props) => <Alert {...props} />;
 
 export const DefaultAlert = Template.bind({});
 DefaultAlert.storyName = 'Default';

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { AvatarProps } from './Avatar';
 import { Avatar } from './Avatar';
 
@@ -7,7 +7,7 @@ export default {
   component: Avatar,
 } as Meta;
 
-const Template: Story<AvatarProps> = (args) => <Avatar {...args} />;
+const Template: StoryFn<AvatarProps> = (args) => <Avatar {...args} />;
 
 export const DefaultAvatar = Template.bind({});
 DefaultAvatar.storyName = 'Default';
@@ -16,7 +16,7 @@ DefaultAvatar.args = {
   img: 'https://flowbite.com/docs/images/people/profile-picture-5.jpg',
 };
 
-export const CustomImage: Story<AvatarProps> = (props) => (
+export const CustomImage: StoryFn<AvatarProps> = (props) => (
   <>
     <Avatar
       {...props}

--- a/src/components/Avatar/AvatarGroup.stories.tsx
+++ b/src/components/Avatar/AvatarGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Avatar } from './Avatar';
 import type { AvatarGroupProps } from './AvatarGroup';
 
@@ -7,7 +7,7 @@ export default {
   component: Avatar.Group,
 } as Meta;
 
-const Template: Story<AvatarGroupProps> = (args) => (
+const Template: StoryFn<AvatarGroupProps> = (args) => (
   <Avatar.Group {...args}>
     <Avatar img="https://flowbite.com/docs/images/people/profile-picture-1.jpg" rounded stacked />
     <Avatar img="https://flowbite.com/docs/images/people/profile-picture-2.jpg" rounded stacked />

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { HiCheck } from 'react-icons/hi';
 import { theme } from '../../';
 import type { BadgeProps } from './Badge';
@@ -19,7 +19,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story<BadgeProps> = (args) => (
+const Template: StoryFn<BadgeProps> = (args) => (
   <div className="flex items-center">
     <Badge {...args} />
   </div>

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { theme } from '../../';
 import type { ButtonProps } from './Button';
 import { Button } from './Button';
@@ -22,7 +22,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story<ButtonProps> = (args) => <Button {...args} />;
+const Template: StoryFn<ButtonProps> = (args) => <Button {...args} />;
 
 export const DefaultButton = Template.bind({});
 DefaultButton.storyName = 'Default';

--- a/src/components/Button/ButtonGroup.stories.tsx
+++ b/src/components/Button/ButtonGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Button } from '.';
 import type { ButtonGroupProps } from './ButtonGroup';
 
@@ -7,7 +7,7 @@ export default {
   component: Button.Group,
 } as Meta;
 
-const Template: Story<ButtonGroupProps> = (args) => (
+const Template: StoryFn<ButtonGroupProps> = (args) => (
   <Button.Group {...args}>
     <Button color="gray">Profile</Button>
     <Button color="gray">Settings</Button>

--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { CarouselProps } from './Carousel';
 import { Carousel } from './Carousel';
 
@@ -7,7 +7,7 @@ export default {
   component: Carousel,
 } as Meta;
 
-const Template: Story<CarouselProps> = (args) => (
+const Template: StoryFn<CarouselProps> = (args) => (
   <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
     <Carousel {...args}>
       <img src="https://flowbite.com/docs/images/carousel/carousel-1.svg" alt="..." />

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { CheckboxProps } from './Checkbox';
 import { Checkbox } from './Checkbox';
 
@@ -7,7 +7,7 @@ export default {
   component: Checkbox,
 } as Meta;
 
-const Template: Story<CheckboxProps> = (args) => <Checkbox {...args} />;
+const Template: StoryFn<CheckboxProps> = (args) => <Checkbox {...args} />;
 
 export const DefaultCheckbox = Template.bind({});
 DefaultCheckbox.storyName = 'Checkbox';

--- a/src/components/DarkThemeToggle/DarkThemeToggle.stories.tsx
+++ b/src/components/DarkThemeToggle/DarkThemeToggle.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Flowbite } from '../../';
 import { DarkThemeToggle } from './DarkThemeToggle';
 
@@ -7,7 +7,7 @@ export default {
   component: DarkThemeToggle,
 } as Meta;
 
-const Template: Story = (args) => (
+const Template: StoryFn = (args) => (
   <Flowbite>
     <DarkThemeToggle {...args} />
   </Flowbite>

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { DropdownProps } from './Dropdown';
 import { Dropdown } from './Dropdown';
 
@@ -14,7 +14,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story<DropdownProps> = (args) => <Dropdown {...args} />;
+const Template: StoryFn<DropdownProps> = (args) => <Dropdown {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/src/components/FileInput/FileInput.stories.tsx
+++ b/src/components/FileInput/FileInput.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { FileInputProps } from './FileInput';
 import { FileInput } from './FileInput';
 
@@ -7,7 +7,7 @@ export default {
   component: FileInput,
 } as Meta;
 
-const Template: Story<FileInputProps> = (args) => <FileInput {...args} />;
+const Template: StoryFn<FileInputProps> = (args) => <FileInput {...args} />;
 
 export const DefaultFileInput = Template.bind({});
 DefaultFileInput.storyName = 'FileInput';

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { BsDribbble, BsFacebook, BsGithub, BsInstagram, BsTwitter } from 'react-icons/bs';
 import { Footer } from './Footer';
 
@@ -7,7 +7,7 @@ export default {
   component: Footer,
 } as Meta;
 
-const Template: Story = ({ children }) => <Footer>{children}</Footer>;
+const Template: StoryFn = ({ children }) => <Footer>{children}</Footer>;
 
 export const DefaultFooter = Template.bind({});
 DefaultFooter.storyName = 'Default';

--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { LabelProps } from './Label';
 import { Label } from './Label';
 
@@ -7,7 +7,7 @@ export default {
   component: Label,
 } as Meta;
 
-const Template: Story<LabelProps> = (args) => <Label {...args} />;
+const Template: StoryFn<LabelProps> = (args) => <Label {...args} />;
 
 export const DefaultLabel = Template.bind({});
 DefaultLabel.storyName = 'Label';

--- a/src/components/ListGroup/ListGroup.stories.tsx
+++ b/src/components/ListGroup/ListGroup.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { HiCloudDownload, HiInbox, HiOutlineAdjustments, HiUserCircle } from 'react-icons/hi';
 import type { ListGroupProps } from './ListGroup';
 import { ListGroup } from './ListGroup';
@@ -8,7 +8,7 @@ export default {
   component: ListGroup,
 } as Meta;
 
-const Template: Story<ListGroupProps> = (args) => <ListGroup {...args} />;
+const Template: StoryFn<ListGroupProps> = (args) => <ListGroup {...args} />;
 
 export const DefaultListGroup = Template.bind({});
 DefaultListGroup.storyName = 'Default';

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import Link from 'next/link';
 import { HiOutlineExclamationCircle } from 'react-icons/hi';
 import { Button, Checkbox, Label, TextInput } from '../../';
@@ -14,7 +14,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story<ModalProps> = ({ children, ...rest }): JSX.Element => {
+const Template: StoryFn<ModalProps> = ({ children, ...rest }): JSX.Element => {
   return (
     <>
       <Button onClick={action('open')}>Toggle modal</Button>

--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { NavbarComponentProps } from '../../';
 import { Avatar, Button, Dropdown, Navbar } from '../../';
 
@@ -7,7 +7,7 @@ export default {
   component: Navbar,
 } as Meta;
 
-const Template: Story<NavbarComponentProps> = (args) => (
+const Template: StoryFn<NavbarComponentProps> = (args) => (
   <div className="w-4/5">
     <Navbar {...args} />
   </div>

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { useEffect, useState } from 'react';
 import type { PaginationProps } from './Pagination';
 import { Pagination } from './Pagination';
@@ -15,7 +15,7 @@ export default {
   ],
 } as Meta;
 
-const Template: Story<PaginationProps> = ({ currentPage = 1, layout = 'pagination', totalPages = 100, ...rest }) => {
+const Template: StoryFn<PaginationProps> = ({ currentPage = 1, layout = 'pagination', totalPages = 100, ...rest }) => {
   const [page, setPage] = useState(currentPage);
 
   const onPageChange = (page: number) => {

--- a/src/components/Progress/Progress.stories.tsx
+++ b/src/components/Progress/Progress.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { ProgressProps } from './Progress';
 import { Progress } from './Progress';
 
@@ -14,7 +14,7 @@ export default {
   ],
 } as Meta;
 
-const Template: Story<ProgressProps> = (args) => <Progress {...args} />;
+const Template: StoryFn<ProgressProps> = (args) => <Progress {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { RadioProps } from './Radio';
 import { Radio } from './Radio';
 
@@ -7,7 +7,7 @@ export default {
   component: Radio,
 } as Meta;
 
-const Template: Story<RadioProps> = (args) => <Radio {...args} />;
+const Template: StoryFn<RadioProps> = (args) => <Radio {...args} />;
 
 export const DefaultRadio = Template.bind({});
 DefaultRadio.storyName = 'Radio';

--- a/src/components/RangeSlider/RangeSlider.stories.tsx
+++ b/src/components/RangeSlider/RangeSlider.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { theme } from '../../';
 import type { RangeSliderProps } from './RangeSlider';
 import { RangeSlider } from './RangeSlider';
@@ -24,7 +24,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story<RangeSliderProps> = (args) => <RangeSlider {...args} />;
+const Template: StoryFn<RangeSliderProps> = (args) => <RangeSlider {...args} />;
 
 export const DefaultRangeSlider = Template.bind({});
 DefaultRangeSlider.storyName = 'RangeSlider';

--- a/src/components/Rating/Rating.stories.tsx
+++ b/src/components/Rating/Rating.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { RatingProps } from './Rating';
 import { Rating } from './Rating';
 
@@ -7,7 +7,7 @@ export default {
   component: Rating,
 } as Meta;
 
-const Template: Story<RatingProps> = (args) => <Rating {...args} />;
+const Template: StoryFn<RatingProps> = (args) => <Rating {...args} />;
 
 export const DefaultRating = Template.bind({});
 DefaultRating.storyName = 'Default';

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { BsFlagFill } from 'react-icons/bs';
 import type { SelectProps } from './Select';
 import { Select } from './Select';
@@ -8,7 +8,7 @@ export default {
   component: Select,
 } as Meta;
 
-const Template: Story<SelectProps> = (args) => <Select {...args} />;
+const Template: StoryFn<SelectProps> = (args) => <Select {...args} />;
 
 export const DefaultSelect = Template.bind({});
 DefaultSelect.storyName = 'Select';

--- a/src/components/Spinner/Spinner.stories.tsx
+++ b/src/components/Spinner/Spinner.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Button } from '../../';
 import { Spinner } from './Spinner';
 
@@ -7,7 +7,7 @@ export default {
   component: Spinner,
 } as Meta;
 
-const Template: Story = (args) => <Spinner {...args} />;
+const Template: StoryFn = (args) => <Spinner {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { TableProps } from './Table';
 import { Table } from './Table';
 
@@ -7,7 +7,7 @@ export default {
   component: Table,
 } as Meta;
 
-const Template: Story<TableProps> = (args) => (
+const Template: StoryFn<TableProps> = (args) => (
   <Table {...args}>
     <Table.Head>
       <Table.HeadCell>Product name</Table.HeadCell>

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { TextInputProps } from './TextInput';
 import { TextInput } from './TextInput';
 
@@ -7,7 +7,7 @@ export default {
   component: TextInput,
 } as Meta;
 
-const Template: Story<TextInputProps> = (args) => <TextInput {...args} />;
+const Template: StoryFn<TextInputProps> = (args) => <TextInput {...args} />;
 
 export const Default = Template.bind({});
 Default.storyName = 'Text input';

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { TextareaProps } from './Textarea';
 import { Textarea } from './Textarea';
 
@@ -7,7 +7,7 @@ export default {
   component: Textarea,
 } as Meta;
 
-const Template: Story<TextareaProps> = (args) => <Textarea {...args} />;
+const Template: StoryFn<TextareaProps> = (args) => <Textarea {...args} />;
 
 export const DefaultTextarea = Template.bind({});
 DefaultTextarea.storyName = 'Textarea';

--- a/src/components/Timeline/Timeline.stories.tsx
+++ b/src/components/Timeline/Timeline.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import type { TimelineProps } from './Timeline';
 import { Timeline } from './Timeline';
 
@@ -7,7 +7,7 @@ export default {
   component: Timeline,
 } as Meta;
 
-const Template: Story<TimelineProps> = (args) => <Timeline {...args} />;
+const Template: StoryFn<TimelineProps> = (args) => <Timeline {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { HiFire } from 'react-icons/hi';
 import type { ToastProps } from './Toast';
 import { Toast } from './Toast';
@@ -8,7 +8,7 @@ export default {
   component: Toast,
 } as Meta;
 
-export const DefaultToast: Story<ToastProps> = (args) => {
+export const DefaultToast: StoryFn<ToastProps> = (args) => {
   return (
     <Toast {...args}>
       <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-cyan-100 text-cyan-500 dark:bg-cyan-800 dark:text-cyan-200">

--- a/src/components/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 import { theme } from '../../';
 import type { ToggleSwitchProps } from './ToggleSwitch';
@@ -11,7 +11,7 @@ export default {
   component: ToggleSwitch,
 } as Meta;
 
-const Template: Story<ToggleSwitchProps> = ({ checked, ...args }) => {
+const Template: StoryFn<ToggleSwitchProps> = ({ checked, ...args }) => {
   const [switchChecked, setSwitchChecked] = useState(checked);
 
   const handleChange = () => {

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, Story } from '@storybook/react';
+import type { Meta, StoryFn } from '@storybook/react';
 import { Button } from '../../';
 import type { TooltipProps } from './Tooltip';
 import { Tooltip } from './Tooltip';
@@ -8,7 +8,7 @@ export default {
   component: Tooltip,
 } as Meta;
 
-const Template: Story<TooltipProps> = (args) => <Tooltip {...args} />;
+const Template: StoryFn<TooltipProps> = (args) => <Tooltip {...args} />;
 
 export const DefaultTooltip = Template.bind({});
 DefaultTooltip.storyName = 'Default';


### PR DESCRIPTION
- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

@storybook/react deprected Use of Story. 
`@deprecated` Use `StoryFn` instead.

Reference related issues using `#` followed by the issue number.

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.
