### PR TITLE
fix: docs navbar - incorrect code preview

### DIFF
--- a/app/docs/components/navbar/navbar.mdx
+++ b/app/docs/components/navbar/navbar.mdx
@@ -24,7 +24,27 @@ Use the default navbar component to showcase the logo and a list of menu items w
 
 On mobile device the navigation bar will be collapsed and you will be able to use the hamburger menu to toggle the menu items by adding the `<Navbar.Toggle>` component.
 
-<CodePreview title="Default navbar">
+<CodePreview
+  title="Default navbar"
+  code={`<Navbar fluid rounded>
+  <Navbar.Brand as={Link} href="https://flowbite-react.com">
+    <img src="/favicon.svg" className="mr-3 h-6 sm:h-9" alt="Flowbite React Logo" />
+    <span className="self-center whitespace-nowrap text-xl font-semibold dark:text-white">Flowbite React</span>
+  </Navbar.Brand>
+  <Navbar.Toggle />
+  <Navbar.Collapse>
+    <Navbar.Link href="#" active>
+      Home
+    </Navbar.Link>
+    <Navbar.Link as={Link} href="#">
+      About
+    </Navbar.Link>
+    <Navbar.Link href="#">Services</Navbar.Link>
+    <Navbar.Link href="#">Pricing</Navbar.Link>
+    <Navbar.Link href="#">Contact</Navbar.Link>
+  </Navbar.Collapse>
+</Navbar>`}
+>
   <Navbar fluid rounded>
     <Navbar.Brand as={Link} href="https://flowbite-react.com">
       <img src="/favicon.svg" className="mr-3 h-6 sm:h-9" alt="Flowbite React Logo" />
@@ -49,7 +69,29 @@ On mobile device the navigation bar will be collapsed and you will be able to us
 
 Use this example to show a CTA button inside the navbar component for marketing advantages and to increase the conversion rate of your website.
 
-<CodePreview importFlowbiteReact="Button, Navbar" title="Navbar with CTA button">
+<CodePreview
+  importFlowbiteReact="Button, Navbar"
+  title="Navbar with CTA button"
+  code={`<Navbar fluid rounded>
+  <Navbar.Brand href="https://flowbite-react.com">
+    <img src="/favicon.svg" className="mr-3 h-6 sm:h-9" alt="Flowbite React Logo" />
+    <span className="self-center whitespace-nowrap text-xl font-semibold dark:text-white">Flowbite React</span>
+  </Navbar.Brand>
+  <div className="flex md:order-2">
+    <Button>Get started</Button>
+    <Navbar.Toggle />
+  </div>
+  <Navbar.Collapse>
+    <Navbar.Link href="#" active>
+      Home
+    </Navbar.Link>
+    <Navbar.Link href="#">About</Navbar.Link>
+    <Navbar.Link href="#">Services</Navbar.Link>
+    <Navbar.Link href="#">Pricing</Navbar.Link>
+    <Navbar.Link href="#">Contact</Navbar.Link>
+  </Navbar.Collapse>
+</Navbar>`}
+>
   <Navbar fluid rounded>
     <Navbar.Brand href="https://flowbite-react.com">
       <img src="/favicon.svg" className="mr-3 h-6 sm:h-9" alt="Flowbite React Logo" />
@@ -75,7 +117,45 @@ Use this example to show a CTA button inside the navbar component for marketing 
 
 Use this example to feature a dropdown menu when clicking on the user avatar inside the navbar by importing the `<Avatar>` and `<Dropdown>` components.
 
-<CodePreview importFlowbiteReact="Dropdown, Navbar" title="Navbar with dropdown">
+<CodePreview
+  importFlowbiteReact="Dropdown, Navbar"
+  title="Navbar with dropdown"
+  code={`<Navbar fluid rounded>
+  <Navbar.Brand href="https://flowbite-react.com">
+    <img src="/favicon.svg" className="mr-3 h-6 sm:h-9" alt="Flowbite React Logo" />
+    <span className="self-center whitespace-nowrap text-xl font-semibold dark:text-white">Flowbite React</span>
+  </Navbar.Brand>
+  <div className="flex md:order-2">
+    <Dropdown
+      arrowIcon={false}
+      inline
+      label={
+        <Avatar alt="User settings" img="https://flowbite.com/docs/images/people/profile-picture-5.jpg" rounded />
+      }
+    >
+      <Dropdown.Header>
+        <span className="block text-sm">Bonnie Green</span>
+        <span className="block truncate text-sm font-medium">name@flowbite.com</span>
+      </Dropdown.Header>
+      <Dropdown.Item>Dashboard</Dropdown.Item>
+      <Dropdown.Item>Settings</Dropdown.Item>
+      <Dropdown.Item>Earnings</Dropdown.Item>
+      <Dropdown.Divider />
+      <Dropdown.Item>Sign out</Dropdown.Item>
+    </Dropdown>
+    <Navbar.Toggle />
+  </div>
+  <Navbar.Collapse>
+    <Navbar.Link href="#" active>
+      Home
+    </Navbar.Link>
+    <Navbar.Link href="#">About</Navbar.Link>
+    <Navbar.Link href="#">Services</Navbar.Link>
+    <Navbar.Link href="#">Pricing</Navbar.Link>
+    <Navbar.Link href="#">Contact</Navbar.Link>
+  </Navbar.Collapse>
+</Navbar>`}
+>
   <Navbar fluid rounded>
     <Navbar.Brand href="https://flowbite-react.com">
       <img src="/favicon.svg" className="mr-3 h-6 sm:h-9" alt="Flowbite React Logo" />


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Docs `Navbar` shows incorrect code preview.

### Before
<img width="859" alt="Screenshot 2023-10-12 at 14 15 55" src="https://github.com/themesberg/flowbite-react/assets/41998826/c0e1d8a7-7b8b-49c6-8e4b-7201d7b33300">

### After
<img width="886" alt="Screenshot 2023-10-12 at 14 16 04" src="https://github.com/themesberg/flowbite-react/assets/41998826/1336471e-0008-4c9a-827d-2552af74d135">
