### PR TITLE
docs: fix broken blockquote link in components. Moved to Typography

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -262,7 +262,6 @@ const DocsSidebar: FC<DocsLayoutState> = ({ isCollapsed, setCollapsed }) => {
                         </Badge>
                       </span>
                     </SidebarLink>
-                    <SidebarLink href="/docs/components/blockquote">Blockquote</SidebarLink>
                     <SidebarLink href="/docs/components/breadcrumb">Breadcrumb</SidebarLink>
                     <SidebarLink href="/docs/components/button">Button</SidebarLink>
                     <SidebarLink href="/docs/components/button-group">Button group</SidebarLink>


### PR DESCRIPTION
- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

Remove /docs/components/blockquote link. It exists in /docs/typography/blockquote.

Reference related issues using `#` followed by the issue number.

Fixes #1049 

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.
