### PR TITLE
fix(pagination): updating lastPage variable correctly for table layout

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -65,7 +65,7 @@ const PaginationComponent: FC<PaginationProps> = ({
 }) => {
   const theme = mergeDeep(getTheme().pagination, customTheme);
 
-  const lastPage = Math.min(Math.max(currentPage + 2, 5), totalPages);
+  const lastPage = Math.min(Math.max(layout === 'pagination' ? currentPage + 2 : currentPage + 4, 5), totalPages);
   const firstPage = Math.max(1, lastPage - 4);
 
   const goToNextPage = (): void => {


### PR DESCRIPTION

The page number was not showing correctly on first few clicks because lastPage variable was not updating on the first few clicks when the layout was table due to incorrect addition. Was working correctly when the layout was pagination.

fix #1150

- [ ] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.
lastPage variable was set to currentPage+2 which is correct for pagination layout but for table layout, it needs to be currentPage+4 so that lastPage can be 5 after first click only.
Reference related issues using `#` followed by the issue number.
#1150 
If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.
NA