### PR TITLE
fix(button): fix error Button cannot be used as a JSX component

### DIFF
--- a/src/helpers/generic-forward-ref.ts
+++ b/src/helpers/generic-forward-ref.ts
@@ -5,8 +5,8 @@ import { forwardRef } from 'react';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type FixedForwardRef = <T, P = {}>(
-  render: (props: P, ref: React.Ref<T>) => React.ReactNode,
-) => (props: P & React.RefAttributes<T>) => React.ReactNode;
+  render: (props: P, ref: React.Ref<T>) => JSX.Element,
+) => (props: P & React.RefAttributes<T>) => JSX.Element;
 
 const genericForwardRef = forwardRef as FixedForwardRef;
 


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

Fix error after updating to v0.6.0 Button cannot be used as a JSX component. Its return type 'ReactNode' is not a valid JSX element.

Reference related issues using `#` followed by the issue number.

fix #962

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.
