### PR TITLE
fix: docs - avatar - render properly code example

### DIFF
--- a/app/docs/components/avatar/avatar.mdx
+++ b/app/docs/components/avatar/avatar.mdx
@@ -173,7 +173,33 @@ Change the default size of the avatar component by passing the `size` prop. Size
 
 You can override the default image element by passing the `img` prop to the `<Avatar>` component. This is useful if you want to use a different image element like `<Image>` from Next.js.
 
-<CodePreview importFlowbiteReact="Avatar" title="Override image element">
+<CodePreview
+  importFlowbiteReact="Avatar"
+  title="Override image element"
+  code={`<div className="flex flex-wrap gap-2">
+  <Avatar
+    img={(props) => (
+      <Image
+        alt=""
+        height="48"
+        referrerPolicy="no-referrer"
+        src="/images/people/profile-picture-5.jpg"
+        width="48"
+        {...props}
+      />
+    )}
+  />
+  <Avatar
+    img={(props) => (
+      <picture>
+        <source media="(min-width: 900px)" srcSet="/images/people/profile-picture-3.jpg" />
+        <source media="(min-width: 480px)" srcSet="/images/people/profile-picture-4.jpg" />
+        <Image alt="" height="48" src="/images/people/profile-picture-5.jpg" width="48" {...props} />
+      </picture>
+    )}
+  />
+</div>`}
+>
   <div className="flex flex-wrap gap-2">
     <Avatar
       img={(props) => (


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Docs: fix `Avatar` section `Override image element` code preview.

### Before
<img width="902" alt="Screenshot 2023-09-27 at 13 01 46" src="https://github.com/themesberg/flowbite-react/assets/41998826/adfc8c9b-c466-4c41-942a-4701cb38a11b">

### After
<img width="871" alt="Screenshot 2023-09-27 at 13 06 54" src="https://github.com/themesberg/flowbite-react/assets/41998826/a7c98ea6-4a66-4c43-ace7-7ce598daf88f">