### PR TITLE
Docs: add open graph meta tags

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -29,6 +29,18 @@ export function generateMetadata({ params }: Props): Metadata {
   return {
     title: doc.title,
     description: doc.description,
+    openGraph: {
+      type: 'article',
+      title: doc.title,
+      description: doc.description,
+      images: 'https://flowbite.s3.amazonaws.com/github/flowbite-react.png',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: doc.title,
+      description: doc.description,
+      images: ['https://flowbite.s3.amazonaws.com/github/flowbite-react.png'],
+    },
   };
 }
 


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

### Changes

- [x] add open graph meta tags

### Result

Before
<img width="609" alt="Screenshot 2023-11-07 at 14 49 46" src="https://github.com/themesberg/flowbite-react/assets/41998826/07b75c96-2aa2-4355-bbc9-39222805cfb8">

After

Same image, but with the correct title and description. I cannot show a preview since the OG only works for published reachable domains, not local environment.