### PR TITLE
docs sidebar: new badge smaller

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -208,7 +208,7 @@ function NewBadge({ children }: PropsWithChildren) {
   return (
     <span className="flex items-center gap-2">
       {children}
-      <Badge color="cyan" className="px-2">
+      <Badge color="cyan" className="px-1.5 h-4">
         New
       </Badge>
     </span>


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Make the new badge smaller.

### Result

Before
<img width="254" alt="Screenshot 2023-11-16 at 16 30 01" src="https://github.com/themesberg/flowbite-react/assets/41998826/d666fc35-e70e-4b07-9cf3-223644f032f3">

After
<img width="251" alt="Screenshot 2023-11-16 at 16 30 36" src="https://github.com/themesberg/flowbite-react/assets/41998826/11b920ad-5869-4548-8bac-6ce529974c2d">
