### PR TITLE
components(DarkThemeToggle): fix custom icon types

### DIFF
--- a/src/components/DarkThemeToggle/DarkThemeToggle.tsx
+++ b/src/components/DarkThemeToggle/DarkThemeToggle.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ComponentProps, FC } from 'react';
+import type { IconBaseProps } from 'react-icons';
 import { HiMoon, HiSun } from 'react-icons/hi';
 import { twMerge } from 'tailwind-merge';
 import { mergeDeep } from '../../helpers/merge-deep';
@@ -18,8 +19,8 @@ export interface FlowbiteDarkThemeToggleRootTheme {
 }
 
 export interface DarkThemeToggleProps extends ComponentProps<'button'> {
-  iconDark?: string;
-  iconLight?: string;
+  iconDark?: FC<IconBaseProps>;
+  iconLight?: FC<IconBaseProps>;
   theme?: DeepPartial<FlowbiteDarkThemeToggleTheme>;
 }
 


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

### Changes

- [x] fixed `DarkThemeToggle` component custom icons `iconDark` and `iconLight` types

### Issue

#1143 

### Result

Before

<img width="1319" alt="Screenshot 2023-11-23 at 11 27 16" src="https://github.com/themesberg/flowbite-react/assets/41998826/b404b47b-5ebb-4d14-9027-88317559121f">

After

<img width="412" alt="Screenshot 2023-11-23 at 11 20 47" src="https://github.com/themesberg/flowbite-react/assets/41998826/a70bf250-f43a-4a3f-b8d4-154bb5b9dab9">