### PR TITLE
fix(pagination): Show page number when there is only 1 page

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -90,7 +90,7 @@ const PaginationComponent: FC<PaginationProps> = ({
           <PaginationNavigation
             className={twMerge(theme.pages.previous.base, showIcon && theme.pages.showIcon)}
             onClick={goToPreviousPage}
-            disabled={currentPage === 1}
+            disabled={currentPage <= 1}
           >
             {showIcon && <HiChevronLeft aria-hidden className={theme.pages.previous.icon} />}
             {previousLabel}

--- a/src/components/Pagination/helpers.spec.ts
+++ b/src/components/Pagination/helpers.spec.ts
@@ -4,10 +4,13 @@ import { range } from './helpers';
 describe('Helpers / Range', () => {
   it('should return the empty list, given start >= end', () => {
     expect(range(20, 10)).toEqual([]);
-    expect(range(10, 10)).toEqual([]);
   });
 
   it('should return every number from start to end, inclusive, given start < end', () => {
     expect(range(10, 20)).toEqual([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+  });
+
+  it('should a single number == start == end, given start == end', () => {
+    expect(range(10, 10)).toEqual([10]);
   });
 });

--- a/src/components/Pagination/helpers.ts
+++ b/src/components/Pagination/helpers.ts
@@ -1,5 +1,5 @@
 export const range: (start: number, end: number) => number[] = (start, end) => {
-  if (start >= end) {
+  if (start > end) {
     return [];
   }
 


### PR DESCRIPTION
When there is only 1 page the page number is not shown, instead only the disabled buttons () are shown. The correct behavior is to show the active page number (1) and have the buttons disabled.

This is fixed by modifying the range functions implementation to return an array with a single number when start and end are equal, instead of an empty array. The change to range function doesn't break any other functionality.

fix #1048

**Current:**
![image](https://github.com/themesberg/flowbite-react/assets/59092504/cc4bb511-bed6-482b-9379-7449b9265a31)

**Fixed:**
![image](https://github.com/themesberg/flowbite-react/assets/59092504/bf9b362f-293c-4f20-8fb4-10f3221ca116)
