### PR TITLE
fix(labels): default dark color of the input labels should be white

### DIFF
--- a/src/components/Label/theme.ts
+++ b/src/components/Label/theme.ts
@@ -5,7 +5,7 @@ export const labelTheme: FlowbiteLabelTheme = {
     base: 'text-sm font-medium',
     disabled: 'opacity-50',
     colors: {
-      default: 'text-gray-900 dark:text-gray-300',
+      default: 'text-gray-900 dark:text-white',
       info: 'text-cyan-500 dark:text-cyan-600',
       failure: 'text-red-700 dark:text-red-500',
       warning: 'text-yellow-500 dark:text-yellow-600',


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

The dark mode colors of the label input should be white instead of `gray-300`.

We should also make the default checkbox, radio, and toggle colors as such:

`text-gray-500` and `dark:text-gray-300`

For the toggle switch I see there's a separate theme file, but for the Checkbox and Radio elements it inherits the one from the form labels which should be separate as well, in my opinion.

This PR addresses the form input element labels above the inputs and makes them white on dark mode.