### PR TITLE
docs(button): fix sizes examples

### DIFF
--- a/examples/button/button.loading.tsx
+++ b/examples/button/button.loading.tsx
@@ -8,7 +8,7 @@ import { Button } from 'flowbite-react';
 
 function Component() {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap items-start gap-2">
       <Button size="xs" isProcessing>
         Click me!
       </Button>
@@ -34,7 +34,7 @@ import { Button } from 'flowbite-react';
 
 function Component() {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap items-start gap-2">
       <Button size="xs" isProcessing>
         Click me!
       </Button>
@@ -57,7 +57,7 @@ function Component() {
 
 function Component() {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap items-start gap-2">
       <Button size="xs" isProcessing>
         Click me!
       </Button>

--- a/examples/button/button.sizes.tsx
+++ b/examples/button/button.sizes.tsx
@@ -8,7 +8,7 @@ import { Button } from 'flowbite-react';
 
 function Component() {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap items-start gap-2">
       <Button size="xs">Extra small</Button>
       <Button size="sm">Small</Button>
       <Button size="md">Base</Button>
@@ -24,7 +24,7 @@ import { Button } from 'flowbite-react';
 
 function Component() {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap items-start gap-2">
       <Button size="xs">Extra small</Button>
       <Button size="sm">Small</Button>
       <Button size="md">Base</Button>
@@ -37,7 +37,7 @@ function Component() {
 
 function Component() {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="flex flex-wrap items-start gap-2">
       <Button size="xs">Extra small</Button>
       <Button size="sm">Small</Button>
       <Button size="md">Base</Button>


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

### Changes

- [x] fix docs `Button` size examples

### Result

Before

<img width="859" alt="Screenshot 2023-12-04 at 09 30 51" src="https://github.com/themesberg/flowbite-react/assets/41998826/5b515fca-293e-4f09-8246-c0ae2f4a1eaf">
<img width="855" alt="Screenshot 2023-12-04 at 09 31 31" src="https://github.com/themesberg/flowbite-react/assets/41998826/436a9d89-9dbf-4e4b-b9a6-e7ff43974e97">

After

<img width="860" alt="Screenshot 2023-12-04 at 09 31 23" src="https://github.com/themesberg/flowbite-react/assets/41998826/88f4988a-ae66-4095-baa4-58e6631144bb">
<img width="861" alt="Screenshot 2023-12-04 at 09 31 37" src="https://github.com/themesberg/flowbite-react/assets/41998826/6236a0be-d906-4371-a340-e66ec6a1676c">
