### PR TITLE
feat(button): Ghost button color

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -2,9 +2,15 @@ import Link from 'next/link';
 import type { FC } from 'react';
 import { BsGithub } from 'react-icons/bs';
 import { SiDiscord, SiStorybook } from 'react-icons/si';
-import { Badge, DarkThemeToggle, Tooltip } from '~/src';
+import { Badge, Button, DarkThemeToggle, Tooltip } from '~/src';
 import pkg from './../package.json' assert { type: 'json' };
 import { DocSearchInput } from './docsearch-input';
+
+const buttonIconTheme = {
+  size: {
+    md: 'p-2.5',
+  },
+};
 
 export const NavbarLinks: FC = () => {
   return (
@@ -44,30 +50,42 @@ export const NavbarIcons: FC = () => {
       <div className="lg:hidden">
         <DocSearchInput />
       </div>
-      <a
-        href="https://storybook.flowbite-react.com/"
-        className="hidden rounded-lg p-2.5 text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-700 lg:block"
-      >
-        <Tooltip animation={false} content="View Storybook">
+      <Tooltip animation={false} content="View Storybook">
+        <Button
+          as="a"
+          href="https://storybook.flowbite-react.com/"
+          color="ghost"
+          className="hidden p-0 lg:block"
+          theme={buttonIconTheme}
+        >
           <SiStorybook aria-hidden className="h-5 w-5" />
-        </Tooltip>
-      </a>
-      <a
-        href="https://discord.gg/4eeurUVvTy"
-        className="hidden rounded-lg p-2.5 text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-700 lg:block"
-      >
-        <Tooltip animation={false} content="Join Discord Community">
+        </Button>
+      </Tooltip>
+
+      <Tooltip animation={false} content="Join Discord Community">
+        <Button
+          as="a"
+          href="https://discord.gg/4eeurUVvTy"
+          color="ghost"
+          className="hidden p-0 lg:block"
+          theme={buttonIconTheme}
+        >
           <SiDiscord aria-hidden className="h-5 w-5" />
-        </Tooltip>
-      </a>
-      <a
-        href="https://github.com/themesberg/flowbite-react"
-        className="hidden rounded-lg p-2.5 text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-gray-700 lg:block"
-      >
-        <Tooltip animation={false} content="View on GitHub">
+        </Button>
+      </Tooltip>
+
+      <Tooltip animation={false} content="View on GitHub">
+        <Button
+          as="a"
+          href="https://github.com/themesberg/flowbite-react"
+          color="ghost"
+          className="hidden p-0 lg:block"
+          theme={buttonIconTheme}
+        >
           <BsGithub aria-hidden className="h-5 w-5" />
-        </Tooltip>
-      </a>
+        </Button>
+      </Tooltip>
+
       <Tooltip animation={false} content="Toggle dark mode">
         <DarkThemeToggle />
       </Tooltip>

--- a/examples/button/button.iconOnly.tsx
+++ b/examples/button/button.iconOnly.tsx
@@ -23,6 +23,12 @@ function Component() {
       <Button outline pill>
         <HiOutlineArrowRight className="h-6 w-6" />
       </Button>
+      <Button color="ghost">
+        <HiOutlineArrowRight className="h-6 w-6" />
+      </Button>
+      <Button color="ghost" className="p-0" theme={{ size: { md: 'p-2.5' } }}>
+        <HiOutlineArrowRight className="h-6 w-6" />
+      </Button>
     </div>
   );
 }
@@ -47,6 +53,12 @@ function Component() {
       <Button outline pill>
         <HiOutlineArrowRight className="h-6 w-6" />
       </Button>
+      <Button color="ghost">
+        <HiOutlineArrowRight className="h-6 w-6" />
+      </Button>
+      <Button color="ghost" className="p-0" theme={{ size: { md: 'p-2.5' } }}>
+        <HiOutlineArrowRight className="h-6 w-6" />
+      </Button>
     </div>
   );
 }
@@ -65,6 +77,12 @@ function Component() {
         <HiOutlineArrowRight className="h-6 w-6" />
       </Button>
       <Button outline pill>
+        <HiOutlineArrowRight className="h-6 w-6" />
+      </Button>
+      <Button color="ghost">
+        <HiOutlineArrowRight className="h-6 w-6" />
+      </Button>
+      <Button color="ghost" className="p-0" theme={{ size: { md: 'p-2.5' } }}>
         <HiOutlineArrowRight className="h-6 w-6" />
       </Button>
     </div>

--- a/examples/button/button.pill.tsx
+++ b/examples/button/button.pill.tsx
@@ -13,6 +13,9 @@ function Component() {
       <Button color="blue" pill>
         Blue
       </Button>
+      <Button color="ghost" pill>
+        Ghost
+      </Button>
       <Button color="gray" pill>
         Gray
       </Button>
@@ -49,6 +52,9 @@ function Component() {
       <Button color="blue" pill>
         Blue
       </Button>
+      <Button color="ghost" pill>
+        Ghost
+      </Button>
       <Button color="gray" pill>
         Gray
       </Button>
@@ -81,6 +87,9 @@ function Component() {
       <Button pill>Default</Button>
       <Button color="blue" pill>
         Blue
+      </Button>
+      <Button color="ghost" pill>
+        Ghost
       </Button>
       <Button color="gray" pill>
         Gray

--- a/examples/button/button.root.tsx
+++ b/examples/button/button.root.tsx
@@ -11,6 +11,7 @@ function Component() {
     <div className="flex flex-wrap gap-2">
       <Button>Default</Button>
       <Button color="blue">Blue</Button>
+      <Button color="ghost">Ghost</Button>
       <Button color="gray">Gray</Button>
       <Button color="dark">Dark</Button>
       <Button color="light">Light</Button>
@@ -31,6 +32,7 @@ function Component() {
     <div className="flex flex-wrap gap-2">
       <Button>Default</Button>
       <Button color="blue">Blue</Button>
+      <Button color="ghost">Ghost</Button>
       <Button color="gray">Gray</Button>
       <Button color="dark">Dark</Button>
       <Button color="light">Light</Button>
@@ -48,6 +50,7 @@ function Component() {
     <div className="flex flex-wrap gap-2">
       <Button>Default</Button>
       <Button color="blue">Blue</Button>
+      <Button color="ghost">Ghost</Button>
       <Button color="gray">Gray</Button>
       <Button color="dark">Dark</Button>
       <Button color="light">Light</Button>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -48,6 +48,7 @@ export interface FlowbiteButtonOutlineTheme extends FlowbiteBoolean {
 
 export interface ButtonColors
   extends Pick<FlowbiteColors, 'dark' | 'failure' | 'gray' | 'info' | 'light' | 'purple' | 'success' | 'warning'> {
+  ghost: string;
   [key: string]: string;
 }
 

--- a/src/components/Button/theme.ts
+++ b/src/components/Button/theme.ts
@@ -5,6 +5,8 @@ export const buttonTheme: FlowbiteButtonTheme = {
   base: 'group flex items-stretch items-center justify-center p-0.5 text-center font-medium relative focus:z-10 focus:outline-none transition-[color,background-color,border-color,text-decoration-color,fill,stroke,box-shadow]',
   fullSized: 'w-full',
   color: {
+    ghost:
+      'text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-700',
     dark: 'text-white bg-gray-800 border border-transparent enabled:hover:bg-gray-900 focus:ring-4 focus:ring-gray-300 dark:bg-gray-800 dark:enabled:hover:bg-gray-700 dark:focus:ring-gray-800 dark:border-gray-700',
     failure:
       'text-white bg-red-700 border border-transparent enabled:hover:bg-red-800 focus:ring-4 focus:ring-red-300 dark:bg-red-600 dark:enabled:hover:bg-red-700 dark:focus:ring-red-900',

--- a/src/components/DarkThemeToggle/DarkThemeToggle.tsx
+++ b/src/components/DarkThemeToggle/DarkThemeToggle.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ComponentProps, FC } from 'react';
+import type { ComponentPropsWithoutRef, FC } from 'react';
 import type { IconBaseProps } from 'react-icons';
 import { HiMoon, HiSun } from 'react-icons/hi';
 import { twMerge } from 'tailwind-merge';
@@ -9,6 +9,7 @@ import { mergeDeep } from '../../helpers/merge-deep';
 import { useThemeMode } from '../../hooks/use-theme-mode';
 import { getTheme } from '../../theme-store';
 import type { DeepPartial } from '../../types';
+import { Button } from '../Button';
 
 export interface FlowbiteDarkThemeToggleTheme {
   root: FlowbiteDarkThemeToggleRootTheme;
@@ -19,7 +20,7 @@ export interface FlowbiteDarkThemeToggleRootTheme {
   icon: string;
 }
 
-export interface DarkThemeToggleProps extends ComponentProps<'button'> {
+export interface DarkThemeToggleProps extends ComponentPropsWithoutRef<'button'> {
   iconDark?: FC<IconBaseProps>;
   iconLight?: FC<IconBaseProps>;
   theme?: DeepPartial<FlowbiteDarkThemeToggleTheme>;
@@ -38,10 +39,15 @@ export const DarkThemeToggle: FC<DarkThemeToggleProps> = ({
   const theme = mergeDeep(getTheme().darkThemeToggle, customTheme);
 
   return (
-    <button
-      type="button"
+    <Button
       aria-label="Toggle dark mode"
       data-testid="dark-theme-toggle"
+      color="ghost"
+      theme={{
+        size: {
+          md: 'p-0',
+        },
+      }}
       className={twMerge(theme.root.base, className)}
       onClick={toggleMode}
       {...props}
@@ -56,7 +62,7 @@ export const DarkThemeToggle: FC<DarkThemeToggleProps> = ({
         data-active={isMounted && computedMode === 'light'}
         className={twMerge(theme.root.icon, 'dark:hidden')}
       />
-    </button>
+    </Button>
   );
 };
 

--- a/src/components/DarkThemeToggle/theme.ts
+++ b/src/components/DarkThemeToggle/theme.ts
@@ -2,7 +2,7 @@ import type { FlowbiteDarkThemeToggleTheme } from './DarkThemeToggle';
 
 export const darkThemeToggleTheme: FlowbiteDarkThemeToggleTheme = {
   root: {
-    base: 'rounded-lg p-2.5 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-700',
+    base: 'rounded-lg p-2.5 text-sm',
     icon: 'h-5 w-5',
   },
 };


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

This PR creates the ghost button color, which basically was already a common button used throughout the docs app and by the `DarkThemeToggle`. Now this PR makes it available to use this style in the regular `Button` component

<img width="943" alt="image" src="https://github.com/themesberg/flowbite-react/assets/14295280/4c3c65a1-b118-49b5-91cd-63984db79857">

<img width="925" alt="image" src="https://github.com/themesberg/flowbite-react/assets/14295280/48e44d71-dc7a-48c9-ab01-8ac804f820d7">

<img width="982" alt="image" src="https://github.com/themesberg/flowbite-react/assets/14295280/6677d550-8d48-4ecf-ba18-122d1df1b169">

Reference related issues using `#` followed by the issue number.
Fix #857

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.
