### PR TITLE
fix(toggleswitch): disable + checked state and deprecated html event replacement

### DIFF
--- a/app/docs/components/forms/forms.mdx
+++ b/app/docs/components/forms/forms.mdx
@@ -456,6 +456,7 @@ Use the `<ToggleSwitch>` component to ask users to enable or disable an option s
     <ToggleSwitch checked={props.switch1} label="Toggle me" onChange={props.setSwitch1} />
     <ToggleSwitch checked={props.switch2} label="Toggle me (checked)" onChange={props.setSwitch2} />
     <ToggleSwitch checked={false} disabled label="Toggle me (disabled)" onChange={() => undefined} />
+    <ToggleSwitch checked={true} disabled label="Toggle me (disabled)" onChange={() => undefined} />
     <ToggleSwitch checked={props.switch3} onChange={props.setSwitch3} />
   </div>
 </CodePreview>

--- a/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, FC, KeyboardEvent, MouseEvent } from 'react';
-import { useId } from 'react';
+import { useId, useRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 import type { DeepPartial, FlowbiteBoolean, FlowbiteColors } from '../../';
 import { useTheme } from '../../';
@@ -44,16 +44,18 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
 }) => {
   const id = useId();
   const theme = mergeDeep(useTheme().theme.toggleSwitch, customTheme);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const toggle = (): void => onChange(!checked);
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>): void => {
-    event.preventDefault();
     toggle();
   };
 
-  const handleKeyPress = (event: KeyboardEvent<HTMLButtonElement>): void => {
-    event.preventDefault();
+  const handleOnKeyDown = (event: KeyboardEvent<HTMLButtonElement>): void => {
+    if (event.code == 'Enter') {
+      event.preventDefault();
+    }
   };
 
   return (
@@ -62,12 +64,13 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
         <input checked={checked} hidden name={name} readOnly type="checkbox" className="sr-only" />
       ) : null}
       <button
+        ref={buttonRef}
         aria-checked={checked}
         aria-labelledby={`${id}-flowbite-toggleswitch-label`}
         disabled={disabled}
         id={`${id}-flowbite-toggleswitch`}
         onClick={handleClick}
-        onKeyPress={handleKeyPress}
+        onKeyDown={handleOnKeyDown}
         role="switch"
         tabIndex={0}
         type="button"
@@ -79,7 +82,7 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
           className={twMerge(
             theme.toggle.base,
             theme.toggle.checked[checked ? 'on' : 'off'],
-            !disabled && checked && theme.toggle.checked.color[color],
+            checked && theme.toggle.checked.color[color],
           )}
         />
         {label?.length ? (

--- a/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, FC, KeyboardEvent } from 'react';
-import { useId, useRef } from 'react';
+import { useId } from 'react';
 import { twMerge } from 'tailwind-merge';
 import type { DeepPartial, FlowbiteBoolean, FlowbiteColors } from '../../';
 import { useTheme } from '../../';
@@ -44,7 +44,6 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
 }) => {
   const id = useId();
   const theme = mergeDeep(useTheme().theme.toggleSwitch, customTheme);
-  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const toggle = (): void => onChange(!checked);
 
@@ -64,7 +63,6 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
         <input checked={checked} hidden name={name} readOnly type="checkbox" className="sr-only" />
       ) : null}
       <button
-        ref={buttonRef}
         aria-checked={checked}
         aria-labelledby={`${id}-flowbite-toggleswitch-label`}
         disabled={disabled}

--- a/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, FC, KeyboardEvent, MouseEvent } from 'react';
+import type { ComponentProps, FC, KeyboardEvent } from 'react';
 import { useId, useRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 import type { DeepPartial, FlowbiteBoolean, FlowbiteColors } from '../../';
@@ -48,7 +48,7 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
 
   const toggle = (): void => onChange(!checked);
 
-  const handleClick = (event: MouseEvent<HTMLButtonElement>): void => {
+  const handleClick = (): void => {
     toggle();
   };
 


### PR DESCRIPTION
- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

As described in issue #986 the component `ToggleSwitch` wasn't acting as expected when `checked={true} disabled={true}`. This PR fixes the issue. This also replaces the deprecated `onKeyPress` API with `onKeyDown`.

Fixes #986 

⚠️ This PR replaces the `onKeyPress` with `onKeyDown`. It should not break anything, since the API is only internally used.
