### PR TITLE
feat(web) add new example of advanced list component

### DIFF
--- a/apps/web/content/docs/typography/list.mdx
+++ b/apps/web/content/docs/typography/list.mdx
@@ -41,6 +41,12 @@ Use the `ordered` prop tag to create an ordered list of items with numbers.
 
 <Example name="list.ordered" />
 
+## Advanced layout
+
+This example can be used to show more details for each list item such as the user’s name, email and profile picture.
+
+<Example name="list.advanced" />
+
 ## Horizontal list
 
 Use this example to create a horizontally aligned list of items.

--- a/apps/web/content/docs/typography/list.mdx
+++ b/apps/web/content/docs/typography/list.mdx
@@ -1,6 +1,6 @@
 ---
 title: React Lists - Flowbite
-description: Use the list component to show an unordered or ordered list of items based on multiple styles, layouts, and variants built with Tailwind CSS and Flowbite.
+description: Use the list component to show an unordered or ordered list of items based on multiple styles, layouts, and variants built with Tailwind CSS and Flowbite
 ---
 
 Get started with a collection of list components built with Tailwind CSS for ordered and unordered lists with bullets, numbers, or icons and other styles and layouts to show a list of items inside an article or throughout your web page.

--- a/apps/web/content/docs/typography/list.mdx
+++ b/apps/web/content/docs/typography/list.mdx
@@ -1,6 +1,6 @@
 ---
 title: React Lists - Flowbite
-description: Use the list component to show an unordered or ordered list of items based on multiple styles, layouts, and variants built with Tailwind CSS and Flowbite
+description: Use the list component to show an unordered or ordered list of items based on multiple styles, layouts, and variants built with Tailwind CSS and Flowbite.
 ---
 
 Get started with a collection of list components built with Tailwind CSS for ordered and unordered lists with bullets, numbers, or icons and other styles and layouts to show a list of items inside an article or throughout your web page.

--- a/apps/web/examples/list/index.ts
+++ b/apps/web/examples/list/index.ts
@@ -1,3 +1,4 @@
+export { advanced } from "./list.advanced";
 export { horizontal } from "./list.horizontal";
 export { icon } from "./list.icon";
 export { nested } from "./list.nested";

