### PR TITLE
docs: Server components page + banner update

### DIFF
--- a/components/banner.tsx
+++ b/components/banner.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { FC } from 'react';
 
 export const Banner: FC = () => {
@@ -9,16 +10,14 @@ export const Banner: FC = () => {
       <div className="items-center md:flex">
         <p className="text-sm font-medium text-gray-900 dark:text-white md:my-0">
           <span className="mr-2 hidden rounded bg-cyan-100 px-2.5 py-0.5 text-xs font-semibold text-cyan-800 dark:bg-cyan-200 dark:text-cyan-800 md:inline">
-            Community
+            New
           </span>
-          🗳️ Help us by voting and providing feedback for supporting Server Components in Next.js!
-          <a
+          Flowbite React now supports Server Components and has full Next.js App Router support!
+          <Link
             className="ml-2 inline-flex items-center text-sm font-medium text-cyan-600 hover:underline dark:text-cyan-500 md:ml-2"
-            href="https://github.com/themesberg/flowbite-react/discussions/940"
-            target="_blank"
-            rel="nofollow noreferred noopener"
+            href="/docs/getting-started/server-components"
           >
-            Check discussion on GitHub
+            Check it out
             <svg
               className="ml-1.5 h-3 w-3 text-cyan-600 dark:text-cyan-500"
               aria-hidden="true"
@@ -34,7 +33,7 @@ export const Banner: FC = () => {
                 d="M1 5h12m0 0L9 1m4 4L9 9"
               />
             </svg>
-          </a>
+          </Link>
         </p>
       </div>
     </div>

--- a/content/docs/getting-started/server-components.mdx
+++ b/content/docs/getting-started/server-components.mdx
@@ -1,0 +1,100 @@
+---
+title: React Server Components (RSC) - Flowbite
+description: Learn how to use Flowbite React components inside React Server Components
+---
+
+React Server Components individually fetch data and render entirely on the server, and the resulting HTML is streamed into the client-side React component tree.
+
+RSCs can help reduce the size of the client-side JavaScript bundle and improve loading performance.
+
+## Usage
+
+Without `'use client'` directive:
+
+```jsx
+import { Button } from 'flowbite-react';
+
+function Component() {
+  return <Button>Default</Button>;
+}
+```
+
+With `'use client'` directive:
+
+```jsx
+'use client';
+
+import { Button } from 'flowbite-react';
+
+function Component() {
+  return <Button onClick={() => console.log('clicked!')}>Default</Button>;
+}
+```
+
+Incorrect: without `'use client'` directive and user event passed as prop (`onClick`) resulting in error:
+
+```jsx
+// errors
+
+import { Button } from 'flowbite-react';
+
+function Component() {
+  return <Button onClick={() => console.log('clicked!')}>Default</Button>;
+}
+```
+
+## Compound components
+
+Compound components DO NOT work in React Server Components, therefore each component must be specifically imported as such:
+
+Incorrect usage:
+
+```jsx
+// errors
+
+import { Button } from 'flowbite-react';
+
+function Component() {
+  return (
+    <Button.Group>
+      <Button color="gray">Profile</Button>
+      <Button color="gray">Settings</Button>
+      <Button color="gray">Messages</Button>
+    </Button.Group>
+  );
+}
+```
+
+Correct usage:
+
+```jsx
+// works
+
+import { Button, ButtonGroup } from 'flowbite-react';
+
+function Component() {
+  return (
+    <ButtonGroup>
+      <Button color="gray">Profile</Button>
+      <Button color="gray">Settings</Button>
+      <Button color="gray">Messages</Button>
+    </ButtonGroup>
+  );
+}
+```
+
+## Support
+
+All Flowbite React components are server-ready, meaning they can be rendered inside React Server Components without the need of `'use client'` directive at the top of the file.
+
+Here's a list of all Flowbite React components that are fully rendered on the server:
+
+`Alert`, `Avatar`, `Badge`, `Banner`, `Blockquote`, `Breadcrumb`, `Button`, `Card`, `Checkbox`, `File input`, `Floating Label`, `Footer`, `Helper text`, `Kbd`, `Label`, `List`, `List Group`, `Progress`, `Radio`, `Range slider`, `Select`, `Spinner`, `Textarea`, `Text input`, `Tooltip`.
+
+## Notes
+
+User event props (such as `onClick`, `onBlur`, ...etc) DO NOT work in React Server Components.
+
+To pass any user events to a Flowbite React component (such as `onClick`, `onBlur`) the parent component must have the `'use client'` directive.
+
+Only serializable data can be passed to a server component as props (eg: functions will not work).

--- a/data/docs-sidebar.ts
+++ b/data/docs-sidebar.ts
@@ -19,6 +19,7 @@ export const DOCS_SIDEBAR: DocsSidebarSection[] = [
       { title: 'Introduction', href: '/docs/getting-started/introduction' },
       { title: 'Quickstart', href: '/docs/getting-started/quickstart' },
       { title: 'Next.js', href: '/docs/getting-started/nextjs', isNew: true },
+      { title: 'Server Components', href: '/docs/getting-started/server-components', isNew: true },
       { title: 'TypeScript', href: '/docs/getting-started/typescript' },
       { title: 'License', href: '/docs/getting-started/license' },
       { title: 'Changelog', href: 'https://github.com/themesberg/flowbite-react/releases', isExternal: true },


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

With the release of v0.7.0 bringing full React Server Components (RSCs) support, we need to update the docs as well.

### Changes

- [x] create `server-components` page
- [x] update sidebar items
- [x] update banner with new RSC support

### Result

Banner
<img width="1511" alt="Screenshot 2023-11-15 at 16 32 07" src="https://github.com/themesberg/flowbite-react/assets/41998826/81e6df70-0aac-41e8-9d2c-636237e3a58e">

Docs `server-components` page
<img width="1504" alt="Screenshot 2023-11-15 at 16 32 12" src="https://github.com/themesberg/flowbite-react/assets/41998826/aaa3d76b-be33-407c-bcfc-865ce57fa0f5">
<img width="1499" alt="Screenshot 2023-11-15 at 16 32 23" src="https://github.com/themesberg/flowbite-react/assets/41998826/5da1bcc6-4337-4d8a-b72c-d3b09ffca750">
<img width="1501" alt="Screenshot 2023-11-15 at 16 32 28" src="https://github.com/themesberg/flowbite-react/assets/41998826/82e88c1d-9cd1-4cbb-9fb6-8bf67136322d">
