### PR TITLE
fix: absolute to relative import

### DIFF
--- a/src/components/DarkThemeToggle/DarkThemeToggle.tsx
+++ b/src/components/DarkThemeToggle/DarkThemeToggle.tsx
@@ -4,7 +4,7 @@ import type { ComponentProps, FC } from 'react';
 import type { IconBaseProps } from 'react-icons';
 import { HiMoon, HiSun } from 'react-icons/hi';
 import { twMerge } from 'tailwind-merge';
-import { useIsMounted } from '~/src/hooks/use-is-mounted';
+import { useIsMounted } from '../../hooks/use-is-mounted';
 import { mergeDeep } from '../../helpers/merge-deep';
 import { useThemeMode } from '../../hooks/use-theme-mode';
 import { getTheme } from '../../theme-store';


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

`DarkThemeToggle` component crashes due to absolute import which is not resolved by the bundler.

### Issues
#1182

### Changes

- [x] change `DarkThemeToggle` absolute import to relative