### PR TITLE
fix(modal): modal overflowing bottom in chrome on ios

### DIFF
--- a/src/components/Modal/theme.ts
+++ b/src/components/Modal/theme.ts
@@ -33,7 +33,7 @@ export const modalTheme: FlowbiteModalTheme = {
   },
   content: {
     base: 'relative h-full w-full p-4 md:h-auto',
-    inner: 'relative rounded-lg bg-white shadow dark:bg-gray-700 flex flex-col max-h-[90vh]',
+    inner: 'relative rounded-lg bg-white shadow dark:bg-gray-700 flex flex-col max-h-[90dvh]',
   },
   body: {
     base: 'p-6 flex-1 overflow-auto',


### PR DESCRIPTION
Modal overflowing the bottom in chrome on ios due to not using dynamic viewport units.

- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

I fixed this problem in my personal project by changing the inner prop of modal's theme. This [answer](https://stackoverflow.com/a/77490743) helped me.

| Current | Fixed |
|--------|--------|
| ![IMG_3639](https://github.com/themesberg/flowbite-react/assets/9607568/4f905f42-7a55-4019-a725-fbee4c1183b6) | ![IMG_3638](https://github.com/themesberg/flowbite-react/assets/9607568/8355bfa2-15f3-4279-8fef-927dc733bb65) | 