### PR TITLE
fix: dropdown theme - granular control

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ExtendedRefs, useInteractions } from '@floating-ui/react';
+import type { ExtendedRefs } from '@floating-ui/react';
 import { FloatingFocusManager, FloatingList, useListNavigation, useTypeahead } from '@floating-ui/react';
 import type {
   ComponentProps,
@@ -14,22 +14,19 @@ import type {
   RefCallback,
   SetStateAction,
 } from 'react';
-import { cloneElement, createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { cloneElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { HiOutlineChevronDown, HiOutlineChevronLeft, HiOutlineChevronRight, HiOutlineChevronUp } from 'react-icons/hi';
 import { twMerge } from 'tailwind-merge';
 import { mergeDeep } from '../../helpers/merge-deep';
 import { useBaseFLoating, useFloatingInteractions } from '../../helpers/use-floating';
 import { getTheme } from '../../theme-store';
 import type { DeepPartial } from '../../types';
-import type { ButtonProps } from '../Button';
-import { Button } from '../Button';
+import { Button, type ButtonProps } from '../Button';
 import type { FloatingProps, FlowbiteFloatingTheme } from '../Floating';
-import type { FlowbiteDropdownDividerTheme } from './DropdownDivider';
-import { DropdownDivider } from './DropdownDivider';
-import type { FlowbiteDropdownHeaderTheme } from './DropdownHeader';
-import { DropdownHeader } from './DropdownHeader';
-import type { FlowbiteDropdownItemTheme } from './DropdownItem';
-import { DropdownItem } from './DropdownItem';
+import { DropdownContext } from './DropdownContext';
+import { DropdownDivider, type FlowbiteDropdownDividerTheme } from './DropdownDivider';
+import { DropdownHeader, type FlowbiteDropdownHeaderTheme } from './DropdownHeader';
+import { DropdownItem, type FlowbiteDropdownItemTheme } from './DropdownItem';
 
 export interface FlowbiteDropdownFloatingTheme
   extends FlowbiteFloatingTheme,
@@ -116,15 +113,6 @@ const Trigger = ({
     </Button>
   );
 };
-
-interface DropdownContextValue {
-  activeIndex: number | null;
-  dismissOnClick?: boolean;
-  getItemProps: ReturnType<typeof useInteractions>['getItemProps'];
-  handleSelect: (index: number | null) => void;
-}
-
-export const DropdownContext = createContext<DropdownContextValue>({} as DropdownContextValue);
 
 const DropdownComponent: FC<DropdownProps> = ({
   children,
@@ -219,6 +207,7 @@ const DropdownComponent: FC<DropdownProps> = ({
       </Trigger>
       <DropdownContext.Provider
         value={{
+          theme,
           activeIndex,
           dismissOnClick,
           getItemProps,

--- a/src/components/Dropdown/DropdownContext.tsx
+++ b/src/components/Dropdown/DropdownContext.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import type { useInteractions } from '@floating-ui/react';
+import { createContext, useContext } from 'react';
+import type { DeepPartial } from '../../types';
+import type { FlowbiteDropdownTheme } from './Dropdown';
+
+type DropdownContext = {
+  theme?: DeepPartial<FlowbiteDropdownTheme>;
+  activeIndex: number | null;
+  dismissOnClick?: boolean;
+  getItemProps: ReturnType<typeof useInteractions>['getItemProps'];
+  handleSelect: (index: number | null) => void;
+};
+
+export const DropdownContext = createContext<DropdownContext | undefined>(undefined);
+
+export function useDropdownContext(): DropdownContext {
+  const context = useContext(DropdownContext);
+
+  if (!context) {
+    throw new Error('useDropdownContext should be used within the DropdownContext provider!');
+  }
+
+  return context;
+}

--- a/src/components/Dropdown/DropdownDivider.tsx
+++ b/src/components/Dropdown/DropdownDivider.tsx
@@ -1,13 +1,22 @@
+'use client';
+
 import type { ComponentProps, FC } from 'react';
 import { twMerge } from 'tailwind-merge';
-import { getTheme } from '../../theme-store';
+import type { DeepPartial } from '../../types';
+import { useDropdownContext } from './DropdownContext';
 
 export interface FlowbiteDropdownDividerTheme {
   divider: string;
 }
 
-export const DropdownDivider: FC<ComponentProps<'div'>> = ({ className, ...props }) => {
-  const theme = getTheme().dropdown.floating.divider;
+export type DropdownDividerProps = {
+  theme?: DeepPartial<FlowbiteDropdownDividerTheme>;
+} & ComponentProps<'div'>;
+
+export const DropdownDivider: FC<DropdownDividerProps> = ({ className, theme: customTheme = {}, ...props }) => {
+  const { theme: dropdownTheme } = useDropdownContext();
+
+  const theme = customTheme.divider ?? dropdownTheme?.floating?.divider;
 
   return <div className={twMerge(theme, className)} {...props} />;
 };

--- a/src/components/Dropdown/DropdownHeader.tsx
+++ b/src/components/Dropdown/DropdownHeader.tsx
@@ -1,14 +1,24 @@
+'use client';
+
 import type { ComponentProps, FC, PropsWithChildren } from 'react';
 import { twMerge } from 'tailwind-merge';
-import { getTheme } from '../../theme-store';
+import type { DeepPartial } from '../../types';
+import { useDropdownContext } from './DropdownContext';
 import { DropdownDivider } from './DropdownDivider';
 
 export interface FlowbiteDropdownHeaderTheme {
   header: string;
 }
 
-export const DropdownHeader: FC<PropsWithChildren & ComponentProps<'div'>> = ({ children, className, ...props }) => {
-  const theme = getTheme().dropdown.floating.header;
+export type DropdownHeaderProps = {
+  theme?: DeepPartial<FlowbiteDropdownHeaderTheme>;
+} & PropsWithChildren &
+  ComponentProps<'div'>;
+
+export const DropdownHeader: FC<DropdownHeaderProps> = ({ children, className, theme: customTheme = {}, ...props }) => {
+  const { theme: dropdownTheme } = useDropdownContext();
+
+  const theme = customTheme.header ?? dropdownTheme?.floating?.header;
 
   return (
     <>

--- a/src/components/Dropdown/DropdownItem.tsx
+++ b/src/components/Dropdown/DropdownItem.tsx
@@ -2,14 +2,11 @@
 
 import { useListItem } from '@floating-ui/react';
 import type { ComponentProps, ComponentPropsWithoutRef, ElementType, FC, RefCallback } from 'react';
-import { useContext } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { mergeDeep } from '../../helpers/merge-deep';
-import { getTheme } from '../../theme-store';
 import type { DeepPartial } from '../../types';
-import type { ButtonBaseProps } from '../Button/ButtonBase';
-import { ButtonBase } from '../Button/ButtonBase';
-import { DropdownContext } from './Dropdown';
+import { ButtonBase, type ButtonBaseProps } from '../Button/ButtonBase';
+import { useDropdownContext } from './DropdownContext';
 
 export interface FlowbiteDropdownItemTheme {
   container: string;
@@ -34,9 +31,9 @@ export const DropdownItem = <T extends ElementType = 'button'>({
   ...props
 }: DropdownItemProps<T>) => {
   const { ref, index } = useListItem({ label: typeof children === 'string' ? children : undefined });
-  const { activeIndex, dismissOnClick, getItemProps, handleSelect } = useContext(DropdownContext);
+  const { theme: dropdownTheme, activeIndex, dismissOnClick, getItemProps, handleSelect } = useDropdownContext();
   const isActive = activeIndex === index;
-  const theme = mergeDeep(getTheme().dropdown.floating.item, customTheme);
+  const theme = mergeDeep(dropdownTheme?.floating?.item ?? {}, customTheme);
 
   const theirProps = props as ButtonBaseProps<T>;
 


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

`Dropdown` is missing granular control over the theme object.

### Issue
#1060

### Changes

- [x] pass down merged root `theme` object from `Dropdown` through `DropdownContext`
- [x] add `theme` prop to `DropdownHeader` and override default styles (coming from `Dropdown` theme object)
- [x] add `theme` prop to `DropdownDivider` and override default styles (coming from `Dropdown` theme object)
- [x] override default to `DropdownItem`

### API changes
- `DropdownHeader` and `DropdownDivider` now accept `theme` object as well

### Code

<img width="695" alt="Screenshot 2023-10-13 at 11 15 40" src="https://github.com/themesberg/flowbite-react/assets/41998826/71459761-2d56-4721-b0d4-9acaa69f82f4">

### Before

<img width="1384" alt="Screenshot 2023-10-13 at 11 16 40" src="https://github.com/themesberg/flowbite-react/assets/41998826/8e0800a6-7e49-4ad5-91ff-b2741616ad6e">

### After

<img width="1236" alt="Screenshot 2023-10-13 at 11 14 33" src="https://github.com/themesberg/flowbite-react/assets/41998826/a6544a03-b5cb-42ef-9ad1-041e7906b5bd">
<img width="1236" alt="Screenshot 2023-10-13 at 11 14 39" src="https://github.com/themesberg/flowbite-react/assets/41998826/ab8543ec-8810-424c-8ed1-e46a35c26cba">
