### PR TITLE
docs(examples/../timeline.horizontal.tsx): timeline Horizontal was missing the horizontal boolean value

### DIFF
--- a/examples/timeline/timeline.horizontal.tsx
+++ b/examples/timeline/timeline.horizontal.tsx
@@ -23,7 +23,7 @@ import { HiArrowNarrowRight, HiCalendar } from 'react-icons/hi';
 
 function Component() {
   return (
-    <Timeline>
+    <Timeline horizontal>
       <Timeline.Item>
         <Timeline.Point icon={HiCalendar} />
         <Timeline.Content>


### PR DESCRIPTION
Timeline Horizontal example in the Docs was missing the horizontal boolean value on <Timeline> element


current Docs at  [Timeline Horizontal](https://www.flowbite-react.com/docs/components/timeline#horizontal-timeline)
![image](https://github.com/themesberg/flowbite-react/assets/32231977/551b7d1d-8225-4391-81e0-fd0e4df5c485)


**and below is the Current proposed fix in Docs**
![image](https://github.com/themesberg/flowbite-react/assets/32231977/f684d7a9-0ad0-4b8d-8fbb-13bea7811ed0)
