### PR TITLE
docs: adds tab custom theme example

### DIFF
--- a/app/docs/components/tabs/index.tsx
+++ b/app/docs/components/tabs/index.tsx
@@ -3,17 +3,33 @@
 import type { FC } from 'react';
 import { useRef, useState } from 'react';
 import { DocsContentLayout } from '~/app/components/docs-content-layout';
-import type { TabsRef } from '~/src';
+import type { CustomFlowbiteTheme, TabsRef } from '~/src';
 import TabsDocs from './tabs.mdx';
 
 const TabsPage: FC = () => {
   const [activeTab, setActiveTab] = useState<number>(0);
   const tabsRef = useRef<TabsRef>(null);
 
+  const customTheme: CustomFlowbiteTheme['tab'] = {
+    tablist: {
+      tabitem: {
+        styles: {
+          default: {
+            active: {
+              on: 'bg-blue-100 text-blue-600 dark:bg-blue-800 dark:text-blue-500',
+              off: 'text-gray-500 hover:bg-blue-50 hover:text-blue-600 dark:text-blue-400 dark:hover:bg-blue-800  dark:hover:text-blue-300',
+            },
+          },
+        },
+      },
+    },
+  };
+
   const state = {
     activeTab,
     setActiveTab,
     tabsRef,
+    customTheme,
   };
 
   return (

--- a/app/docs/components/tabs/tabs.mdx
+++ b/app/docs/components/tabs/tabs.mdx
@@ -314,6 +314,42 @@ To learn more about how to customize the appearance of components, please see th
   <code>{JSON.stringify(theme.tab, null, 2)}</code>
 </pre>
 
+### Component theme example
+
+<CodePreview
+  githubPage="Tab/Tabs"
+  importExternal="import { HiAdjustments, HiClipboardList, HiUserCircle } from 'react-icons/hi';
+import { MdDashboard } from 'react-icons/md';"
+  importFlowbiteReact="Tabs"
+  title="Default tabs"
+>
+  <Tabs.Group theme={props.customTheme} aria-label="Default tabs" style="default">
+    <Tabs.Item active title="Profile" icon={HiUserCircle}>
+      This is <span className="font-medium text-gray-800 dark:text-white">Profile tab's associated content</span>.
+      Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to
+      control the content visibility and styling.
+    </Tabs.Item>
+    <Tabs.Item title="Dashboard" icon={MdDashboard}>
+      This is <span className="font-medium text-gray-800 dark:text-white">Dashboard tab's associated content</span>.
+      Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to
+      control the content visibility and styling.
+    </Tabs.Item>
+    <Tabs.Item title="Settings" icon={HiAdjustments}>
+      This is <span className="font-medium text-gray-800 dark:text-white">Settings tab's associated content</span>.
+      Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to
+      control the content visibility and styling.
+    </Tabs.Item>
+    <Tabs.Item title="Contacts" icon={HiClipboardList}>
+      This is <span className="font-medium text-gray-800 dark:text-white">Contacts tab's associated content</span>.
+      Clicking another tab will toggle the visibility of this one for the next. The tab JavaScript swaps classes to
+      control the content visibility and styling.
+    </Tabs.Item>
+    <Tabs.Item disabled title="Disabled">
+      Disabled content
+    </Tabs.Item>
+  </Tabs.Group>
+</CodePreview>
+
 ## References
 
 - [Flowbite Tabs](https://flowbite.com/docs/components/tabs/)


### PR DESCRIPTION
- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

I noticed that some people have no idea how to customize the component. So, I introduced a section to the documentation that kind of shows a practical example.

Check that "Tabs" component. :)