### PR TITLE
API: expose `getTheme()`, `getThemeMode()` functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,4 @@ export * from './components/Tooltip';
 export * from './hooks/use-theme-mode';
 
 export * from './theme';
+export { getTheme, getThemeMode } from './theme-store';


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Augment the API and expose `getTheme()`, `getThemeMode()` functions. (discord members/users know better).