--- a/apps/web/examples/list/list.advanced.tsx
+++ b/apps/web/examples/list/list.advanced.tsx
@@ -21,9 +21,7 @@ function Component() {
       </ListItem>
       <ListItem className="py-3 sm:py-4">
         <div className="flex items-center space-x-4 rtl:space-x-reverse">
-          <div className="flex-shrink-0">
-            <img className="h-8 w-8 rounded-full" src="/images/people/profile-picture-3.jpg" alt="Neil image" />
-          </div>
+          <Avatar img="/images/people/profile-picture-3.jpg" alt="Neil image" rounded size="sm" />
           <div className="min-w-0 flex-1">
             <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Bonnie Green</p>
             <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
@@ -84,9 +82,7 @@ function Component() {
       </ListItem>
       <ListItem className="py-3 sm:py-4">
         <div className="flex items-center space-x-4 rtl:space-x-reverse">
-          <div className="flex-shrink-0">
-            <img className="h-8 w-8 rounded-full" src="/images/people/profile-picture-3.jpg" alt="Neil image" />
-          </div>
+          <Avatar img="/images/people/profile-picture-3.jpg" alt="Neil image" rounded size="sm" />
           <div className="min-w-0 flex-1">
             <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Bonnie Green</p>
             <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
@@ -144,9 +140,7 @@ function Component() {
       </ListItem>
       <ListItem className="py-3 sm:py-4">
         <div className="flex items-center space-x-4 rtl:space-x-reverse">
-          <div className="flex-shrink-0">
-            <img className="h-8 w-8 rounded-full" src="/images/people/profile-picture-3.jpg" alt="Neil image" />
-          </div>
+          <Avatar img="/images/people/profile-picture-3.jpg" alt="Neil image" rounded size="sm" />
           <div className="min-w-0 flex-1">
             <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Bonnie Green</p>
             <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>

--- a/apps/web/examples/list/list.advanced.tsx
+++ b/apps/web/examples/list/list.advanced.tsx
@@ -1,0 +1,207 @@
+import { Avatar, List, ListItem } from "flowbite-react";
+import { type CodeData } from "~/components/code-demo";
+
+const code = `
+"use client";
+
+import { List, Avatar } from "flowbite-react";
+
+function Component() {
+  return (
+    <List unstyled className="max-w-md divide-y divide-gray-200 dark:divide-gray-700">
+      <ListItem className="pb-3 sm:pb-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-1.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Neil Sims</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$320</div>
+        </div>
+      </ListItem>
+      <ListItem className="py-3 sm:py-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <div className="flex-shrink-0">
+            <img className="h-8 w-8 rounded-full" src="/images/people/profile-picture-3.jpg" alt="Neil image" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Bonnie Green</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$3467</div>
+        </div>
+      </ListItem>
+      <ListItem className="py-3 sm:py-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-2.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Michael Gough</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$67</div>
+        </div>
+      </ListItem>
+      <ListItem className="py-3 sm:py-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-5.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Thomas Lean</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$2367</div>
+        </div>
+      </ListItem>
+      <ListItem className="pb-0 pt-3 sm:pt-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-4.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Lana Byrd</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$367</div>
+        </div>
+      </ListItem>
+    </List>
+  );
+}
+`;
+
+const codeRSC = `
+import { Avatar, List, ListItem } from "flowbite-react";
+
+function Component() {
+  return (
+    <List unstyled className="max-w-md divide-y divide-gray-200 dark:divide-gray-700">
+      <ListItem className="pb-3 sm:pb-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-1.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Neil Sims</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$320</div>
+        </div>
+      </ListItem>
+      <ListItem className="py-3 sm:py-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <div className="flex-shrink-0">
+            <img className="h-8 w-8 rounded-full" src="/images/people/profile-picture-3.jpg" alt="Neil image" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Bonnie Green</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$3467</div>
+        </div>
+      </ListItem>
+      <ListItem className="py-3 sm:py-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-2.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Michael Gough</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$67</div>
+        </div>
+      </ListItem>
+      <ListItem className="py-3 sm:py-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-5.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Thomas Lean</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$2367</div>
+        </div>
+      </ListItem>
+      <ListItem className="pb-0 pt-3 sm:pt-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-4.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Lana Byrd</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$367</div>
+        </div>
+      </ListItem>
+    </List>
+  );
+}
+`;
+
+function Component() {
+  return (
+    <List unstyled className="max-w-md divide-y divide-gray-200 dark:divide-gray-700">
+      <ListItem className="pb-3 sm:pb-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-1.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Neil Sims</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$320</div>
+        </div>
+      </ListItem>
+      <ListItem className="py-3 sm:py-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <div className="flex-shrink-0">
+            <img className="h-8 w-8 rounded-full" src="/images/people/profile-picture-3.jpg" alt="Neil image" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Bonnie Green</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$3467</div>
+        </div>
+      </ListItem>
+      <ListItem className="py-3 sm:py-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-2.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Michael Gough</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$67</div>
+        </div>
+      </ListItem>
+      <ListItem className="py-3 sm:py-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-5.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Thomas Lean</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$2367</div>
+        </div>
+      </ListItem>
+      <ListItem className="pb-0 pt-3 sm:pt-4">
+        <div className="flex items-center space-x-4 rtl:space-x-reverse">
+          <Avatar img="/images/people/profile-picture-4.jpg" alt="Neil image" rounded size="sm" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white">Lana Byrd</p>
+            <p className="truncate text-sm text-gray-500 dark:text-gray-400">email@flowbite.com</p>
+          </div>
+          <div className="inline-flex items-center text-base font-semibold text-gray-900 dark:text-white">$367</div>
+        </div>
+      </ListItem>
+    </List>
+  );
+}
+
+export const advanced: CodeData = {
+  type: "single",
+  code: [
+    {
+      fileName: "client",
+      language: "tsx",
+      code,
+    },
+    {
+      fileName: "server",
+      language: "tsx",
+      code: codeRSC,
+    },
+  ],
+  githubSlug: "list/list.advanced.tsx",
+  component: <Component />,
+};


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Add new example of advanced list component

There are no breaking API changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced an "Advanced layout" section in the documentation to showcase enhanced list displays including user details like names, emails, and profile pictures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->