### PR TITLE
fix: scroll to section blocking above content

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -3,10 +3,7 @@ import type { MDXComponents } from 'mdx/types';
 export const useMDXComponents: (components: MDXComponents) => MDXComponents = (components) => {
   return {
     h2: (props) => (
-      <h2
-        className="group relative z-20 text-2xl font-bold text-gray-900 before:invisible before:-mt-20 before:block before:h-20 before:content-[''] before:dark:text-white"
-        {...props}
-      >
+      <h2 className="group relative z-20 scroll-mt-20 text-2xl font-bold text-gray-900" {...props}>
         {props.children}
         <a
           aria-label={`Link to this section: ${props.children}`}
@@ -18,10 +15,7 @@ export const useMDXComponents: (components: MDXComponents) => MDXComponents = (c
       </h2>
     ),
     h3: (props) => (
-      <h3
-        className="group relative z-10 text-2xl font-bold text-gray-900 before:invisible before:-mt-20 before:block before:h-20 before:content-[''] before:dark:text-white"
-        {...props}
-      >
+      <h3 className="group relative z-10 scroll-mt-20 text-2xl font-bold text-gray-900" {...props}>
         {props.children}
         <a
           aria-label={`Link to this section: ${props.children}`}


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

In the docs section, the heading elements have a `::before` element with a height of `5rem` used solely for scrolling to that area with a top-offset of `5rem`.

### Problem

`h2/h3` component

https://github.com/themesberg/flowbite-react/assets/41998826/0335dcf2-722d-4c97-ae8e-6de551aed973

<img width="1005" alt="Screenshot 2023-09-22 at 13 19 38" src="https://github.com/themesberg/flowbite-react/assets/41998826/35951856-863b-4be6-b0b2-5b09386dd402">

`::before` element

<img width="1628" alt="Screenshot 2023-09-22 at 13 18 48" src="https://github.com/themesberg/flowbite-react/assets/41998826/445279af-b789-43ab-a5b1-8e4503e97a38">

### Solution

Remove the `::before` element with vanilla CSS rule `scroll-margin-top` (https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top)

### Result

https://github.com/themesberg/flowbite-react/assets/41998826/d808361b-e74b-45fb-beff-41c5f81b0fd3

<img width="795" alt="Screenshot 2023-09-22 at 13 26 20" src="https://github.com/themesberg/flowbite-react/assets/41998826/2875a77b-d36f-4367-af16-58882010803b">
