### PR TITLE
fix(navbar): on Mobile Screen Navbar remains open even page is changed

### DIFF
--- a/src/components/Navbar/NavbarCollapse.tsx
+++ b/src/components/Navbar/NavbarCollapse.tsx
@@ -18,22 +18,14 @@ export interface NavbarCollapseProps extends ComponentProps<'div'> {
 }
 
 export const NavbarCollapse: FC<NavbarCollapseProps> = ({ children, className, theme: customTheme = {}, ...props }) => {
-  const { theme: rootTheme, isOpen, setIsOpen } = useNavbarContext();
+  const { theme: rootTheme, isOpen } = useNavbarContext();
 
   const theme = mergeDeep(rootTheme.collapse, customTheme);
-
-  const handleClick = () => {
-    setIsOpen(!isOpen);
-  };
 
   return (
     <div
       data-testid="flowbite-navbar-collapse"
       className={twMerge(theme.base, theme.hidden[!isOpen ? 'on' : 'off'], className)}
-      onClick={handleClick}
-      onKeyDown={handleClick}
-      role="button"
-      tabIndex={0}
       {...props}
     >
       <ul className={theme.list}>{children}</ul>

--- a/src/components/Navbar/NavbarCollapse.tsx
+++ b/src/components/Navbar/NavbarCollapse.tsx
@@ -18,14 +18,19 @@ export interface NavbarCollapseProps extends ComponentProps<'div'> {
 }
 
 export const NavbarCollapse: FC<NavbarCollapseProps> = ({ children, className, theme: customTheme = {}, ...props }) => {
-  const { theme: rootTheme, isOpen } = useNavbarContext();
+  const { theme: rootTheme, isOpen, setIsOpen } = useNavbarContext();
 
   const theme = mergeDeep(rootTheme.collapse, customTheme);
+
+  const handleClick = () => {
+    setIsOpen(!isOpen);
+  };
 
   return (
     <div
       data-testid="flowbite-navbar-collapse"
       className={twMerge(theme.base, theme.hidden[!isOpen ? 'on' : 'off'], className)}
+      onClick={handleClick}
       {...props}
     >
       <ul className={theme.list}>{children}</ul>

--- a/src/components/Navbar/NavbarCollapse.tsx
+++ b/src/components/Navbar/NavbarCollapse.tsx
@@ -31,6 +31,9 @@ export const NavbarCollapse: FC<NavbarCollapseProps> = ({ children, className, t
       data-testid="flowbite-navbar-collapse"
       className={twMerge(theme.base, theme.hidden[!isOpen ? 'on' : 'off'], className)}
       onClick={handleClick}
+      onKeyDown={handleClick}
+      role="button"
+      tabIndex={0}
       {...props}
     >
       <ul className={theme.list}>{children}</ul>

--- a/src/components/Navbar/NavbarLink.tsx
+++ b/src/components/Navbar/NavbarLink.tsx
@@ -31,13 +31,13 @@ export const NavbarLink: FC<NavbarLinkProps> = ({
   onClick,
   ...props
 }) => {
-  const { theme: rootTheme, isOpen, setIsOpen } = useNavbarContext();
+  const { theme: rootTheme, setIsOpen } = useNavbarContext();
 
   const theme = mergeDeep(rootTheme.link, customTheme);
 
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
-    setIsOpen(!isOpen);
-    onClick && onClick(event);
+    setIsOpen(false);
+    onClick?.(event);
   };
 
   return (

--- a/src/components/Navbar/NavbarLink.tsx
+++ b/src/components/Navbar/NavbarLink.tsx
@@ -30,9 +30,13 @@ export const NavbarLink: FC<NavbarLinkProps> = ({
   theme: customTheme = {},
   ...props
 }) => {
-  const { theme: rootTheme } = useNavbarContext();
+  const { theme: rootTheme, isOpen, setIsOpen } = useNavbarContext();
 
   const theme = mergeDeep(rootTheme.link, customTheme);
+
+  const handleClick = () => {
+    setIsOpen(!isOpen);
+  };
 
   return (
     <li>
@@ -44,6 +48,7 @@ export const NavbarLink: FC<NavbarLinkProps> = ({
           theme.disabled[disabled ? 'on' : 'off'],
           className,
         )}
+        onClick={handleClick}
         {...props}
       >
         {children}

--- a/src/components/Navbar/NavbarLink.tsx
+++ b/src/components/Navbar/NavbarLink.tsx
@@ -28,7 +28,7 @@ export const NavbarLink: FC<NavbarLinkProps> = ({
   children,
   className,
   theme: customTheme = {},
-  onClick: userOnClick,
+  onClick,
   ...props
 }) => {
   const { theme: rootTheme, isOpen, setIsOpen } = useNavbarContext();
@@ -37,7 +37,7 @@ export const NavbarLink: FC<NavbarLinkProps> = ({
 
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     setIsOpen(!isOpen);
-    userOnClick && userOnClick(event);
+    onClick && onClick(event);
   };
 
   return (

--- a/src/components/Navbar/NavbarLink.tsx
+++ b/src/components/Navbar/NavbarLink.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ComponentProps, ElementType, FC } from 'react';
+import type { ComponentProps, ElementType, FC, MouseEvent } from 'react';
 import { twMerge } from 'tailwind-merge';
 import { mergeDeep } from '../../helpers/merge-deep';
 import type { DeepPartial } from '../../types';
@@ -28,14 +28,16 @@ export const NavbarLink: FC<NavbarLinkProps> = ({
   children,
   className,
   theme: customTheme = {},
+  onClick: userOnClick,
   ...props
 }) => {
   const { theme: rootTheme, isOpen, setIsOpen } = useNavbarContext();
 
   const theme = mergeDeep(rootTheme.link, customTheme);
 
-  const handleClick = () => {
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     setIsOpen(!isOpen);
+    userOnClick && userOnClick(event);
   };
 
   return (


### PR DESCRIPTION
When we go to the Mobile Screen and when we click on Navbar, it opens the Collapse, and when we click on any of the Link and it get redirected to another page, but Navbar Collapse isn't getting closed, it was only getting closed from Navbar Toggle nowhere else.

This fix is adding the onClick event to NavbarCollapse so whenever we click on the Link, it is closing the navbar.

**Current:**
![image](https://github.com/themesberg/flowbite-react/assets/32231977/26169171-8447-4d3f-b19b-da54ed8c7b6a)


**Fixed:**
![image](https://github.com/themesberg/flowbite-react/assets/32231977/16d9fecf-8895-435b-91e4-ccc5ecc9c61e)
