### PR TITLE
Fix CSP violation in Carousel drag-scroll helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,11 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.2",
+    "classnames": "^2.5.1",
     "contentlayer": "^0.3.4",
+    "debounce": "^2.0.0",
     "flowbite": "^2.0.0",
     "react-icons": "^4.11.0",
-    "react-indiana-drag-scroll": "^2.2.0",
     "tailwind-merge": "^2.0.0"
   },
   "devDependencies": {

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -3,7 +3,7 @@
 import type { ComponentProps, FC, ReactElement, ReactNode } from 'react';
 import { Children, cloneElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { HiOutlineChevronLeft, HiOutlineChevronRight } from 'react-icons/hi';
-import ScrollContainer from 'react-indiana-drag-scroll';
+import ScrollContainer from '../../helpers/drag-scroll';
 import { twMerge } from 'tailwind-merge';
 import { isClient } from '../../helpers/is-client';
 import { mergeDeep } from '../../helpers/merge-deep';

--- a/src/helpers/drag-scroll/index.tsx
+++ b/src/helpers/drag-scroll/index.tsx
@@ -373,7 +373,9 @@ export default class ScrollContainer extends PureComponent<Props> {
         className={classnames(className, this.pressed && draggingClassName, {
           '!scroll-auto [&>*]:pointer-events-none [&>*]:cursor-grab': this.pressed,
           'overflow-auto': this.isMobile,
-          'hide-scrollbars': hideScrollbars,
+          'overflow-hidden !overflow-x-hidden [overflow:-moz-scrollbars-none] [scrollbar-width:none]': hideScrollbars,
+          '[&::-webkit-scrollbar]:[-webkit-appearance:none !important] [&::-webkit-scrollbar]:!hidden [&::-webkit-scrollbar]:!h-0 [&::-webkit-scrollbar]:!w-0 [&::-webkit-scrollbar]:!bg-transparent':
+            hideScrollbars,
         })}
         style={style}
         ref={this.getRef}

--- a/src/helpers/drag-scroll/index.tsx
+++ b/src/helpers/drag-scroll/index.tsx
@@ -1,0 +1,386 @@
+import type { CSSProperties, ElementType, MutableRefObject, ReactNode, Ref, RefObject } from 'react';
+import React, { PureComponent } from 'react';
+import classnames from 'classnames';
+import debounce from 'debounce';
+
+export interface ScrollEvent {
+  external: boolean;
+}
+
+export interface ScrollContainerProps {
+  vertical?: boolean;
+  horizontal?: boolean;
+  hideScrollbars?: boolean;
+  activationDistance?: number;
+  children?: ReactNode;
+  onStartScroll?: (event: ScrollEvent) => void;
+  onScroll?: (event: ScrollEvent) => void;
+  onEndScrolll?: (event: ScrollEvent) => void;
+  onClick?: (event: MouseEvent) => void;
+  className?: string;
+  draggingClassName?: string;
+  style?: CSSProperties;
+  ignoreElements?: string;
+  nativeMobileScroll?: boolean;
+  ref?: ReactNode;
+  component?: ElementType;
+  innerRef?: Ref<HTMLElement>;
+  stopPropagation?: boolean;
+  buttons?: number[];
+}
+
+const SCROLL_END_DEBOUNCE = 300;
+
+const LEFT_BUTTON = 0;
+
+export interface ScrollEvent {
+  external: boolean;
+}
+
+interface Props {
+  vertical?: boolean;
+  horizontal?: boolean;
+  hideScrollbars?: boolean;
+  activationDistance?: number;
+  children?: ReactNode;
+  onStartScroll?: (event: ScrollEvent) => void;
+  onScroll?: (event: ScrollEvent) => void;
+  onEndScroll?: (event: ScrollEvent) => void;
+  onClick?: (event: MouseEvent) => void;
+  className?: string;
+  draggingClassName?: string;
+  style?: CSSProperties;
+  ignoreElements?: string;
+  nativeMobileScroll?: boolean;
+  ref?: ReactNode;
+  innerRef?: Ref<HTMLElement>;
+  stopPropagation?: boolean;
+  buttons?: number[];
+}
+
+export default class ScrollContainer extends PureComponent<Props> {
+  static defaultProps = {
+    nativeMobileScroll: true,
+    hideScrollbars: true,
+    activationDistance: 10,
+    vertical: true,
+    horizontal: true,
+    stopPropagation: false,
+    style: {},
+    buttons: [LEFT_BUTTON],
+  };
+  container: RefObject<HTMLElement>;
+  scrolling: boolean;
+  started: boolean;
+  pressed: boolean;
+  isMobile: boolean = false;
+  internal: boolean;
+
+  scrollLeft?: number;
+  scrollTop?: number;
+  clientX?: number;
+  clientY?: number;
+
+  constructor(props: ScrollContainerProps) {
+    super(props);
+    this.container = React.createRef();
+    this.onEndScroll = debounce(this.onEndScroll, SCROLL_END_DEBOUNCE);
+
+    // Is container scrolling now (for example by inertia)
+    this.scrolling = false;
+    // Is scrolling started
+    this.started = false;
+    // Is touch active or mouse pressed down
+    this.pressed = false;
+    // Is event internal
+    this.internal = false;
+
+    // Bind callbacks
+    this.getRef = this.getRef.bind(this);
+  }
+
+  componentDidMount() {
+    const { nativeMobileScroll } = this.props;
+    const container = this.container.current!;
+
+    window.addEventListener('mouseup', this.onMouseUp);
+    window.addEventListener('mousemove', this.onMouseMove);
+    window.addEventListener('touchmove', this.onTouchMove, { passive: false });
+    window.addEventListener('touchend', this.onTouchEnd);
+
+    // due to https://github.com/facebook/react/issues/9809#issuecomment-414072263
+    container.addEventListener('touchstart', this.onTouchStart, {
+      passive: false,
+    });
+    container.addEventListener('mousedown', this.onMouseDown, {
+      passive: false,
+    });
+
+    if (nativeMobileScroll) {
+      // We should check if it's the mobile device after page was loaded
+      // to prevent breaking SSR
+      this.isMobile = this.isMobileDevice();
+
+      // If it's the mobile device, we should rerender to change styles
+      if (this.isMobile) {
+        this.forceUpdate();
+      }
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('mouseup', this.onMouseUp);
+    window.removeEventListener('mousemove', this.onMouseMove);
+    window.removeEventListener('touchmove', this.onTouchMove);
+    window.removeEventListener('touchend', this.onTouchEnd);
+  }
+
+  getElement() {
+    return this.container.current;
+  }
+
+  isMobileDevice() {
+    return typeof window.orientation !== 'undefined' || navigator.userAgent.indexOf('IEMobile') !== -1;
+  }
+
+  isDraggable(target: HTMLElement) {
+    const ignoreElements = this.props.ignoreElements;
+    if (ignoreElements) {
+      const closest = target.closest(ignoreElements);
+      return closest === null || closest.contains(this.getElement());
+    } else {
+      return true;
+    }
+  }
+
+  isScrollable() {
+    const container = this.container.current;
+    return (
+      container && (container.scrollWidth > container.clientWidth || container.scrollHeight > container.clientHeight)
+    );
+  }
+
+  // Simulate 'onEndScroll' event that fires when scrolling is stopped
+  onEndScroll = () => {
+    this.scrolling = false;
+    if (!this.pressed && this.started) {
+      this.processEnd();
+    }
+  };
+
+  onScroll = () => {
+    const container = this.container.current!;
+    // Ignore the internal scrolls
+    if (container.scrollLeft !== this.scrollLeft || container.scrollTop !== this.scrollTop) {
+      this.scrolling = true;
+      this.processScroll();
+      this.onEndScroll();
+    }
+  };
+
+  onTouchStart = (e: TouchEvent) => {
+    const { nativeMobileScroll } = this.props;
+    if (this.isDraggable(e.target as HTMLElement)) {
+      this.internal = true;
+      if (nativeMobileScroll && this.scrolling) {
+        this.pressed = true;
+      } else {
+        const touch = e.touches[0];
+        this.processClick(touch.clientX, touch.clientY);
+        if (!nativeMobileScroll && this.props.stopPropagation) {
+          e.stopPropagation();
+        }
+      }
+    }
+  };
+
+  onTouchEnd = () => {
+    const { nativeMobileScroll } = this.props;
+    if (this.pressed) {
+      if (this.started && (!this.scrolling || !nativeMobileScroll)) {
+        this.processEnd();
+      } else {
+        this.pressed = false;
+      }
+      this.forceUpdate();
+    }
+  };
+
+  onTouchMove = (e: TouchEvent) => {
+    const { nativeMobileScroll } = this.props;
+    if (this.pressed && (!nativeMobileScroll || !this.isMobile)) {
+      const touch = e.touches[0];
+      if (touch) {
+        this.processMove(touch.clientX, touch.clientY);
+      }
+      e.preventDefault();
+      if (this.props.stopPropagation) {
+        e.stopPropagation();
+      }
+    }
+  };
+
+  onMouseDown = (e: MouseEvent) => {
+    if (this.isDraggable(e.target as HTMLElement) && this.isScrollable()) {
+      this.internal = true;
+      if (this.props?.buttons?.indexOf(e.button) !== -1) {
+        this.processClick(e.clientX, e.clientY);
+        e.preventDefault();
+        if (this.props.stopPropagation) {
+          e.stopPropagation();
+        }
+      }
+    }
+  };
+
+  onMouseMove = (e: MouseEvent) => {
+    if (this.pressed) {
+      this.processMove(e.clientX, e.clientY);
+      e.preventDefault();
+      if (this.props.stopPropagation) {
+        e.stopPropagation();
+      }
+    }
+  };
+
+  onMouseUp = (e: MouseEvent) => {
+    if (this.pressed) {
+      if (this.started) {
+        this.processEnd();
+      } else {
+        this.internal = false;
+        this.pressed = false;
+        this.forceUpdate();
+        if (this.props.onClick) {
+          this.props.onClick(e);
+        }
+      }
+      e.preventDefault();
+      if (this.props.stopPropagation) {
+        e.stopPropagation();
+      }
+    }
+  };
+
+  processClick(clientX: number, clientY: number) {
+    const container = this.container.current;
+    this.scrollLeft = container?.scrollLeft;
+    this.scrollTop = container?.scrollTop;
+    this.clientX = clientX;
+    this.clientY = clientY;
+    this.pressed = true;
+  }
+
+  processStart(changeCursor = true) {
+    const { onStartScroll } = this.props;
+
+    this.started = true;
+
+    // Add the class to change displayed cursor
+    if (changeCursor) {
+      document.body.classList.add('cursor-grab');
+    }
+
+    if (onStartScroll) {
+      onStartScroll({
+        external: !this.internal,
+      });
+    }
+    this.forceUpdate();
+  }
+
+  // Process native scroll (scrollbar, mobile scroll)
+  processScroll() {
+    if (this.started) {
+      const { onScroll } = this.props;
+      if (onScroll) {
+        onScroll({
+          external: !this.internal,
+        });
+      }
+    } else {
+      this.processStart(false);
+    }
+  }
+
+  // Process non-native scroll
+  processMove(newClientX: number, newClientY: number) {
+    const { horizontal, vertical, activationDistance, onScroll } = this.props;
+    const container = this.container.current!;
+
+    if (!this.started) {
+      if (
+        (horizontal && Math.abs(newClientX - this.clientX!) > activationDistance!) ||
+        (vertical && Math.abs(newClientY - this.clientY!) > activationDistance!)
+      ) {
+        this.clientX = newClientX;
+        this.clientY = newClientY;
+        this.processStart();
+      }
+    } else {
+      if (horizontal) {
+        container.scrollLeft -= newClientX - this.clientX!;
+      }
+      if (vertical) {
+        container.scrollTop -= newClientY - this.clientY!;
+      }
+      if (onScroll) {
+        onScroll({ external: !this.internal });
+      }
+      this.clientX = newClientX;
+      this.clientY = newClientY;
+      this.scrollLeft = container.scrollLeft;
+      this.scrollTop = container.scrollTop;
+    }
+  }
+
+  processEnd() {
+    const { onEndScroll } = this.props;
+    const container = this.container.current;
+
+    if (container && onEndScroll) {
+      onEndScroll({
+        external: !this.internal,
+      });
+    }
+
+    this.pressed = false;
+    this.started = false;
+    this.scrolling = false;
+    this.internal = false;
+
+    document.body.classList.remove('cursor-grab');
+    this.forceUpdate();
+  }
+
+  getRef(el: HTMLDivElement) {
+    [this.container, this.props.innerRef].forEach((ref) => {
+      if (ref) {
+        if (typeof ref === 'function') {
+          ref(el);
+        } else {
+          (ref as MutableRefObject<HTMLElement>).current = el;
+        }
+      }
+    });
+  }
+
+  render() {
+    const { children, draggingClassName, className, style, hideScrollbars } = this.props;
+
+    return (
+      <div
+        className={classnames(className, this.pressed && draggingClassName, {
+          '!scroll-auto [&>*]:pointer-events-none [&>*]:cursor-grab': this.pressed,
+          'overflow-auto': this.isMobile,
+          'hide-scrollbars': hideScrollbars,
+        })}
+        style={style}
+        ref={this.getRef}
+        onScroll={this.onScroll}
+      >
+        {children}
+      </div>
+    );
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,18 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  .hide-scrollbars::-webkit-scrollbar {
+    display: none !important;
+    height: 0 !important;
+    width: 0 !important;
+    background: transparent !important;
+    -webkit-appearance: none !important;
+  }
+  .hide-scrollbars {
+    overflow: hidden;
+    overflow: -moz-scrollbars-none;
+    scrollbar-width: none;
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,18 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@layer utilities {
-  .hide-scrollbars::-webkit-scrollbar {
-    display: none !important;
-    height: 0 !important;
-    width: 0 !important;
-    background: transparent !important;
-    -webkit-appearance: none !important;
-  }
-  .hide-scrollbars {
-    overflow: hidden;
-    overflow: -moz-scrollbars-none;
-    scrollbar-width: none;
-  }
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5597,10 +5597,10 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-classnames@^2.2.6:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
-  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+classnames@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
 
 clean-css@^5.2.2:
   version "5.3.3"
@@ -6409,10 +6409,10 @@ dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
   integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
 
-debounce@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
-  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
+debounce@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-2.0.0.tgz#b2f914518a1481466f4edaee0b063e4d473ad549"
+  integrity sha512-xRetU6gL1VJbs85Mc4FoEGSjQxzpdxRyFhe3lmWFyy2EzydIcD4xzUvRJMD+NPDfMwKNhxa3PvsIOU32luIWeA==
 
 debug@2.6.9, debug@^2.6.9:
   version "2.6.9"
@@ -6816,11 +6816,6 @@ eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
-
-easy-bem@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/easy-bem/-/easy-bem-1.1.1.tgz#1bfcc10425498090bcfddc0f9c000aba91399e03"
-  integrity sha512-GJRqdiy2h+EXy6a8E6R+ubmqUM08BK0FWNq41k24fup6045biQ8NXxoXimiwegMQvFFV3t1emADdGNL1TlS61A==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -12739,15 +12734,6 @@ react-icons@^4.11.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.12.0.tgz#54806159a966961bfd5cdb26e492f4dafd6a8d78"
   integrity sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==
-
-react-indiana-drag-scroll@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-indiana-drag-scroll/-/react-indiana-drag-scroll-2.2.0.tgz#657e14bbdf4888cc738e9fa8dc4384d76c348c0b"
-  integrity sha512-+W/3B2OQV0FrbdnsoIo4dww/xpH0MUQJz6ziQb7H+oBko3OCbXuzDFYnho6v6yhGrYDNWYPuFUewb89IONEl/A==
-  dependencies:
-    classnames "^2.2.6"
-    debounce "^1.2.0"
-    easy-bem "^1.1.1"
 
 react-is@18.1.0:
   version "18.1.0"


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Users of flowbite-react with a strict CSP will not permit inline styles. In order to whitelist inline styles in a CSP, you must add the `unsafe-inline` value to the `style-src` directive. Allowing inline styles opens the application up to cross-site scripting attacks (XSS). 

The `<Carousel>` component in flowbite-react indirectly introduces inline styles via the `react-indiana-drag-scroll` library, which [inlines all of its styles via the build process](https://github.com/Norserium/react-indiana-drag-scroll/blob/6b76dcbddfcbc69a48411f91f68f266901e24694/rollup.config.js#L35).

I considered updating react-indiana-drag-scroll's build config to avoid inlining the styles, but that would introduce a signifiant breaking change for all other users of the library. So, given the small size of the dependency's codebase (1 file) and the fact that the library is already stable (no changes for 2+ years), I felt it was best to simply hoist the code into react-flowbite and do away with the inline styles by leaning on TailwindCSS classes instead. react-indiana-drag-scroll's MIT license fully permits this move.

The 2 new dependencies were dependencies of react-indiana-drag-scroll. I attempted to limit changes to that code as much as possible, to avoid regressions. But some changes were needed to address improper use of TypeScript in that project.

I did some basic manual tests in the development environment on the carousel page, and everything appears to work as expected.

I did not add tests as the dependency itself also did not have any tests to speak of.