### PR TITLE
Fix the tooltip centered when wrapping an avatar inside an avatar group

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -24,6 +24,7 @@ export interface FlowbiteAvatarRootTheme {
   rounded: string;
   size: AvatarSizes;
   stacked: string;
+  tooltip: string;
   status: FlowbiteAvatarStatusTheme;
   statusPosition: FlowbitePositions;
 }
@@ -108,7 +109,11 @@ const AvatarComponent: FC<AvatarProps> = ({
     'data-testid': 'flowbite-avatar-img',
   };
   return (
-    <div className={twMerge(theme.root.base, className)} data-testid="flowbite-avatar" {...props}>
+    <div
+      className={twMerge(theme.root.base, stacked && theme.root.tooltip, className)}
+      data-testid="flowbite-avatar"
+      {...props}
+    >
       <div className="relative">
         {img ? (
           typeof img === 'string' ? (

--- a/src/components/Avatar/theme.ts
+++ b/src/components/Avatar/theme.ts
@@ -30,6 +30,7 @@ export const avatarTheme: FlowbiteAvatarTheme = {
       xl: 'w-36 h-36',
     },
     stacked: 'ring-2 ring-gray-300 dark:ring-gray-500',
+    tooltip: '-ml-2',
     statusPosition: {
       'bottom-left': '-bottom-1 -left-1',
       'bottom-center': '-bottom-1 center',
@@ -54,7 +55,7 @@ export const avatarTheme: FlowbiteAvatarTheme = {
     },
   },
   group: {
-    base: 'flex -space-x-4',
+    base: 'flex ml-4',
   },
   groupCounter: {
     base: 'relative flex items-center justify-center w-10 h-10 text-xs font-medium text-white bg-gray-700 rounded-full ring-2 ring-gray-300 hover:bg-gray-600 dark:ring-gray-500',


### PR DESCRIPTION
## Summary
Make the tooltip centered on the avatar inside the avatar group.

## Motivation
When using a tooltip for an avatar inside an avatar group, the tooltip is not centered. This issue occurs only on avatars inside the avatar group.

## Changes Made
Added `"tooltip"` property to avatar theme.

Use of `"tooltip"` property based on `"stacked"` parameter. If `"stacked=true"` then the tooltip property will be sent for customization if using a tooltip.

However, if you keep using stacked without a tooltip, the behavior will remain the same.

## Reference
fix #1231

___

- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)
