### PR TITLE
docs: fixed typo

### DIFF
--- a/content/docs/components/forms.mdx
+++ b/content/docs/components/forms.mdx
@@ -35,7 +35,7 @@ Use this example of a form component with `<TextInput>`, `<Checkbox>`, `<Label>`
 
 ## Input sizing
 
-Use the `sizing` prop on the `<TextInput>` form component from React to set the size of the input fields. You can hoose from the `sm`, `md`, and `lg` size options.
+Use the `sizing` prop on the `<TextInput>` form component from React to set the size of the input fields. You can choose from the `sm`, `md`, and `lg` size options.
 
 <Example name="forms.inputSizing" />
 


### PR DESCRIPTION
Fixed typo in Input sizing section from "hoose" to "choose"

- [x]  I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.
Fixed the typo in the docs so that it's easier for end user's reading.

Reference related issues using `#` followed by the issue number.

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.
