### PR TITLE
ci: add `release` workflow

### DIFF
--- a/.changeset/quick-avocados-reflect.md
+++ b/.changeset/quick-avocados-reflect.md
@@ -1,5 +1,0 @@
----
-"flowbite-react": patch
----
-
-add github release workflow

--- a/.changeset/quick-avocados-reflect.md
+++ b/.changeset/quick-avocados-reflect.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+add github release workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Run build
+        run: bun run build
+
+      - name: Create Release Pull Request or Publish to NPM
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: bun run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This will allow us to easily release packages in a more elegant manner by just merging a PR, when ready.

### Changes

- [x] add github `release` workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Implemented a workflow for automating the release process, including building and publishing releases or NPM packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->