### PR TITLE
fix(footer>theme.ts): adding margin to right in footer links

### DIFF
--- a/src/components/Footer/theme.ts
+++ b/src/components/Footer/theme.ts
@@ -9,7 +9,7 @@ export const footerTheme: FlowbiteFooterTheme = {
   groupLink: {
     base: 'flex flex-wrap text-sm text-gray-500 dark:text-white',
     link: {
-      base: 'last:mr-0 md:mr-6',
+      base: 'last:mr-0 md:mr-6 me-4',
       href: 'hover:underline',
     },
     col: 'flex-col space-y-4',


### PR DESCRIPTION

- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

The link elements were not responsive because there was no default margin set. me-4 was added to
non-react footer but not in react footer.

Reference related issues using `#` followed by the issue number.

#1085 

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.
NA

![image](https://github.com/themesberg/flowbite-react/assets/20161529/e872b455-ef36-4f61-bff2-92064ef40bf8)

