### PR TITLE
fix: issue #846 - docs dropdown - `custom trigger` section not render…

### DIFF
--- a/app/docs/components/dropdown/dropdown.mdx
+++ b/app/docs/components/dropdown/dropdown.mdx
@@ -183,7 +183,15 @@ Add a custom `onClick` event handler to the `<Dropdown.Item>` component to handl
 
 To customize the trigger element you can use `renderTrigger` property.
 
-<CodePreview title="Custom trigger dropdown">
+<CodePreview
+  title="Custom trigger dropdown"
+  code={`<Dropdown dismissOnClick={false} renderTrigger={() => <span>My custom trigger</span>}>
+  <Dropdown.Item>Dashboard</Dropdown.Item>
+  <Dropdown.Item>Settings</Dropdown.Item>
+  <Dropdown.Item>Earnings</Dropdown.Item>
+  <Dropdown.Item>Sign out</Dropdown.Item>
+</Dropdown>`}
+>
   <Dropdown dismissOnClick={false} renderTrigger={() => <span>My custom trigger</span>}>
     <Dropdown.Item>Dashboard</Dropdown.Item>
     <Dropdown.Item>Settings</Dropdown.Item>


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Docs: dropdown - fix `custom trigger` section not rendering properly ES6 callback in `code-preview`.

Reference related issues using `#` followed by the issue number.
#846 

### Before
<img width="867" alt="Screenshot 2023-09-27 at 12 39 26" src="https://github.com/themesberg/flowbite-react/assets/41998826/6ab8879b-7b1d-49a7-a4e4-b5217a2f93d5">

### After
<img width="865" alt="Screenshot 2023-09-27 at 12 38 43" src="https://github.com/themesberg/flowbite-react/assets/41998826/6bef9e00-01d9-4823-a84b-ea2a06a82f24">
