### PR TITLE
homepage: image optimisations, avoid content bounce on reload

### DIFF
--- a/components/homepage/contributors-section.tsx
+++ b/components/homepage/contributors-section.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from 'next/link';
 import type { FC } from 'react';
 import { Tooltip } from '~/src';
@@ -41,10 +42,12 @@ export const ContributorsSection: FC = async () => {
               {contributors.map((contributor) => (
                 <Tooltip key={contributor.id} content={contributor.login}>
                   <Link href={contributor.html_url} rel="nofollow noreferrer noopener" target="_blank">
-                    <img
+                    <Image
                       src={contributor.avatar_url}
                       alt={`${contributor.login} avatar`}
                       className="h-10 w-10 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-600 dark:text-gray-300 sm:h-12 sm:w-12 lg:h-16 lg:w-16"
+                      width={64}
+                      height={64}
                     />
                   </Link>
                 </Tooltip>

--- a/components/homepage/dark-mode-section/dark-mode-section.tsx
+++ b/components/homepage/dark-mode-section/dark-mode-section.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from 'next/link';
 import type { FC } from 'react';
 import { DarkModeSwitcher } from './dark-mode-switcher';
@@ -15,15 +16,19 @@ export const DarkModeSection: FC = () => {
       <div className="mx-auto w-full max-w-8xl px-4 py-8 lg:px-20 lg:py-24">
         <div className="flex w-full flex-row-reverse self-stretch py-6 lg:gap-16 lg:py-10">
           <div className="hidden w-1/2 items-center lg:flex">
-            <img
+            <Image
               src="/images/feature-sections/react-dark-mode.png"
               className="dark:hidden"
               alt="React dark mode preview"
+              width={608}
+              height={443}
             />
-            <img
+            <Image
               src="/images/feature-sections/react-dark-mode-dark.png"
               className="hidden dark:block"
               alt="React dark mode preview (inverted colors)"
+              width={608}
+              height={443}
             />
           </div>
           <div className="flex w-1/2 flex-grow flex-col items-start gap-4 divide-y dark:divide-gray-700 lg:gap-8">

--- a/components/homepage/figma-section.tsx
+++ b/components/homepage/figma-section.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import type { FC } from 'react';
 
 export const FigmaSection: FC = () => {
@@ -224,17 +225,21 @@ export const FigmaSection: FC = () => {
           </div>
           <div className="hidden h-full flex-col items-center justify-center lg:flex">
             <div className="relative rounded-xl dark:hidden">
-              <img
+              <Image
                 src="/images/feature-sections/flowbite-react-figma.png"
                 className="max-w-auto w-full"
                 alt="Flowbite Figma Design System mockup"
+                width={592}
+                height={364}
               />
             </div>
             <div className="relative hidden dark:block">
-              <img
+              <Image
                 src="/images/feature-sections/flowbite-react-figma-dark.png"
                 className="max-w-auto w-full rounded-xl"
                 alt="Flowbite Figma Design System mockup (dark mode)"
+                width={592}
+                height={364}
               />
             </div>
           </div>

--- a/components/homepage/hero-section/hero-section.tsx
+++ b/components/homepage/hero-section/hero-section.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import type { FC } from 'react';
 import { HiOutlineArrowRight } from 'react-icons/hi';
 import { Button } from '~/src';
@@ -32,10 +33,16 @@ export const HeroSection: FC = () => {
           </div>
           <div className="hidden items-center p-0 md:flex">
             <div className="relative dark:hidden">
-              <img className="h-auto max-w-full" src="/images/gallery.png" alt="Header" />
+              <Image className="h-auto max-w-full" src="/images/gallery.png" alt="Header" width={620} height={416} />
             </div>
             <div className="relative hidden dark:block">
-              <img className="h-auto max-w-full" src="/images/gallery-dark.png" alt="Header" />
+              <Image
+                className="h-auto max-w-full"
+                src="/images/gallery-dark.png"
+                alt="Header"
+                width={620}
+                height={416}
+              />
             </div>
           </div>
         </div>

--- a/components/homepage/react-section.tsx
+++ b/components/homepage/react-section.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import type { FC } from 'react';
 import { HiOutlineArrowRight } from 'react-icons/hi';
 import { Button } from '~/src';
@@ -17,15 +18,19 @@ export const ReactSection: FC = () => {
       <div className="mx-auto w-full max-w-8xl px-4 py-8 lg:px-20 lg:py-24">
         <div className="flex w-full flex-row self-stretch py-6 lg:gap-16 lg:py-10">
           <div className="hidden w-1/2 items-center lg:flex">
-            <img
+            <Image
               src="/images/feature-sections/react-ui-components.png"
               className="dark:hidden"
               alt="React UI component code preview"
+              width={608}
+              height={535}
             />
-            <img
+            <Image
               src="/images/feature-sections/react-ui-components-dark.png"
               className="hidden dark:block"
               alt="React UI component code preview (dark mode)"
+              width={608}
+              height={535}
             />
           </div>
           <div className="flex w-1/2 flex-grow flex-col items-start gap-4 divide-y dark:divide-gray-700 lg:gap-8">

--- a/components/homepage/social-proof-section.tsx
+++ b/components/homepage/social-proof-section.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import { type FC } from 'react';
 import { safeResJson } from '~/src/helpers/http';
 
@@ -72,10 +73,12 @@ export const SocialProofSection: FC = async () => {
                 </p>
               </div>
               <div className="flex flex-row items-center gap-3.5 self-stretch">
-                <img
+                <Image
                   src="/images/feature-sections/eugene.jpg"
                   className="h-6 w-6 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-600 dark:text-gray-300"
                   alt="Eugene Fedorenko Avatar"
+                  width={24}
+                  height={24}
                 />
                 <div className="flex items-center gap-3">
                   <span className="font-semibold leading-tight text-gray-900 dark:text-white">Eugene Fedorenko</span>

--- a/components/homepage/tailwind-section.tsx
+++ b/components/homepage/tailwind-section.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from 'next/link';
 import type { FC } from 'react';
 
@@ -7,15 +8,19 @@ export const TailwindSection: FC = () => {
       <div className="mx-auto w-full max-w-8xl px-4 py-8 lg:px-20 lg:py-24">
         <div className="flex w-full flex-row self-stretch py-6 lg:gap-16 lg:py-10">
           <div className="hidden w-1/2 items-center lg:flex">
-            <img
+            <Image
               src="/images/feature-sections/tailwind-css-react.png"
               className="dark:hidden"
               alt="Tailwind CSS with React code"
+              width={549}
+              height={496}
             />
-            <img
+            <Image
               src="/images/feature-sections/tailwind-css-react-dark.png"
               className="hidden dark:block"
               alt="Tailwind CSS with React code (dark mode)"
+              width={549}
+              height={496}
             />
           </div>
           <div className="flex w-1/2 flex-grow flex-col items-start gap-4 divide-y dark:divide-gray-700 lg:gap-8">

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,14 @@ import TerserPlugin from 'terser-webpack-plugin';
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+      },
+    ],
+  },
   webpack(config) {
     // Retain React FC display names and anonymous function bodies for docs
     config.optimization.minimizer = [


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

### Changes

- [x] image optimisations using `Image` component from Next.js instead of vanilla HTML `img` tag

### Result

#### Before

https://github.com/themesberg/flowbite-react/assets/41998826/86cf10db-377c-45b3-bc9f-70157c41a7f0

https://github.com/themesberg/flowbite-react/assets/41998826/80ed52aa-46f6-420c-9d7e-8cb754cffb44

#### After

https://github.com/themesberg/flowbite-react/assets/41998826/0cb7dceb-9eca-41f7-91fc-e00ef6924604

https://github.com/themesberg/flowbite-react/assets/41998826/ee721e40-2092-4dee-b9cd-1f705c0abf58