### PR TITLE
feat(component): default to `type="text"` on `<TextInput>`

### DIFF
--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -64,6 +64,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       shadow,
       sizing = 'md',
       theme: customTheme = {},
+      type = 'text',
       ...props
     },
     ref,
@@ -95,6 +96,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
                 theme.field.input.withAddon[addon ? 'on' : 'off'],
                 theme.field.input.withShadow[shadow ? 'on' : 'off'],
               )}
+              type={type}
               {...props}
               ref={ref}
             />


### PR DESCRIPTION
All of the other form components provide an implicit `type=".."` field so this one should, too. It is implied by the name that this will be an `<input type="text">` by default, and you have the *option* to provide a specific other `type`.

- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Make `<TextInput>`s slightly more convenient when the `type="text"`, since "Text input" implies that.

No breaking changes! `type="text"` typed explicitly will still work, but won't be necessary anymore. Explicit `type="search"`, etc. will work the same.