### PR TITLE
fix: layout overflow

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -54,13 +54,13 @@ const DocsLayout: NextPage<PropsWithChildren> = ({ children }) => {
 
   return (
     <Flowbite>
-      <div className="w-full min-w-0 flex-auto lg:static lg:max-h-full lg:overflow-visible">
-        <div className="relative max-h-screen w-full overflow-auto bg-white text-gray-600 antialiased dark:bg-gray-900 dark:text-gray-400">
+      <div className="w-full min-w-0 flex-auto">
+        <div className="relative bg-white text-gray-600 antialiased dark:bg-gray-900 dark:text-gray-400">
           <Banner />
           <DocsNavbar {...state} />
           <div className="lg:flex">
             <DocsSidebar {...state} />
-            <div className="w-full min-w-0 flex-auto lg:static lg:max-h-full lg:overflow-visible">
+            <div className="w-full min-w-0 flex-auto">
               <div className="flex w-full">
                 <div className="pb:12 mx-auto flex min-w-0 max-w-4xl flex-col divide-y divide-gray-200 px-4 pt-6 dark:divide-gray-800 lg:px-8 lg:pb-16 lg:pt-8 xl:pb-24">
                   <main>{children}</main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -64,14 +64,11 @@ export default function HomePageContent() {
 
   return (
     <Flowbite>
-      <div className="relative max-h-screen w-full overflow-auto bg-white text-gray-600 antialiased dark:bg-gray-900 dark:text-gray-400">
+      <div className="relative bg-white text-gray-600 antialiased dark:bg-gray-900 dark:text-gray-400">
         <Banner />
         <HomeNavbar />
         <div className="lg:flex">
-          <main
-            className="min-w-0 flex-auto divide-y dark:divide-gray-700 lg:static lg:max-h-full lg:overflow-visible"
-            ref={mainRef}
-          >
+          <main className="min-w-0 flex-auto divide-y dark:divide-gray-700" ref={mainRef}>
             <HeroSection />
             <FeaturedSection />
             <ComponentsSection />


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Currently the overflow container is isolated within a nested div, leading to inconsistent preservation of scroll on-page-reload.

### Changes

- [x] remove nested overflow values, allow it to be on `body` level

### Before

https://github.com/themesberg/flowbite-react/assets/41998826/afe7e2cf-2696-4ce6-bdce-a22a22b1ffc0

### After

https://github.com/themesberg/flowbite-react/assets/41998826/50b6d5f0-0a71-400c-b9f7-8306a8b9b2c1

