### PR TITLE
Fix broken contributing link in UI README

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -321,7 +321,7 @@ For casual chatting with others using the library:
 
 ## Contributing
 
-Thank you for your interest in helping! Visit our [guide on contributing](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md) to get started.
+Thank you for your interest in helping! Visit our [guide on contributing](https://github.com/themesberg/flowbite-react/blob/main/.github/CONTRIBUTING.md) to get started.
 
 ## Figma
 


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Just fixes a broken link in the README, which I noticed when attempting to review the contributor's guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the link to the contributing guide in the UI package documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->