### PR TITLE
Add suppressHydrationWarning for nextJS

### DIFF
--- a/apps/web/content/docs/guides/next-js.mdx
+++ b/apps/web/content/docs/guides/next-js.mdx
@@ -146,7 +146,7 @@ import { ThemeModeScript } from "flowbite-react";
 
 export default function RootLayout({ children }) {
   return (
-    <html>
+    <html suppressHydrationWarning>
       <head>
         <ThemeModeScript />
       </head>
@@ -165,7 +165,7 @@ import { ThemeModeScript } from "flowbite-react";
 
 export default function Document() {
   return (
-    <Html>
+    <Html suppressHydrationWarning>
       <Head>
         <ThemeModeScript />
       </Head>


### PR DESCRIPTION
Using darkMode can lead to an hydratation warning.

As described in nextjs doc `While rendering your application, there was a difference between the React tree that was pre-rendered from the server and the React tree that was rendered during the first render in the browser (hydration).`

https://nextjs.org/docs/messages/react-hydration-error

https://github.com/pacocoursey/next-themes?tab=readme-ov-file#with-app



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Documentation**
	- Updated the Next.js guide to include information on suppressing hydration warnings in `RootLayout` and `Document` components.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->