### PR TITLE
docs dark mode: section for Next.js

### DIFF
--- a/content/docs/customize/dark-mode.mdx
+++ b/content/docs/customize/dark-mode.mdx
@@ -21,4 +21,51 @@ export default function MyPage() {
 }
 ```
 
+## NextJS
+
+In server side rendered applications, such as NextJS, to avoid page flicker (if `dark` mode is set) before NextJS hydrates the content, `ThemeModeScript` component must be rendered in `Head` component (see implementation below).
+
+`ThemeModeScript` renders a script tag that sets `dark` or removes `dark` from `<html>` element before hydration occurs.
+
+### App router
+
+```tsx
+// app/layout.tsx
+
+import { ThemeModeScript } from 'flowbite-react';
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head>
+        <ThemeModeScript />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+### Pages router
+
+```tsx
+// pages/_document.tsx
+
+import { ThemeModeScript } from 'flowbite-react';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <ThemeModeScript />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}
+```
+
 <div className="h-[20vh]" />


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

With the RSCs support in Next.js app router and the new changes to the core library theme, we need to update the docs as well.

### Result
<img width="891" alt="Screenshot 2023-11-16 at 17 00 14" src="https://github.com/themesberg/flowbite-react/assets/41998826/dfb53bbb-383a-4ff1-9517-eabfb34678cb">
