### PR TITLE
feat(component): toggleSwitch add sizing prop (sm|md|lg)

### DIFF
--- a/src/components/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -33,3 +33,24 @@ DefaultToggleSwitch.argTypes = {
     },
   },
 };
+
+export const SmallToggleSwitch = Template.bind({});
+SmallToggleSwitch.storyName = 'Small Toggle switch';
+SmallToggleSwitch.args = {
+  sizing: 'sm',
+  label: 'small toggle switch',
+};
+
+export const MediumToggleSwitch = Template.bind({});
+MediumToggleSwitch.storyName = 'Medium Toggle switch';
+MediumToggleSwitch.args = {
+  sizing: 'md',
+  label: 'default toggle switch',
+};
+
+export const LargeToggleSwitch = Template.bind({});
+LargeToggleSwitch.storyName = 'Large Toggle switch';
+LargeToggleSwitch.args = {
+  sizing: 'lg',
+  label: 'large toggle switch',
+};

--- a/src/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch/ToggleSwitch.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps, FC, KeyboardEvent } from 'react';
 import { useId } from 'react';
 import { twMerge } from 'tailwind-merge';
-import type { DeepPartial, FlowbiteBoolean, FlowbiteColors } from '../../';
+import type { DeepPartial, FlowbiteBoolean, FlowbiteColors, FlowbiteTextInputSizes } from '../../';
 import { useTheme } from '../../';
 import { mergeDeep } from '../../helpers/merge-deep';
 
@@ -18,6 +18,7 @@ export interface FlowbiteToggleSwitchRootTheme {
 
 export interface FlowbiteToggleSwitchToggleTheme {
   base: string;
+  sizes: FlowbiteTextInputSizes;
   checked: FlowbiteBoolean & {
     color: FlowbiteColors;
   };
@@ -26,6 +27,7 @@ export interface FlowbiteToggleSwitchToggleTheme {
 export type ToggleSwitchProps = Omit<ComponentProps<'button'>, 'onChange'> & {
   checked: boolean;
   color?: keyof FlowbiteColors;
+  sizing?: keyof FlowbiteTextInputSizes;
   label?: string;
   onChange: (checked: boolean) => void;
   theme?: DeepPartial<FlowbiteToggleSwitchTheme>;
@@ -35,6 +37,7 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
   checked,
   className,
   color = 'blue',
+  sizing = 'md',
   disabled,
   label,
   name,
@@ -81,6 +84,7 @@ export const ToggleSwitch: FC<ToggleSwitchProps> = ({
             theme.toggle.base,
             theme.toggle.checked[checked ? 'on' : 'off'],
             checked && theme.toggle.checked.color[color],
+            theme.toggle.sizes[sizing],
           )}
         />
         {label?.length ? (

--- a/src/components/ToggleSwitch/theme.ts
+++ b/src/components/ToggleSwitch/theme.ts
@@ -10,7 +10,7 @@ export const toggleSwitchTheme: FlowbiteToggleSwitchTheme = {
     label: 'ml-3 text-sm font-medium text-gray-900 dark:text-gray-300',
   },
   toggle: {
-    base: 'toggle-bg h-6 w-11 rounded-full border group-focus:ring-4 group-focus:ring-cyan-500/25',
+    base: 'toggle-bg rounded-full border group-focus:ring-4 group-focus:ring-cyan-500/25',
     checked: {
       on: 'after:translate-x-full after:border-white',
       off: 'border-gray-200 bg-gray-200 dark:border-gray-600 dark:bg-gray-700',
@@ -33,6 +33,11 @@ export const toggleSwitchTheme: FlowbiteToggleSwitchTheme = {
         info: 'bg-cyan-600 border-cyan-600',
         pink: 'bg-pink-600 border-pink-600',
       },
+    },
+    sizes: {
+      sm: 'w-9 h-5 after:absolute after:top-[2px] after:left-[2px] after:h-4 after:w-4',
+      md: 'w-11 h-6 after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5',
+      lg: 'w-14 h-7 after:absolute after:top-0.5 after:left-[4px] after:h-6 after:w-6',
     },
   },
 };


### PR DESCRIPTION
- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

Sizing (sm|md|lg) for ToggleSwitch component
I added some storybook example for now. 
The examples will be on its own /docs/forms/toggleswitch page being worked on in #998.

Reference related issues using `#` followed by the issue number.

#998 

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.

added sizing prop. Not a breaking change. default is still md (which has class w-11 h-6 ...)
