### PR TITLE
docs(component): fix broken link to progress bar GitHub docs in READM…

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ If you want to contribute to Flowbite React, you can follow the [contributing gu
   </tr>
   <tr>
   <td width="33.3333%">
-        <a href="https://flowbite-react.com/docs/components/progress-bar">
+        <a href="https://www.flowbite-react.com/docs/components/progress">
             <img alt="React Progress bar" src="https://flowbite.s3.amazonaws.com/github/progress.jpg">
         </a>
     </td>


### PR DESCRIPTION
…E.md

Fix broken link to progress bar github documentation in README.md. The previous link was pointing to [https://flowbite-react.com/docs/components/progress-bar], but now it points to the correct URL: [https://www.flowbite-react.com/docs/components/progress].

- [ ] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

I was going to use the Progress Bar & refered to that component's link in the github docs only to find it was a broken 404 link.

Reference related issues using `#` followed by the issue number.

N/A

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.

N/A