### PR TITLE
fix(dropdown.tsx): handling the Placeholder if the label isnt provided

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -191,7 +191,7 @@ const DropdownComponent: FC<DropdownProps> = ({
         getReferenceProps={getReferenceProps}
         renderTrigger={renderTrigger}
       >
-        {label}
+        {label ?? 'Dropdown Button'}
         {arrowIcon && <Icon className={theme.arrowIcon} />}
       </Trigger>
       {open && (


### PR DESCRIPTION
currently the Dropdown - the label has to be passed, if the there is no label, then showing default placeholder

fix #1260 