### PR TITLE
fix(Datepicker): expose focus() and clear() methods via ref.

### DIFF
--- a/src/components/Datepicker/Datepicker.spec.tsx
+++ b/src/components/Datepicker/Datepicker.spec.tsx
@@ -1,8 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, renderHook, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import type { DatepickerRef } from './Datepicker';
 import { Datepicker } from './Datepicker';
 import { getFormattedDate } from './helpers';
 import userEvent from '@testing-library/user-event';
+import { useRef } from 'react';
 
 describe('Components / Datepicker', () => {
   it("should display today's date by default", () => {
@@ -73,5 +75,33 @@ describe('Components / Datepicker', () => {
 
     await userEvent.click(screen.getByRole('textbox'));
     await userEvent.click(document.body);
+  });
+
+  it('should focus the input when ref.current.focus is called', () => {
+    const {
+      result: { current: ref },
+    } = renderHook(() => useRef<DatepickerRef>(null));
+    render(<Datepicker ref={ref} />);
+
+    act(() => ref.current?.focus());
+
+    expect(screen.getByRole('textbox')).toHaveFocus();
+  });
+
+  it('should clear the value when ref.current.clear is called', async () => {
+    const todaysDateInDefaultLanguage = getFormattedDate('en', new Date());
+    const todaysDayOfMonth = new Date().getDate();
+    const anotherDay = todaysDayOfMonth === 1 ? 2 : 1;
+
+    const {
+      result: { current: ref },
+    } = renderHook(() => useRef<DatepickerRef>(null));
+    render(<Datepicker ref={ref} />);
+
+    await userEvent.click(screen.getByRole('textbox'));
+    await userEvent.click(screen.getAllByText(anotherDay)[0]);
+    act(() => ref.current?.clear());
+
+    expect(screen.getByDisplayValue(todaysDateInDefaultLanguage)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #1299 (possibly #1039)

- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

# Summarize the changes made and the motivation behind them.

Enhanced the Datepicker component to expose `clear()` and `focus()` ref methods.
This is required when datepicker value is in controlled mode.

# Reference related issues using `#` followed by the issue number.
Closes #1299 and (possibly #1039)

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.

No breaking changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the Datepicker component to support direct manipulation through `focus` and `clear` methods.
- **Refactor**
	- Improved the Datepicker component's architecture for better usability and control.
- **Tests**
	- Added new tests to ensure the functionality of focusing and clearing values in the Datepicker component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->