### PR TITLE
fix: `CodePreview` - show explicit false props

### DIFF
--- a/app/components/code-preview.tsx
+++ b/app/components/code-preview.tsx
@@ -14,7 +14,7 @@ import { Tooltip } from '~/src';
 const reactElementToJSXStringOptions: Options = {
   filterProps: ['key', 'ref'],
   showFunctions: true,
-  sortProps: true,
+  useBooleanShorthandSyntax: false,
 };
 
 interface CodePreviewProps extends PropsWithChildren, ComponentProps<'div'> {
@@ -62,6 +62,7 @@ export const CodePreview: FC<CodePreviewProps> = ({
   code = deleteJSXSpaces(code);
   code = deleteSVGs(code);
   code = replaceWebpackImportsOnFunctions(code);
+  code = explicitTruthyPropsToShorthandSyntax(code);
   code = `'use client';
 
 import { ${importFlowbiteReact ?? firstComponentDisplayName(code)} } from 'flowbite-react';
@@ -230,4 +231,8 @@ const slugToUpperCamelCase = (str: string) => {
     .replaceAll(/-/g, ' ')
     .replaceAll(/\b[a-z]/g, (letter) => letter.toUpperCase())
     .replaceAll(/\s/g, '');
+};
+
+const explicitTruthyPropsToShorthandSyntax = (str: string) => {
+  return str.replaceAll(/={true}/g, '');
 };


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

If the setting `useBooleanShorthandSyntax` is not set to `false` in the https://github.com/algolia/react-element-to-jsx-string/tree/master options object, it will remove for good any prop looking like this `prop={false}`, even tho the default is set to `true` within the component.

This is a problem because it can misguide people when they look at the code snippet, if they copy it and paste it -> they should see the same results, which today is not the case, for example for https://www.flowbite-react.com/docs/components/datepicker#autohide.


### Changes

- show explicit false props (eg: `visible={false}`)
- removing `sortProps` since it defaults to `true`

This issue currently affects the following components: 

1. avatar
2. carousel
3. datepicker
4. dropdown
5. rating
6. tooltip

### MDX source code

<img width="987" alt="Screenshot 2023-09-22 at 16 07 28" src="https://github.com/themesberg/flowbite-react/assets/41998826/189c82f2-9ee6-41ed-9d24-44c7d773284a">

### Before

<img width="895" alt="Screenshot 2023-09-22 at 14 47 21" src="https://github.com/themesberg/flowbite-react/assets/41998826/548da2e3-8f3e-471a-90a5-0cd51ea7bdf2">

### After

<img width="787" alt="Screenshot 2023-09-22 at 16 06 09" src="https://github.com/themesberg/flowbite-react/assets/41998826/07f7be3d-236d-4673-b377-9dba8bef32e0">
