### PR TITLE
fix(datepicker.tsx): fix theme and add onSelectedDate callback

### DIFF
--- a/src/components/Datepicker/Datepicker.tsx
+++ b/src/components/Datepicker/Datepicker.tsx
@@ -83,6 +83,7 @@ export interface DatepickerProps extends Omit<TextInputProps, 'theme'> {
   language?: string;
   weekStart?: WeekStart;
   theme?: DeepPartial<FlowbiteDatepickerTheme>;
+  onSelectedDateChanged?: (date: Date) => void;
 }
 
 export const Datepicker: FC<DatepickerProps> = ({
@@ -101,6 +102,7 @@ export const Datepicker: FC<DatepickerProps> = ({
   weekStart = WeekStart.Sunday,
   className,
   theme: customTheme = {},
+  onSelectedDateChanged,
   ...props
 }) => {
   const theme = mergeDeep(useTheme().theme.datepicker, customTheme);
@@ -122,6 +124,10 @@ export const Datepicker: FC<DatepickerProps> = ({
   const changeSelectedDate = (date: Date, useAutohide: boolean) => {
     setSelectedDate(date);
 
+    if (onSelectedDateChanged) {
+      onSelectedDateChanged(date);
+    }
+
     if (autoHide && view === Views.Days && useAutohide == true && !inline) {
       setIsOpen(false);
     }
@@ -131,14 +137,14 @@ export const Datepicker: FC<DatepickerProps> = ({
   const renderView = (type: Views): ReactNode => {
     switch (type) {
       case Views.Decades:
-        return <DatepickerViewsDecades />;
+        return <DatepickerViewsDecades theme={theme.views.decades} />;
       case Views.Years:
-        return <DatepickerViewsYears />;
+        return <DatepickerViewsYears theme={theme.views.years} />;
       case Views.Months:
-        return <DatepickerViewsMonth />;
+        return <DatepickerViewsMonth theme={theme.views.months} />;
       case Views.Days:
       default:
-        return <DatepickerViewsDays />;
+        return <DatepickerViewsDays theme={theme.views.days} />;
     }
   };
 


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

This change fixes the issue with the custom themes not being applied to the Datepicker views and adds a callback function in order to be able to get the selected date

Reference related issues using `#` followed by the issue number.

Fixed #968 #964 

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.

Added a new prop `onSelectedDateChanged` to `Datepicker` but it is optional and therefore should not be a breaking change.