### PR TITLE
fix(storybook): fix the `argTypes.weekStart.mapping` on `Datepicker.stories.tsx`

### DIFF
--- a/src/components/Datepicker/Datepicker.stories.tsx
+++ b/src/components/Datepicker/Datepicker.stories.tsx
@@ -15,7 +15,9 @@ export default {
     },
     weekStart: {
       options: Object.values(WeekStart).filter((x) => typeof x === 'string'),
-      mapping: WeekStart,
+      mapping: Object.entries(WeekStart)
+        .filter(([, value]) => typeof value !== 'string')
+        .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {}),
       control: {
         type: 'select',
         labels: Object.entries(WeekStart)


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

When you click Datepicker on the storybook, throws an `invalid time value` error.
I guess it is because the default value of `weekStart` arg becomes string `Sunday` by the `argTypes.weekStart.mapping`. The `weekStart` arg is expected the number.
This PR fixed the value of `argTypes.weekStart.mapping` to be only the string key.

```diff
- argTypes.weekStart.mapping: { 0: "Sunday", 1: "Monday", 2: "Tuesday", 3: "Wednesday", 4: "Thursday", 5: "Friday", 6: "Saturday", Sunday: 0, Monday: 1, Tuesday: 2, Wednesday: 3, Thursday: 4, Friday: 5, Saturday: 6 }
+ argTypes.weekStart.mapping: { Sunday: 0, Monday: 1, Tuesday: 2, Wednesday: 3, Thursday: 4, Friday: 5, Saturday: 6 }
```
fix #1167
