### PR TITLE
docs sidebar (typography): add missing `List` link

### DIFF
--- a/data/docs-sidebar.ts
+++ b/data/docs-sidebar.ts
@@ -79,6 +79,9 @@ export const DOCS_SIDEBAR: DocsSidebarSection[] = [
   {
     title: 'typography',
     href: '/typography/',
-    items: [{ title: 'Blockquote', href: '/docs/typography/blockquote', isNew: true }],
+    items: [
+      { title: 'Blockquote', href: '/docs/typography/blockquote', isNew: true },
+      { title: 'List', href: '/docs/typography/list', isNew: true },
+    ],
   },
 ];


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Docs sidebar was missing the `List` item;

### Changes

- [x] add missing `List` item in docs sidebar typography section

### Result

Before

<img width="258" alt="Screenshot 2023-11-28 at 09 18 14" src="https://github.com/themesberg/flowbite-react/assets/41998826/e220dda8-a210-474b-8bf1-16b449873174">

After

<img width="254" alt="Screenshot 2023-11-28 at 09 18 07" src="https://github.com/themesberg/flowbite-react/assets/41998826/3ecdfa55-afed-41b7-ac1d-c72b8a5f6920">
