### PR TITLE
fix: Floating Label theme import

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,4 +1,3 @@
-import { floatingLabelTheme } from '~/src/components/FloatingLabel/theme';
 import type { FlowbiteTheme } from '.';
 import { accordionTheme } from './components/Accordion/theme';
 import { alertTheme } from './components/Alert/theme';
@@ -13,6 +12,7 @@ import { darkThemeToggleTheme } from './components/DarkThemeToggle/theme';
 import { datePickerTheme } from './components/Datepicker/theme';
 import { dropdownTheme } from './components/Dropdown/theme';
 import { fileInputTheme } from './components/FileInput/theme';
+import { floatingLabelTheme } from './components/FloatingLabel/theme';
 import { footerTheme } from './components/Footer/theme';
 import { helperTextTheme } from './components/HelperText/theme';
 import { kbdTheme } from './components/Kbd/theme';


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.
I made an error in importing the FLoating Label Theme, when I developed the component, now I have fixed the import, and it should be working fine after this fix

Reference related issues using `#` followed by the issue number.
https://github.com/themesberg/flowbite-react/issues/1022


