### PR TITLE
feat(dropdownitems): add DropdownItemCheckbox and DropdownItemRadio

### DIFF
--- a/content/docs/components/dropdown.mdx
+++ b/content/docs/components/dropdown.mdx
@@ -37,6 +37,23 @@ Add custom icons next to the menu items by using the `icon` prop on the `<Dropdo
 
 <Example name="dropdown.itemsWithIcon" />
 
+## Dropdown items with radio input
+
+Add radio items to the dropdown with `<Dropdown.ItemRadio>` component.
+`<Dropdown.ItemRadio>` accepts a ref that will be passed to the underlying `Radio` component's input element.
+`<Dropdown.ItemRadio>` components with the same `name` prop will be treated as a radio group.
+Optionally pass `dismissOnClick={false}` to the parent `Dropdown` to keep the dropdown open after a radio is toggled.
+
+<Example name="dropdown.itemRadio" />
+
+## Dropdown items with checkbox input
+
+Add checkbox items to the dropdown with `<Dropdown.ItemCheckbox>` component.
+`<Dropdown.ItemCheckbox>` accepts a ref that will be passed to the underlying `Checkbox` component's input element.
+Optionally pass `dismissOnClick={false}` to the parent `Dropdown` to keep the dropdown open after a checkbox is checked.
+
+<Example name="dropdown.itemCheckbox" />
+
 ## Inline dropdown
 
 Use the `inline` prop to make the dropdown appear inline with the trigger element.

--- a/examples/dropdown/dropdown.itemCheckbox.tsx
+++ b/examples/dropdown/dropdown.itemCheckbox.tsx
@@ -1,0 +1,47 @@
+import { type CodeData } from '~/components/code-demo';
+import { Dropdown } from '~/src';
+
+const code = `
+'use client';
+
+import { Dropdown } from 'flowbite-react';
+
+function Component() {
+  return (
+    <Dropdown dismissOnClick={false} label="Dropdown checkboxes">
+        <Dropdown.Header>
+          <span className="block text-sm">Accomodation Type</span>
+        </Dropdown.Header>
+        <Dropdown.ItemCheckbox label="apartment">Apartment</Dropdown.ItemCheckbox>
+        <Dropdown.ItemCheckbox label="house">House</Dropdown.ItemCheckbox>
+        <Dropdown.ItemCheckbox label="hotel">Hotel</Dropdown.ItemCheckbox>
+    </Dropdown>
+  );
+}
+`;
+
+function Component() {
+  return (
+    <Dropdown dismissOnClick={false} label="Dropdown checkboxes">
+      <Dropdown.Header>
+        <span className="block text-sm">Accomodation Type</span>
+      </Dropdown.Header>
+      <Dropdown.ItemCheckbox label="apartment">Apartment</Dropdown.ItemCheckbox>
+      <Dropdown.ItemCheckbox label="house">House</Dropdown.ItemCheckbox>
+      <Dropdown.ItemCheckbox label="hotel">Hotel</Dropdown.ItemCheckbox>
+    </Dropdown>
+  );
+}
+
+export const checkboxItem: CodeData = {
+  type: 'single',
+  code: [
+    {
+      fileName: 'client',
+      language: 'tsx',
+      code,
+    },
+  ],
+  githubSlug: 'dropdown/dropdown.itemCheckbox.tsx',
+  component: <Component />,
+};

--- a/examples/dropdown/dropdown.itemRadio.tsx
+++ b/examples/dropdown/dropdown.itemRadio.tsx
@@ -1,0 +1,65 @@
+import { type CodeData } from '~/components/code-demo';
+import { Dropdown } from '~/src';
+
+const code = `
+'use client';
+
+import { Dropdown } from 'flowbite-react';
+
+function Component() {
+  return (
+    <Dropdown dismissOnClick={false} label="Dropdown radios">
+      <Dropdown.Header>
+        <span className="block text-sm">Select City</span>
+      </Dropdown.Header>
+      <Dropdown.ItemRadio label="berlin" name="city">
+        Berlin
+      </Dropdown.ItemRadio>
+      <Dropdown.ItemRadio label="chicago" name="city">
+        Chicago
+      </Dropdown.ItemRadio>
+      <Dropdown.ItemRadio label="lagos" name="city">
+        Lagos
+      </Dropdown.ItemRadio>
+      <Dropdown.ItemRadio label="tokyo" name="city">
+        Tokyo
+      </Dropdown.ItemRadio>
+    </Dropdown>
+  );
+}
+`;
+
+function Component() {
+  return (
+    <Dropdown dismissOnClick={false} label="Dropdown radios">
+      <Dropdown.Header>
+        <span className="block text-sm">Select City</span>
+      </Dropdown.Header>
+      <Dropdown.ItemRadio label="berlin" name="city">
+        Berlin
+      </Dropdown.ItemRadio>
+      <Dropdown.ItemRadio label="chicago" name="city">
+        Chicago
+      </Dropdown.ItemRadio>
+      <Dropdown.ItemRadio label="lagos" name="city">
+        Lagos
+      </Dropdown.ItemRadio>
+      <Dropdown.ItemRadio label="tokyo" name="city">
+        Tokyo
+      </Dropdown.ItemRadio>
+    </Dropdown>
+  );
+}
+
+export const checkboxItem: CodeData = {
+  type: 'single',
+  code: [
+    {
+      fileName: 'client',
+      language: 'tsx',
+      code,
+    },
+  ],
+  githubSlug: 'dropdown/dropdown.itemRadio.tsx',
+  component: <Component />,
+};

--- a/src/components/Dropdown/Dropdown.spec.tsx
+++ b/src/components/Dropdown/Dropdown.spec.tsx
@@ -186,6 +186,50 @@ describe('Components / Dropdown', () => {
       expect(screen.getByRole('link')).toBe(item);
     });
   });
+
+  describe('Dropdown item radio', async () => {
+    it('should toggle radio item to checked when clicked', async () => {
+      const user = userEvent.setup();
+      render(<TestDropdownInputs dismissOnClick={false} />);
+
+      await act(() => user.click(button()));
+      expect(screen.getByRole('radio', { name: 'Berlin' })).not.toBeChecked();
+      await act(() => userEvent.click(screen.getByText('Berlin')));
+
+      expect(screen.getByRole('radio', { name: 'Berlin' })).toBeChecked();
+    });
+
+    it('should toggle radio when another radio in group in checked', async () => {
+      const user = userEvent.setup();
+      render(<TestDropdownInputs dismissOnClick={false} />);
+
+      await act(() => user.click(button()));
+      expect(screen.getByRole('radio', { name: 'Berlin' })).not.toBeChecked();
+      await act(() => userEvent.click(screen.getByText('Berlin')));
+
+      expect(screen.getByRole('radio', { name: 'Berlin' })).toBeChecked();
+      await act(() => userEvent.click(screen.getByText('Tokyo')));
+      expect(screen.getByRole('radio', { name: 'Berlin' })).not.toBeChecked();
+      expect(screen.getByRole('radio', { name: 'Tokyo' })).toBeChecked();
+    });
+  });
+
+  describe('Dropdown item checkbox', async () => {
+    it('should toggle checkbox item to checked/unchecked when clicked', async () => {
+      const user = userEvent.setup();
+      render(<TestDropdownInputs dismissOnClick={false} />);
+
+      await act(() => user.click(button()));
+      expect(dropdown()).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'House' })).not.toBeChecked();
+
+      await act(() => userEvent.click(screen.getByText('House')));
+      expect(screen.getByRole('checkbox', { name: 'House' })).toBeChecked();
+
+      await act(() => userEvent.click(screen.getByText('House')));
+      expect(screen.getByRole('checkbox', { name: 'House' })).not.toBeChecked();
+    });
+  });
 });
 
 const TestDropdown: FC<Partial<DropdownProps>> = ({
@@ -213,6 +257,44 @@ const TestDropdown: FC<Partial<DropdownProps>> = ({
     <Dropdown.Item>Earnings</Dropdown.Item>
     <Dropdown.Divider />
     <Dropdown.Item>Sign out</Dropdown.Item>
+  </Dropdown>
+);
+
+const TestDropdownInputs: FC<Partial<DropdownProps>> = ({
+  dismissOnClick = false,
+  inline = false,
+  disabled,
+  trigger,
+  renderTrigger,
+}) => (
+  <Dropdown
+    label="Dropdown button"
+    placement="right"
+    dismissOnClick={dismissOnClick}
+    inline={inline}
+    trigger={trigger}
+    disabled={disabled}
+    renderTrigger={renderTrigger}
+  >
+    <Dropdown.Header>
+      <span className="block text-sm">Select City</span>
+    </Dropdown.Header>
+    <Dropdown.ItemRadio label="berlin" name="city">
+      Berlin
+    </Dropdown.ItemRadio>
+    <Dropdown.ItemRadio label="chicago" name="city">
+      Chicago
+    </Dropdown.ItemRadio>
+    <Dropdown.ItemRadio label="lagos" name="city">
+      Lagos
+    </Dropdown.ItemRadio>
+    <Dropdown.ItemRadio label="tokyo" name="city">
+      Tokyo
+    </Dropdown.ItemRadio>
+    <Dropdown.Divider />
+    <Dropdown.ItemCheckbox label="apartment">Apartment</Dropdown.ItemCheckbox>
+    <Dropdown.ItemCheckbox label="house">House</Dropdown.ItemCheckbox>
+    <Dropdown.ItemCheckbox label="hotel">Hotel</Dropdown.ItemCheckbox>
   </Dropdown>
 );
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -26,6 +26,8 @@ import { DropdownContext } from './DropdownContext';
 import { DropdownDivider, type FlowbiteDropdownDividerTheme } from './DropdownDivider';
 import { DropdownHeader, type FlowbiteDropdownHeaderTheme } from './DropdownHeader';
 import { DropdownItem, type FlowbiteDropdownItemTheme } from './DropdownItem';
+import { DropdownItemCheckbox } from './DropdownItemCheckbox';
+import { DropdownItemRadio } from './DropdownItemRadio';
 
 export interface FlowbiteDropdownFloatingTheme
   extends FlowbiteFloatingTheme,
@@ -50,6 +52,13 @@ export interface DropdownProps extends Pick<FloatingProps, 'placement' | 'trigge
   theme?: DeepPartial<FlowbiteDropdownTheme>;
   renderTrigger?: (theme: FlowbiteDropdownTheme) => ReactElement;
   'data-testid'?: string;
+}
+
+type RadioGroupId = string;
+
+export interface DropdownInputsState {
+  radios: { [key: RadioGroupId]: string | null };
+  checkboxes: string[];
 }
 
 const icons: Record<string, FC<ComponentProps<'svg'>>> = {
@@ -121,6 +130,13 @@ const DropdownComponent: FC<DropdownProps> = ({
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [checkedInputs, setCheckedInputs] = useState<{
+    radios: { [key: string]: string | null };
+    checkboxes: string[];
+  }>({
+    radios: {},
+    checkboxes: [],
+  });
   const [buttonWidth, setButtonWidth] = useState<number | undefined>(undefined);
   const elementsRef = useRef<Array<HTMLElement | null>>([]);
   const labelsRef = useRef<Array<string | null>>([]);
@@ -137,10 +153,13 @@ const DropdownComponent: FC<DropdownProps> = ({
     ...buttonProps
   } = theirProps;
 
-  const handleSelect = useCallback((index: number | null) => {
-    setSelectedIndex(index);
-    setOpen(false);
-  }, []);
+  const handleSelect = useCallback(
+    (index: number | null) => {
+      dismissOnClick ? setSelectedIndex(null) : setSelectedIndex(index);
+      dismissOnClick && setOpen(false);
+    },
+    [dismissOnClick],
+  );
 
   const handleTypeaheadMatch = useCallback(
     (index: number | null) => {
@@ -186,7 +205,17 @@ const DropdownComponent: FC<DropdownProps> = ({
   }, [placement]);
 
   return (
-    <DropdownContext.Provider value={{ theme, activeIndex, dismissOnClick, getItemProps, handleSelect }}>
+    <DropdownContext.Provider
+      value={{
+        theme,
+        activeIndex,
+        dismissOnClick,
+        getItemProps,
+        checkedInputs,
+        setCheckedInputs,
+        handleSelect,
+      }}
+    >
       <Trigger
         {...buttonProps}
         refs={refs}
@@ -237,6 +266,8 @@ DropdownDivider.displayName = 'Dropdown.Divider';
 
 export const Dropdown = Object.assign(DropdownComponent, {
   Item: DropdownItem,
+  ItemCheckbox: DropdownItemCheckbox,
+  ItemRadio: DropdownItemRadio,
   Header: DropdownHeader,
   Divider: DropdownDivider,
 });

--- a/src/components/Dropdown/DropdownContext.tsx
+++ b/src/components/Dropdown/DropdownContext.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import type { useInteractions } from '@floating-ui/react';
+import type { Dispatch, SetStateAction } from 'react';
 import { createContext, useContext } from 'react';
-import type { FlowbiteDropdownTheme } from './Dropdown';
+import type { DropdownInputsState, FlowbiteDropdownTheme } from './Dropdown';
 
 type DropdownContext = {
   theme: FlowbiteDropdownTheme;
   activeIndex: number | null;
   dismissOnClick?: boolean;
   getItemProps: ReturnType<typeof useInteractions>['getItemProps'];
+  checkedInputs: DropdownInputsState;
+  setCheckedInputs: Dispatch<SetStateAction<DropdownInputsState>>;
   handleSelect: (index: number | null) => void;
 };
 

--- a/src/components/Dropdown/DropdownItem.tsx
+++ b/src/components/Dropdown/DropdownItem.tsx
@@ -12,6 +12,7 @@ export interface FlowbiteDropdownItemTheme {
   container: string;
   base: string;
   icon: string;
+  input: string;
 }
 
 export type DropdownItemProps<T extends ElementType = 'button'> = {

--- a/src/components/Dropdown/DropdownItemCheckbox.tsx
+++ b/src/components/Dropdown/DropdownItemCheckbox.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useListItem } from '@floating-ui/react';
+import type { ComponentProps, ComponentPropsWithoutRef, ElementType, FC, Ref, RefCallback } from 'react';
+import { forwardRef, useCallback } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { mergeDeep } from '../../helpers/merge-deep';
+import { getTheme } from '../../theme-store';
+import type { DeepPartial } from '../../types';
+import type { ButtonBaseProps } from '../Button/ButtonBase';
+import { ButtonBase } from '../Button/ButtonBase';
+import { Checkbox } from '../Checkbox/Checkbox';
+import { useDropdownContext } from './DropdownContext';
+import type { FlowbiteDropdownItemTheme } from './DropdownItem';
+
+export type DropdownItemCheckboxProps<T extends ElementType = 'button'> = {
+  label: string;
+  value?: string;
+  name?: string;
+  icon?: FC<ComponentProps<'svg'>>;
+  onClick?: () => void;
+  theme?: DeepPartial<FlowbiteDropdownItemTheme>;
+} & ComponentPropsWithoutRef<T>;
+
+export const DropdownItemCheckbox = forwardRef(function DropdownItemCheckBox<T extends ElementType = 'button'>(
+  {
+    label,
+    value,
+    name,
+    children,
+    className,
+    icon: Icon,
+    onClick,
+    theme: customTheme = {},
+    ...props
+  }: DropdownItemCheckboxProps<T>,
+  inputRef: Ref<HTMLInputElement>,
+) {
+  const { ref, index } = useListItem({
+    label: typeof children === 'string' ? children : undefined,
+  });
+  const { activeIndex, checkedInputs, setCheckedInputs, getItemProps, handleSelect } = useDropdownContext();
+  const inputId = label + index;
+  const isActive = activeIndex === index;
+  const isChecked = checkedInputs.checkboxes.includes(inputId);
+  const theme = mergeDeep(getTheme().dropdown.floating.item, customTheme);
+
+  const theirProps = props as ButtonBaseProps<T>;
+
+  const handleCheckboxSelect = useCallback(
+    (index: number | null, inputId: string) => {
+      setCheckedInputs((prev) => {
+        return prev.checkboxes.includes(inputId)
+          ? {
+              ...prev,
+              checkboxes: prev.checkboxes.filter((item) => item !== inputId),
+            }
+          : { ...prev, checkboxes: [...prev.checkboxes, inputId] };
+      });
+
+      handleSelect(index);
+    },
+    [handleSelect, setCheckedInputs],
+  );
+
+  return (
+    <li role="menuitem" className={theme.container}>
+      <label htmlFor={inputId}>
+        <ButtonBase
+          ref={ref as RefCallback<T>}
+          className={twMerge(theme.base, className)}
+          {...theirProps}
+          {...getItemProps({
+            onClick: () => {
+              onClick && onClick();
+              handleCheckboxSelect(index, inputId);
+            },
+          })}
+          tabIndex={isActive ? 0 : -1}
+        >
+          <Checkbox
+            ref={inputRef}
+            checked={isChecked}
+            value={value || label}
+            name={name}
+            id={inputId}
+            onChange={() => null}
+            className={theme.input}
+          />
+          {Icon && <Icon className={theme.icon} />}
+          {children ? children : label}
+        </ButtonBase>
+      </label>
+    </li>
+  );
+});

--- a/src/components/Dropdown/DropdownItemRadio.tsx
+++ b/src/components/Dropdown/DropdownItemRadio.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useListItem } from '@floating-ui/react';
+import type { ComponentProps, ComponentPropsWithoutRef, ElementType, FC, Ref, RefCallback } from 'react';
+import { forwardRef, useCallback } from 'react';
+import { twMerge } from 'tailwind-merge';
+import { mergeDeep } from '../../helpers/merge-deep';
+import { getTheme } from '../../theme-store';
+import type { DeepPartial } from '../../types';
+import type { ButtonBaseProps } from '../Button/ButtonBase';
+import { ButtonBase } from '../Button/ButtonBase';
+import { Radio } from '../Radio/Radio';
+import { useDropdownContext } from './DropdownContext';
+import type { FlowbiteDropdownItemTheme } from './DropdownItem';
+
+export type DropdownItemRadioProps<T extends ElementType = 'button'> = {
+  label: string;
+  value?: string;
+  name?: string;
+  icon?: FC<ComponentProps<'svg'>>;
+  onClick?: () => void;
+  theme?: DeepPartial<FlowbiteDropdownItemTheme>;
+} & ComponentPropsWithoutRef<T>;
+
+export const DropdownItemRadio = forwardRef(function DropdownItemRadio<T extends ElementType = 'button'>(
+  {
+    label,
+    value,
+    name = 'radiogroup',
+    children,
+    className,
+    icon: Icon,
+    onClick,
+    theme: customTheme = {},
+    ...props
+  }: DropdownItemRadioProps<T>,
+  inputRef: Ref<HTMLInputElement>,
+) {
+  const { ref, index } = useListItem({
+    label: typeof children === 'string' ? children : undefined,
+  });
+  const { activeIndex, checkedInputs, setCheckedInputs, getItemProps, handleSelect } = useDropdownContext();
+  const inputId = label + index;
+  const isActive = activeIndex === index;
+  const isChecked = checkedInputs.radios[name] === inputId;
+  const theme = mergeDeep(getTheme().dropdown.floating.item, customTheme);
+
+  const theirProps = props as ButtonBaseProps<T>;
+
+  const handleRadioSelect = useCallback(
+    (index: number | null, inputId: string, radioGroup: string) => {
+      setCheckedInputs((prev) => {
+        return {
+          ...prev,
+          radios: { ...prev.radios, [radioGroup]: inputId },
+        };
+      });
+      handleSelect(index);
+    },
+    [handleSelect, setCheckedInputs],
+  );
+
+  return (
+    <li role="menuitem" className={theme.container}>
+      <label htmlFor={inputId}>
+        <ButtonBase
+          ref={ref as RefCallback<T>}
+          className={twMerge(theme.base, className)}
+          {...theirProps}
+          {...getItemProps({
+            onClick: () => {
+              onClick && onClick();
+              handleRadioSelect(index, inputId, name);
+            },
+          })}
+          tabIndex={isActive ? 0 : -1}
+        >
+          <Radio
+            ref={inputRef}
+            checked={isChecked}
+            value={value || label}
+            name={name}
+            id={inputId}
+            onChange={() => null}
+            className={theme.input}
+          />
+          {Icon && <Icon className={theme.icon} />}
+          {children ? children : label}
+        </ButtonBase>
+      </label>
+    </li>
+  );
+});

--- a/src/components/Dropdown/theme.ts
+++ b/src/components/Dropdown/theme.ts
@@ -23,6 +23,7 @@ export const dropdownTheme: FlowbiteDropdownTheme = {
       container: '',
       base: 'flex items-center justify-start py-2 px-4 text-sm text-gray-700 cursor-pointer w-full hover:bg-gray-100 focus:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-600 focus:outline-none dark:hover:text-white dark:focus:bg-gray-600 dark:focus:text-white',
       icon: 'mr-2 h-4 w-4',
+      input: 'mr-2',
     },
     style: {
       dark: 'bg-gray-900 text-white dark:bg-gray-700',


### PR DESCRIPTION
re #916 and #941 

- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

This commit follows from the conversation in #941 and #916 - adding functionality to the Dropdown component to include Dropdown.ItemRadio and Dropdown.ItemCheckbox.
It also fixes a bug in DropdownItem.tsx that will only ever set the [selectIndex to `null`](https://github.com/themesberg/flowbite-react/blob/8ddebe16f57500d0e55e71e1b5fe42d263fa9767/src/components/Dropdown/DropdownItem.tsx#L49C31-L49C49). Currently, however, [selectedIndex](https://github.com/themesberg/flowbite-react/blob/8ddebe16f57500d0e55e71e1b5fe42d263fa9767/src/components/Dropdown/Dropdown.tsx#L127C10-L127C23) isn't used anywhere, so possibly it should just be removed (or maybe there is conditional styling that should be added to reflect its state)?

Related to #916 and #941

There are no breaking API changes. Both FloatingUI Typeahead functionality and Arrow Navigation will work for the new item components (tabbing through the dropdown also works) in accordance with WCAG.

Additional considerations:
- Storybook will still need to be updated to reflect the new component options (I wasn't able to get the Storybook dev server running, but am happy to do that work as well if the changes look good).
- These changes don't address any issues Flowbite users are running into when trying to place text inputs as children of `DropdownItem` (and the FloatingUI Typeahead catching all the input keystrokes). The component could possibly be updated to not accept children or offer a warning in development.