### PR TITLE
Fix React warning in ButtonGroup

### DIFF
--- a/packages/ui/src/components/Button/ButtonGroup.tsx
+++ b/packages/ui/src/components/Button/ButtonGroup.tsx
@@ -4,7 +4,7 @@ import { twMerge } from "tailwind-merge";
 import { mergeDeep } from "../../helpers/merge-deep";
 import { getTheme } from "../../theme-store";
 import type { DeepPartial } from "../../types";
-import type { ButtonProps } from "../Button";
+import { Button, type ButtonProps } from "../Button";
 
 export interface FlowbiteButtonGroupTheme {
   base: string;
@@ -29,19 +29,20 @@ const processChildren = (
 ): ReactNode => {
   return Children.map(children as ReactElement<ButtonProps>[], (child, index) => {
     if (isValidElement(child)) {
+      const positionInGroupProp = (child.type == Button) ? { positionInGroup: determinePosition(index, Children.count(children)) } : {};
       // Check if the child has nested children
       if (child.props.children) {
         // Recursively process nested children
         return cloneElement(child, {
           ...child.props,
           children: processChildren(child.props.children, outline, pill),
-          positionInGroup: determinePosition(index, Children.count(children)),
+          ...positionInGroupProp
         });
       } else {
         return cloneElement(child, {
           outline,
           pill,
-          positionInGroup: determinePosition(index, Children.count(children)),
+          ...positionInGroupProp
         });
       }
     }
@@ -49,7 +50,7 @@ const processChildren = (
   });
 };
 
-const determinePosition = (index: number, totalChildren: number) => {
+const determinePosition = (index: number, totalChildren: number): keyof PositionInButtonGroup => {
   return index === 0 ? "start" : index === totalChildren - 1 ? "end" : "middle";
 };
 


### PR DESCRIPTION
- [ x ] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

This change fixes the following issue that was introduced recently in commit d0dc810:

ButtonGroup was adding positionInGroup to all children rather than just Buttons.  For example, in the following, both the Buttons and the child spans get positionInGroup props:

```
<Button.Group>
  <Button><span>b1</span></Button>
  <Button><span>b2</span></Button>
</Button.Group>
```

This results in a React warning: “Warning: React does not recognize the `positionInGroup` prop on a DOM element...”

The review comment on the original commit hints at this issue as well:

https://github.com/themesberg/flowbite-react/pull/1273#issuecomment-1991553683
