### PR TITLE
refactor: remove redundant `useContext` -> replace with `useTheme`

### DIFF
--- a/src/components/DarkThemeToggle/DarkThemeToggle.tsx
+++ b/src/components/DarkThemeToggle/DarkThemeToggle.tsx
@@ -1,10 +1,8 @@
 import type { ComponentProps, FC } from 'react';
-import { useContext } from 'react';
 import { HiMoon, HiSun } from 'react-icons/hi';
 import { twMerge } from 'tailwind-merge';
 import type { DeepPartial } from '../../';
 import { useTheme } from '../../';
-import { ThemeContext } from '../../components/Flowbite/ThemeContext';
 import { mergeDeep } from '../../helpers/merge-deep';
 
 export interface FlowbiteDarkThemeToggleTheme {
@@ -31,7 +29,7 @@ export const DarkThemeToggle: FC<DarkThemeToggleProps> = ({
 }) => {
   const theme = mergeDeep(useTheme().theme.darkThemeToggle, customTheme);
 
-  const { mode, toggleMode } = useContext(ThemeContext);
+  const { mode, toggleMode } = useTheme();
 
   return (
     <button


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

A small cleanup by removing redundant imports and reusing existing `useTheme` hook.

No breaking changes.
