### PR TITLE
fix(footer>theme.ts): adding margin to right in footer links

### DIFF
--- a/src/components/Footer/theme.ts
+++ b/src/components/Footer/theme.ts
@@ -9,7 +9,7 @@ export const footerTheme: FlowbiteFooterTheme = {
   groupLink: {
     base: 'flex flex-wrap text-sm text-gray-500 dark:text-white',
     link: {
-      base: 'last:mr-0 md:mr-6',
+      base: 'last:mr-0 md:mr-6 me-4',
       href: 'hover:underline',
     },
     col: 'flex-col space-y-4',

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -65,7 +65,7 @@ const PaginationComponent: FC<PaginationProps> = ({
 }) => {
   const theme = mergeDeep(getTheme().pagination, customTheme);
 
-  const lastPage = Math.min(Math.max(currentPage + 2, 5), totalPages);
+  const lastPage = Math.min(Math.max(layout === 'pagination' ? currentPage + 2 : currentPage + 4, 5), totalPages);
   const firstPage = Math.max(1, lastPage - 4);
 
   const goToNextPage = (): void => {


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

The link elements were not responsive because there was no default margin set. me-4 was added to
non-react footer but not in react footer.

Reference related issues using `#` followed by the issue number.

#1085 

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.
NA

Screenshots

Non-React
![image](https://github.com/themesberg/flowbite-react/assets/20161529/8984eb30-ae93-4036-99f2-82904707fd46)

React
![image](https://github.com/themesberg/flowbite-react/assets/20161529/82149412-4064-40c9-a1af-c783256a4d36)

