### PR TITLE
refactor(components): separate `AdvancedRating` from `Rating` theming

### DIFF
--- a/content/docs/components/rating.mdx
+++ b/content/docs/components/rating.mdx
@@ -51,7 +51,7 @@ To learn more about how to customize the appearance of components, please see th
 
 <Theme name="rating" />
 
-### Advanced rating
+### Advanced rating theme
 
 <Theme name="ratingAdvanced" />
 

--- a/content/docs/components/rating.mdx
+++ b/content/docs/components/rating.mdx
@@ -47,7 +47,13 @@ Use this component as an advanced layout for user ratings that include both the 
 
 To learn more about how to customize the appearance of components, please see the [Theme docs](/docs/customize/theme).
 
+### Rating theme
+
 <Theme name="rating" />
+
+### Advanced rating
+
+<Theme name="ratingAdvanced" />
 
 ## References
 

--- a/src/components/Flowbite/FlowbiteTheme.ts
+++ b/src/components/Flowbite/FlowbiteTheme.ts
@@ -25,7 +25,7 @@ import type { FlowbitePaginationTheme } from '../Pagination';
 import type { FlowbiteProgressTheme } from '../Progress';
 import type { FlowbiteRadioTheme } from '../Radio';
 import type { FlowbiteRangeSliderTheme } from '../RangeSlider';
-import type { FlowbiteRatingTheme } from '../Rating';
+import type { FlowbiteRatingAdvancedTheme, FlowbiteRatingTheme } from '../Rating';
 import type { FlowbiteSelectTheme } from '../Select';
 import type { FlowbiteSidebarTheme } from '../Sidebar';
 import type { FlowbiteSpinnerTheme } from '../Spinner';
@@ -59,6 +59,7 @@ export interface FlowbiteTheme {
   modal: FlowbiteModalTheme;
   navbar: FlowbiteNavbarTheme;
   rating: FlowbiteRatingTheme;
+  ratingAdvanced: FlowbiteRatingAdvancedTheme;
   pagination: FlowbitePaginationTheme;
   sidebar: FlowbiteSidebarTheme;
   progress: FlowbiteProgressTheme;

--- a/src/components/Rating/Rating.tsx
+++ b/src/components/Rating/Rating.tsx
@@ -5,7 +5,6 @@ import { twMerge } from 'tailwind-merge';
 import { mergeDeep } from '../../helpers/merge-deep';
 import { getTheme } from '../../theme-store';
 import type { DeepPartial } from '../../types';
-import type { FlowbiteRatingAdvancedTheme } from './RatingAdvanced';
 import { RatingAdvanced } from './RatingAdvanced';
 import { RatingContext } from './RatingContext';
 import type { FlowbiteRatingStarTheme, FlowbiteStarSizes } from './RatingStar';
@@ -16,7 +15,6 @@ export interface FlowbiteRatingTheme {
     base: string;
   };
   star: FlowbiteRatingStarTheme;
-  advanced: FlowbiteRatingAdvancedTheme;
 }
 
 export interface RatingProps extends ComponentProps<'div'> {

--- a/src/components/Rating/RatingAdvanced.tsx
+++ b/src/components/Rating/RatingAdvanced.tsx
@@ -26,7 +26,7 @@ export const RatingAdvanced: FC<RatingAdvancedProps> = ({
   theme: customTheme = {},
   ...props
 }) => {
-  const theme = mergeDeep(getTheme().rating.advanced, customTheme);
+  const theme = mergeDeep(getTheme().ratingAdvanced, customTheme);
 
   return (
     <div className={twMerge(theme.base, className)} {...props}>

--- a/src/components/Rating/theme.ts
+++ b/src/components/Rating/theme.ts
@@ -1,17 +1,9 @@
 import type { FlowbiteRatingTheme } from './Rating';
+import { FlowbiteRatingAdvancedTheme } from './RatingAdvanced';
 
 export const ratingTheme: FlowbiteRatingTheme = {
   root: {
     base: 'flex items-center',
-  },
-  advanced: {
-    base: 'flex items-center',
-    label: 'text-sm font-medium text-cyan-600 dark:text-cyan-500',
-    progress: {
-      base: 'mx-4 h-5 w-2/4 rounded bg-gray-200 dark:bg-gray-700',
-      fill: 'h-5 rounded bg-yellow-400',
-      label: 'text-sm font-medium text-cyan-600 dark:text-cyan-500',
-    },
   },
   star: {
     empty: 'text-gray-300 dark:text-gray-500',
@@ -21,5 +13,15 @@ export const ratingTheme: FlowbiteRatingTheme = {
       md: 'w-7 h-7',
       lg: 'w-10 h-10',
     },
+  },
+};
+
+export const ratingAdvancedTheme: FlowbiteRatingAdvancedTheme = {
+  base: 'flex items-center',
+  label: 'text-sm font-medium text-cyan-600 dark:text-cyan-500',
+  progress: {
+    base: 'mx-4 h-5 w-2/4 rounded bg-gray-200 dark:bg-gray-700',
+    fill: 'h-5 rounded bg-yellow-400',
+    label: 'text-sm font-medium text-cyan-600 dark:text-cyan-500',
   },
 };

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -25,7 +25,7 @@ import { paginationTheme } from './components/Pagination/theme';
 import { progressTheme } from './components/Progress/theme';
 import { radioTheme } from './components/Radio/theme';
 import { rangeSliderTheme } from './components/RangeSlider/theme';
-import { ratingTheme } from './components/Rating/theme';
+import { ratingAdvancedTheme, ratingTheme } from './components/Rating/theme';
 import { selectTheme } from './components/Select/theme';
 import { sidebarTheme } from './components/Sidebar/theme';
 import { spinnerTheme } from './components/Spinner/theme';
@@ -67,6 +67,7 @@ export const theme: FlowbiteTheme = {
   radio: radioTheme,
   rangeSlider: rangeSliderTheme,
   rating: ratingTheme,
+  ratingAdvanced: ratingAdvancedTheme,
   select: selectTheme,
   textInput: textInputTheme,
   textarea: textareaTheme,


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

### Changes

- [x] separate theme  `RatingAdvanced` from `Rating` since they cant ever be coupled

### API changes

- removed `advanced` from `FlowbiteRatingTheme` interface

### Result

Before
<img width="2210" alt="Screenshot 2023-11-07 at 10 03 10" src="https://github.com/themesberg/flowbite-react/assets/41998826/c532fc66-a82d-4748-bf9e-ef4b08f91b6e">

After
<img width="2215" alt="Screenshot 2023-11-07 at 09 57 50" src="https://github.com/themesberg/flowbite-react/assets/41998826/eacba3c0-0e61-421e-b888-53360613862b">

