### PR TITLE
fix: fix getWeekDays function

### DIFF
--- a/src/components/Datepicker/helpers.ts
+++ b/src/components/Datepicker/helpers.ts
@@ -6,9 +6,13 @@ export enum Views {
 }
 
 export enum WeekStart {
-  Saturday = 0,
+  Saturday,
   Sunday,
   Monday,
+  Tuesday,
+  Wednesday,
+  Thursday,
+  Friday,
 }
 
 export const isDateInRange = (date: Date, minDate?: Date, maxDate?: Date): boolean => {
@@ -61,14 +65,13 @@ export const getFirstDayOfTheMonth = (date: Date, weekStart: WeekStart): Date =>
 
 export const getWeekDays = (lang: string, weekStart: WeekStart): string[] => {
   const weekdays: string[] = [];
-  const date = new Date();
+  const date = new Date(0);
 
   const formatter = new Intl.DateTimeFormat(lang, { weekday: 'short' });
 
   for (let i = 0; i < 7; i++) {
-    const dayIndex = (i + weekStart + 1) % 7; // Calculate the correct day index based on weekStart
-    date.setDate(dayIndex + 1);
-    const formattedWeekday = formatter.format(date);
+    const dayIndex = (i + weekStart + 1) % 7;
+    const formattedWeekday = formatter.format(addDays(date, dayIndex + 1));
     weekdays.push(formattedWeekday.slice(0, 2).charAt(0).toUpperCase() + formattedWeekday.slice(1, 3));
   }
 


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Fixed day suggestions in the top datepicker bar and added support for starting from any day of the week.

https://github.com/themesberg/flowbite-react/issues/1038

If you have ideas on how to simplify or improve it, please comment.

Before:
<img width="286" alt="Zrzut ekranu 2023-10-3 o 18 26 30" src="https://github.com/themesberg/flowbite-react/assets/86367246/7aecfa19-792f-4a95-bb08-ad4ca187e81e">

After:
![Zrzut ekranu 2023-10-3 o 19 37 47](https://github.com/themesberg/flowbite-react/assets/86367246/57fa6ade-75b7-4a04-b99c-a622a9a577c5)
