### PR TITLE
Fix typo in Range Slider documentation

### DIFF
--- a/apps/web/content/docs/components/forms.mdx
+++ b/apps/web/content/docs/components/forms.mdx
@@ -125,7 +125,7 @@ Use the `<ToggleSwitch>` component to ask users to enable or disable an option s
 
 ## Range slider
 
-The `<RangeSlider>` component ca be used to allow users to select a number based on a minimum and maximum value.
+The `<RangeSlider>` component can be used to allow users to select a number based on a minimum and maximum value.
 
 <Example name="forms.rangeSlider" />
 


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Spotted a small typo in the 'Range Slider' section of the docs. Might as well get rid of it!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typo in the description of the `<RangeSlider>` component in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->