### PR TITLE
fix: homepage dark mode `Floating Label` - missing svg

### DIFF
--- a/public/images/components/floating-label-dark.svg
+++ b/public/images/components/floating-label-dark.svg
@@ -1,0 +1,11 @@
+<svg width="284" height="200" viewBox="0 0 284 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="2.5" width="283" height="47" rx="7.5" stroke="#6B7280"/>
+<path d="M0 85C0 80.5817 3.58172 77 8 77H276C280.418 77 284 80.5817 284 85V125H0V85Z" fill="#374151"/>
+<rect y="77" width="284" height="48" rx="8" fill="#374151"/>
+<rect x="12" y="81" width="59" height="6" rx="2" fill="#1C64F2"/>
+<rect y="123" width="284" height="2" fill="#4B5563"/>
+<rect y="152" width="59" height="6" rx="2" fill="#1C64F2"/>
+<rect y="198" width="284" height="2" fill="#4B5563"/>
+<rect width="73" height="6" transform="translate(16)" fill="#111928"/>
+<rect x="24" width="57" height="6" rx="2" fill="#1C64F2"/>
+</svg>


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Homage `Floating Label` card is missing `.svg` image in dark mode.

### Before

https://github.com/themesberg/flowbite-react/assets/41998826/6e7dd0e6-133d-464a-bac2-a6cdd52ef488

### After

https://github.com/themesberg/flowbite-react/assets/41998826/6fbd2610-a6b2-4de2-b957-552576459dee

