### PR TITLE
components(DarkThemeToggle): fix console warning

### DIFF
--- a/src/components/DarkThemeToggle/DarkThemeToggle.tsx
+++ b/src/components/DarkThemeToggle/DarkThemeToggle.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps, FC } from 'react';
 import type { IconBaseProps } from 'react-icons';
 import { HiMoon, HiSun } from 'react-icons/hi';
 import { twMerge } from 'tailwind-merge';
+import { useIsMounted } from '~/src/hooks/use-is-mounted';
 import { mergeDeep } from '../../helpers/merge-deep';
 import { useThemeMode } from '../../hooks/use-theme-mode';
 import { getTheme } from '../../theme-store';
@@ -31,6 +32,7 @@ export const DarkThemeToggle: FC<DarkThemeToggleProps> = ({
   iconLight: IconLight = HiMoon,
   ...props
 }) => {
+  const isMounted = useIsMounted();
   const { computedMode, toggleMode } = useThemeMode();
 
   const theme = mergeDeep(getTheme().darkThemeToggle, customTheme);
@@ -46,12 +48,12 @@ export const DarkThemeToggle: FC<DarkThemeToggleProps> = ({
     >
       <IconDark
         aria-label="Currently dark mode"
-        data-active={computedMode === 'dark'}
+        data-active={isMounted && computedMode === 'dark'}
         className={twMerge(theme.root.icon, 'hidden dark:block')}
       />
       <IconLight
         aria-label="Currently light mode"
-        data-active={computedMode === 'light'}
+        data-active={isMounted && computedMode === 'light'}
         className={twMerge(theme.root.icon, 'dark:hidden')}
       />
     </button>

--- a/src/hooks/use-is-mounted.ts
+++ b/src/hooks/use-is-mounted.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useIsMounted() {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  return mounted;
+}


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Due to `Next.js` hydration process trying to render on server first, then hydrate on client, `data-active` attribute depends on `computedMode` from `useThemeMode` which has the source of storage localstorage. The problem is that there is no valid `computedMode` on server.

### Changes

- [x] fix hydration error log caused by `DarkThemeToggle`

Issue:
#1156
