### PR TITLE
feat(carousel): automatic hiding of navigation buttons when the first…

### DIFF
--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -56,6 +56,7 @@ export interface CarouselProps extends ComponentProps<'div'> {
   theme?: DeepPartial<FlowbiteCarouselTheme>;
   onSlideChange?: (slide: number) => void;
   pauseOnHover?: boolean;
+  autoHideControls?: boolean;
 }
 
 export interface DefaultLeftRightControlProps extends ComponentProps<'div'> {
@@ -74,6 +75,7 @@ export const Carousel: FC<CarouselProps> = ({
   theme: customTheme = {},
   onSlideChange = null,
   pauseOnHover = false,
+  autoHideControls = false,
   ...props
 }) => {
   const theme = mergeDeep(getTheme().carousel, customTheme);
@@ -181,7 +183,11 @@ export const Carousel: FC<CarouselProps> = ({
 
       {items && (
         <>
-          <div className={theme.root.leftControl}>
+          <div
+            className={`${theme.root.leftControl} transition-opacity duration-300 ${
+              activeItem === 0 && autoHideControls ? 'pointer-events-none opacity-0' : 'opacity-100'
+            }`}
+          >
             <button
               className="group"
               data-testid="carousel-left-control"
@@ -192,7 +198,11 @@ export const Carousel: FC<CarouselProps> = ({
               {leftControl ? leftControl : <DefaultLeftControl theme={customTheme} />}
             </button>
           </div>
-          <div className={theme.root.rightControl}>
+          <div
+            className={`${theme.root.rightControl} transition-opacity duration-300 ${
+              activeItem === items.length - 1 && autoHideControls ? 'pointer-events-none opacity-0' : 'opacity-100'
+            }`}
+          >
             <button
               className="group"
               data-testid="carousel-right-control"


### PR DESCRIPTION
feat(carousel): automatic hiding of navigation buttons when the first or last image is active

Added 'autoHideControls' feature to ImageSlider for intuitive navigation button visibility.

- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Gives a nice touch for UX when not needing to move from last image to first one.
Conditional rendering of carousel controls when autoHideControls is true.


https://github.com/themesberg/flowbite-react/assets/36115659/87521d58-b0b4-4d34-bd78-d59b950d10a7


fixes #1205 

New optional prop added to Carousel component: autoHideControls with false as default value.
Example:
<img width="736" alt="Captura de pantalla 2023-12-31 a la(s) 4 34 23 p m" src="https://github.com/themesberg/flowbite-react/assets/36115659/e18c219b-4d2a-42fe-8f14-d3dc2bb73863">

