### PR TITLE
docs: examples - preview iframe opt in

### DIFF
--- a/apps/web/app/examples/[name]/layout.tsx
+++ b/apps/web/app/examples/[name]/layout.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import type { PropsWithChildren } from "react";
+import { twMerge } from "tailwind-merge";
+
+export default function ExamplePageLayout({ children }: PropsWithChildren) {
+  const searchParams = useSearchParams();
+  const noPadding = searchParams.get("noPadding");
+
+  return <main className={twMerge(noPadding === null && "p-5")}>{children}</main>;
+}

--- a/apps/web/app/examples/[name]/page.tsx
+++ b/apps/web/app/examples/[name]/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from "next/navigation";
+
+interface Props {
+  params: {
+    name: string;
+  };
+}
+
+export default async function ExamplePage({ params }: Props) {
+  try {
+    const [key] = params.name.split(".");
+
+    const { Component } = await import(`~/examples/${key}/${params.name}`);
+
+    return Component ? <Component /> : notFound();
+  } catch (e) {
+    notFound();
+  }
+}

--- a/apps/web/examples/accordion/accordion.collapseAll.tsx
+++ b/apps/web/examples/accordion/accordion.collapseAll.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Accordion } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Accordion collapseAll>
       <Accordion.Panel>
@@ -83,7 +83,7 @@ function Component() {
 const codeRSC = `
 import { Accordion, AccordionContent, AccordionPanel, AccordionTitle } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Accordion collapseAll>
       <AccordionPanel>
@@ -157,7 +157,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Accordion collapseAll>
       <AccordionPanel>

--- a/apps/web/examples/accordion/accordion.root.tsx
+++ b/apps/web/examples/accordion/accordion.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Accordion } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Accordion>
       <Accordion.Panel>
@@ -83,7 +83,7 @@ function Component() {
 const codeRSC = `
 import { Accordion, AccordionContent, AccordionPanel, AccordionTitle } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Accordion>
       <AccordionPanel>
@@ -157,7 +157,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Accordion>
       <AccordionPanel>

--- a/apps/web/examples/alert/alert.additionalContent.tsx
+++ b/apps/web/examples/alert/alert.additionalContent.tsx
@@ -8,7 +8,7 @@ const code = `
 import { HiEye, HiInformationCircle } from "react-icons/hi";
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert additionalContent={<ExampleAdditionalContent />} color="warning" icon={HiInformationCircle}>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.
@@ -47,7 +47,7 @@ const codeRSC = `
 import { HiEye, HiInformationCircle } from "react-icons/hi";
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert additionalContent={<ExampleAdditionalContent />} color="warning" icon={HiInformationCircle}>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.
@@ -82,7 +82,7 @@ function ExampleAdditionalContent() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Alert additionalContent={<ExampleAdditionalContent />} color="warning" icon={HiInformationCircle}>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.

--- a/apps/web/examples/alert/alert.allOptions.tsx
+++ b/apps/web/examples/alert/alert.allOptions.tsx
@@ -8,7 +8,7 @@ const code = `
 import { HiEye, HiInformationCircle } from "react-icons/hi";
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert
       additionalContent={<ExampleAdditionalContent />}
@@ -23,7 +23,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Alert
       additionalContent={<ExampleAdditionalContent />}

--- a/apps/web/examples/alert/alert.borderAccent.tsx
+++ b/apps/web/examples/alert/alert.borderAccent.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert color="warning" withBorderAccent>
       <span>
@@ -20,7 +20,7 @@ function Component() {
 const codeRSC = `
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert color="warning" withBorderAccent>
       <span>
@@ -31,7 +31,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Alert color="warning" withBorderAccent>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.

--- a/apps/web/examples/alert/alert.dismissible.tsx
+++ b/apps/web/examples/alert/alert.dismissible.tsx
@@ -8,7 +8,7 @@ const code = `
 
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert color="success" onDismiss={() => alert('Alert dismissed!')}>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.
@@ -17,7 +17,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Alert color="success" onDismiss={() => alert("Alert dismissed!")}>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.

--- a/apps/web/examples/alert/alert.root.tsx
+++ b/apps/web/examples/alert/alert.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert color="info">
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.
@@ -18,7 +18,7 @@ function Component() {
 const codeRSC = `
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert color="info">
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.
@@ -27,7 +27,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Alert color="info">
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.

--- a/apps/web/examples/alert/alert.rounded.tsx
+++ b/apps/web/examples/alert/alert.rounded.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert color="warning" rounded>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.
@@ -18,7 +18,7 @@ function Component() {
 const codeRSC = `
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert color="warning" rounded>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.
@@ -27,7 +27,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Alert color="warning" rounded>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.

--- a/apps/web/examples/alert/alert.withIcon.tsx
+++ b/apps/web/examples/alert/alert.withIcon.tsx
@@ -8,7 +8,7 @@ const code = `
 import { HiInformationCircle } from "react-icons/hi";
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert color="failure" icon={HiInformationCircle}>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.
@@ -21,7 +21,7 @@ const codeRSC = `
 import { HiInformationCircle } from "react-icons/hi";
 import { Alert } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Alert color="failure" icon={HiInformationCircle}>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.
@@ -30,7 +30,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Alert color="failure" icon={HiInformationCircle}>
       <span className="font-medium">Info alert!</span> Change a few things up and try submitting again.

--- a/apps/web/examples/avatar/avatar.colors.tsx
+++ b/apps/web/examples/avatar/avatar.colors.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap gap-2">
@@ -31,7 +31,7 @@ function Component() {
 const codeRSC = `
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap gap-2">
@@ -53,7 +53,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap gap-2">

--- a/apps/web/examples/avatar/avatar.dotIndicator.tsx
+++ b/apps/web/examples/avatar/avatar.dotIndicator.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" status="online" />
@@ -21,7 +21,7 @@ function Component() {
 const codeRSC = `
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" status="online" />
@@ -33,7 +33,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" status="online" />

--- a/apps/web/examples/avatar/avatar.dropdown.tsx
+++ b/apps/web/examples/avatar/avatar.dropdown.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar, Dropdown } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown
       label={<Avatar alt="User settings" img="/images/people/profile-picture-5.jpg" rounded />}
@@ -30,7 +30,7 @@ function Component() {
 const codeRSC = `
 import { Avatar, Dropdown, DropdownDivider, DropdownHeader, DropdownItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown
       label={<Avatar alt="User settings" img="/images/people/profile-picture-5.jpg" rounded />}
@@ -51,7 +51,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Dropdown
       label={<Avatar alt="User settings" img="/images/people/profile-picture-5.jpg" rounded />}

--- a/apps/web/examples/avatar/avatar.overrideImage.tsx
+++ b/apps/web/examples/avatar/avatar.overrideImage.tsx
@@ -8,7 +8,7 @@ const code = `
 import Image from "next/image";
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar
@@ -41,7 +41,7 @@ const codeRSC = `
 import Image from "next/image";
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar
@@ -70,7 +70,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar

--- a/apps/web/examples/avatar/avatar.placeholder.tsx
+++ b/apps/web/examples/avatar/avatar.placeholder.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar />
@@ -19,7 +19,7 @@ function Component() {
 const codeRSC = `
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar />
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar />

--- a/apps/web/examples/avatar/avatar.placeholderInitials.tsx
+++ b/apps/web/examples/avatar/avatar.placeholderInitials.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar placeholderInitials="RR" />
@@ -19,7 +19,7 @@ function Component() {
 const codeRSC = `
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar placeholderInitials="RR" />
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar placeholderInitials="RR" />

--- a/apps/web/examples/avatar/avatar.root.tsx
+++ b/apps/web/examples/avatar/avatar.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" alt="avatar of Jese" rounded />
@@ -19,7 +19,7 @@ function Component() {
 const codeRSC = `
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" alt="avatar of Jese" rounded />
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" alt="avatar of Jese" rounded />

--- a/apps/web/examples/avatar/avatar.sizes.tsx
+++ b/apps/web/examples/avatar/avatar.sizes.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" size="xs" />
@@ -22,7 +22,7 @@ function Component() {
 const codeRSC = `
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" size="xs" />
@@ -35,7 +35,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" size="xs" />

--- a/apps/web/examples/avatar/avatar.stackedLayout.tsx
+++ b/apps/web/examples/avatar/avatar.stackedLayout.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar.Group>
@@ -31,7 +31,7 @@ function Component() {
 const codeRSC = `
 import { Avatar, AvatarGroup } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <AvatarGroup>
@@ -53,7 +53,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <AvatarGroup>

--- a/apps/web/examples/avatar/avatar.withBorder.tsx
+++ b/apps/web/examples/avatar/avatar.withBorder.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" rounded bordered />
@@ -19,7 +19,7 @@ function Component() {
 const codeRSC = `
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" rounded bordered />
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Avatar img="/images/people/profile-picture-5.jpg" rounded bordered />

--- a/apps/web/examples/avatar/avatar.withText.tsx
+++ b/apps/web/examples/avatar/avatar.withText.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Avatar img="/images/people/profile-picture-5.jpg" rounded>
       <div className="space-y-1 font-medium dark:text-white">
@@ -21,7 +21,7 @@ function Component() {
 const codeRSC = `
 import { Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Avatar img="/images/people/profile-picture-5.jpg" rounded>
       <div className="space-y-1 font-medium dark:text-white">
@@ -33,7 +33,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Avatar img="/images/people/profile-picture-5.jpg" rounded>
       <div className="space-y-1 font-medium dark:text-white">

--- a/apps/web/examples/badge/badge.asLink.tsx
+++ b/apps/web/examples/badge/badge.asLink.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Badge } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge href="#">Default</Badge>
@@ -21,7 +21,7 @@ function Component() {
 const codeRSC = `
 import { Badge } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge href="#">Default</Badge>
@@ -33,7 +33,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge href="#">Default</Badge>

--- a/apps/web/examples/badge/badge.root.tsx
+++ b/apps/web/examples/badge/badge.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Badge } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge color="info">Default</Badge>
@@ -25,7 +25,7 @@ function Component() {
 const codeRSC = `
 import { Badge } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge color="info">Default</Badge>
@@ -41,7 +41,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge color="info">Default</Badge>

--- a/apps/web/examples/badge/badge.sizes.tsx
+++ b/apps/web/examples/badge/badge.sizes.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Badge } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge color="info" size="sm">
@@ -41,7 +41,7 @@ function Component() {
 const codeRSC = `
 import { Badge } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge color="info" size="sm">
@@ -73,7 +73,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge color="info" size="sm">

--- a/apps/web/examples/badge/badge.withIcon.tsx
+++ b/apps/web/examples/badge/badge.withIcon.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Badge } from "flowbite-react";
 import { HiCheck, HiClock } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge icon={HiCheck}>2 minutes ago</Badge>
@@ -24,7 +24,7 @@ const codeRSC = `
 import { Badge } from "flowbite-react";
 import { HiCheck, HiClock } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge icon={HiCheck}>2 minutes ago</Badge>
@@ -36,7 +36,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge icon={HiCheck}>2 minutes ago</Badge>

--- a/apps/web/examples/badge/badge.withIconOnly.tsx
+++ b/apps/web/examples/badge/badge.withIconOnly.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Badge } from "flowbite-react";
 import { HiCheck, HiClock } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge icon={HiCheck} />
@@ -24,7 +24,7 @@ const codeRSC = `
 import { Badge } from "flowbite-react";
 import { HiCheck, HiClock } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge icon={HiCheck} />
@@ -36,7 +36,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Badge icon={HiCheck} />

--- a/apps/web/examples/banner/banner.bottomPosition.tsx
+++ b/apps/web/examples/banner/banner.bottomPosition.tsx
@@ -10,7 +10,7 @@ import { Banner } from "flowbite-react";
 import { HiArrowRight, HiX } from "react-icons/hi";
 import { MdPercent } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full justify-between border-t border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700">
@@ -45,7 +45,7 @@ import { Banner, BannerCollapseButton } from "flowbite-react";
 import { HiArrowRight, HiX } from "react-icons/hi";
 import { MdPercent } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full justify-between border-t border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700">
@@ -75,7 +75,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full justify-between border-t border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700">

--- a/apps/web/examples/banner/banner.informational.tsx
+++ b/apps/web/examples/banner/banner.informational.tsx
@@ -10,7 +10,7 @@ import { Banner } from "flowbite-react";
 import { FaBookOpen } from "react-icons/fa";
 import { HiArrowRight, HiX } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full flex-col justify-between border-b border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700 md:flex-row">
@@ -51,7 +51,7 @@ import { Banner, BannerCollapseButton } from "flowbite-react";
 import { FaBookOpen } from "react-icons/fa";
 import { HiArrowRight, HiX } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full flex-col justify-between border-b border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700 md:flex-row">
@@ -87,7 +87,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full flex-col justify-between border-b border-gray-200 bg-gray-50 p-4 md:flex-row dark:border-gray-600 dark:bg-gray-700">

--- a/apps/web/examples/banner/banner.marketingCTA.tsx
+++ b/apps/web/examples/banner/banner.marketingCTA.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Banner, Button } from "flowbite-react";
 import { HiX } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-[calc(100%-2rem)] flex-col justify-between rounded-lg border border-gray-100 bg-white p-4 shadow-sm dark:border-gray-600 dark:bg-gray-700 md:flex-row lg:max-w-7xl">
@@ -42,7 +42,7 @@ const codeRSC = `
 import { Banner, BannerCollapseButton } from "flowbite-react";
 import { HiX } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-[calc(100%-2rem)] flex-col justify-between rounded-lg border border-gray-100 bg-white p-4 shadow-sm dark:border-gray-600 dark:bg-gray-700 md:flex-row lg:max-w-7xl">
@@ -72,7 +72,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-[calc(100%-2rem)] flex-col justify-between rounded-lg border border-gray-100 bg-white p-4 shadow-sm md:flex-row lg:max-w-7xl dark:border-gray-600 dark:bg-gray-700">

--- a/apps/web/examples/banner/banner.newsletter.tsx
+++ b/apps/web/examples/banner/banner.newsletter.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Banner, Button, Label, TextInput } from "flowbite-react";
 import { HiX } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full items-center justify-between border-b border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700">
@@ -37,7 +37,7 @@ const codeRSC = `
 import { Banner, BannerCollapseButton, Button, Label, TextInput } from "flowbite-react";
 import { HiX } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full items-center justify-between border-b border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700">
@@ -62,7 +62,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full items-center justify-between border-b border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700">

--- a/apps/web/examples/banner/banner.root.tsx
+++ b/apps/web/examples/banner/banner.root.tsx
@@ -10,7 +10,7 @@ import { Banner } from "flowbite-react";
 import { HiX } from "react-icons/hi";
 import { MdAnnouncement } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full justify-between border-b border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700">
@@ -42,7 +42,7 @@ import { Banner, BannerCollapseButton } from "flowbite-react";
 import { HiX } from "react-icons/hi";
 import { MdAnnouncement } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full justify-between border-b border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700">
@@ -69,7 +69,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Banner>
       <div className="flex w-full justify-between border-b border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700">

--- a/apps/web/examples/blockquote/blockquote.center.tsx
+++ b/apps/web/examples/blockquote/blockquote.center.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-center">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -19,7 +19,7 @@ function Component() {
 const codeRSC = `
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-center">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-center">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to

--- a/apps/web/examples/blockquote/blockquote.icon.tsx
+++ b/apps/web/examples/blockquote/blockquote.icon.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote>
       <svg
@@ -28,7 +28,7 @@ function Component() {
 const codeRSC = `
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote>
       <svg
@@ -47,7 +47,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Blockquote>
       <svg

--- a/apps/web/examples/blockquote/blockquote.large.tsx
+++ b/apps/web/examples/blockquote/blockquote.large.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-2xl">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -19,7 +19,7 @@ function Component() {
 const codeRSC = `
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-2xl">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-2xl">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to

--- a/apps/web/examples/blockquote/blockquote.left.tsx
+++ b/apps/web/examples/blockquote/blockquote.left.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote>
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -19,7 +19,7 @@ function Component() {
 const codeRSC = `
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote>
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Blockquote>
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to

--- a/apps/web/examples/blockquote/blockquote.medium.tsx
+++ b/apps/web/examples/blockquote/blockquote.medium.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-xl">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -19,7 +19,7 @@ function Component() {
 const codeRSC = `
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-xl">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-xl">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to

--- a/apps/web/examples/blockquote/blockquote.paragraphContext.tsx
+++ b/apps/web/examples/blockquote/blockquote.paragraphContext.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       <p className="mb-3 text-gray-500 dark:text-gray-400">
@@ -40,7 +40,7 @@ function Component() {
 const codeRSC = `
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       <p className="mb-3 text-gray-500 dark:text-gray-400">
@@ -71,7 +71,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <>
       <p className="mb-3 text-gray-500 dark:text-gray-400">

--- a/apps/web/examples/blockquote/blockquote.right.tsx
+++ b/apps/web/examples/blockquote/blockquote.right.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-right">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -19,7 +19,7 @@ function Component() {
 const codeRSC = `
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-right">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-right">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to

--- a/apps/web/examples/blockquote/blockquote.root.tsx
+++ b/apps/web/examples/blockquote/blockquote.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote>
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -19,7 +19,7 @@ function Component() {
 const codeRSC = `
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote>
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Blockquote>
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to

--- a/apps/web/examples/blockquote/blockquote.small.tsx
+++ b/apps/web/examples/blockquote/blockquote.small.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-lg">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -19,7 +19,7 @@ function Component() {
 const codeRSC = `
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-lg">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Blockquote className="text-lg">
       "Flowbite is just awesome. It contains tons of predesigned components and pages starting from login screen to

--- a/apps/web/examples/blockquote/blockquote.solidBackground.tsx
+++ b/apps/web/examples/blockquote/blockquote.solidBackground.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       <p className="text-gray-500 dark:text-gray-400">
@@ -28,7 +28,7 @@ function Component() {
 const codeRSC = `
 import { Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       <p className="text-gray-500 dark:text-gray-400">
@@ -47,7 +47,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <>
       <p className="text-gray-500 dark:text-gray-400">

--- a/apps/web/examples/blockquote/blockquote.userReview.tsx
+++ b/apps/web/examples/blockquote/blockquote.userReview.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar, Blockquote, Rating } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <figure className="max-w-screen-md">
       <div className="mb-4 flex items-center">
@@ -39,7 +39,7 @@ function Component() {
 const codeRSC = `
 import { Avatar, Blockquote, Rating, RatingStar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <figure className="max-w-screen-md">
       <div className="mb-4 flex items-center">
@@ -69,7 +69,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <figure className="max-w-screen-md">
       <div className="mb-4 flex items-center">

--- a/apps/web/examples/blockquote/blockquote.userTestimonial.tsx
+++ b/apps/web/examples/blockquote/blockquote.userTestimonial.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Avatar, Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <figure className="mx-auto max-w-screen-md text-center">
       <svg
@@ -39,7 +39,7 @@ function Component() {
 const codeRSC = `
 import { Avatar, Blockquote } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <figure className="mx-auto max-w-screen-md text-center">
       <svg
@@ -69,7 +69,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <figure className="mx-auto max-w-screen-md text-center">
       <svg

--- a/apps/web/examples/breadcrumb/breadcrumb.backgroundColor.tsx
+++ b/apps/web/examples/breadcrumb/breadcrumb.backgroundColor.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Breadcrumb } from "flowbite-react";
 import { HiHome } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Breadcrumb aria-label="Solid background breadcrumb example" className="bg-gray-50 px-5 py-3 dark:bg-gray-800">
       <Breadcrumb.Item href="#" icon={HiHome}>
@@ -25,7 +25,7 @@ const codeRSC = `
 import { Breadcrumb, BreadcrumbItem } from "flowbite-react";
 import { HiHome } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Breadcrumb aria-label="Solid background breadcrumb example" className="bg-gray-50 px-5 py-3 dark:bg-gray-800">
       <BreadcrumbItem href="#" icon={HiHome}>
@@ -38,7 +38,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Breadcrumb aria-label="Solid background breadcrumb example" className="bg-gray-50 px-5 py-3 dark:bg-gray-800">
       <BreadcrumbItem href="#" icon={HiHome}>

--- a/apps/web/examples/breadcrumb/breadcrumb.root.tsx
+++ b/apps/web/examples/breadcrumb/breadcrumb.root.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Breadcrumb } from "flowbite-react";
 import { HiHome } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Breadcrumb aria-label="Default breadcrumb example">
       <Breadcrumb.Item href="#" icon={HiHome}>
@@ -25,7 +25,7 @@ const codeRSC = `
 import { Breadcrumb, BreadcrumbItem } from "flowbite-react";
 import { HiHome } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Breadcrumb aria-label="Default breadcrumb example">
       <BreadcrumbItem href="#" icon={HiHome}>
@@ -38,7 +38,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Breadcrumb aria-label="Default breadcrumb example">
       <BreadcrumbItem href="#" icon={HiHome}>

--- a/apps/web/examples/button/button.disabled.tsx
+++ b/apps/web/examples/button/button.disabled.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Button disabled>Disabled button</Button>;
 }
 `;
@@ -14,12 +14,12 @@ function Component() {
 const codeRSC = `
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Button disabled>Disabled button</Button>;
 }
 `;
 
-function Component() {
+export function Component() {
   return <Button disabled>Disabled button</Button>;
 }
 

--- a/apps/web/examples/button/button.gradientDuo.tsx
+++ b/apps/web/examples/button/button.gradientDuo.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button gradientDuoTone="purpleToBlue">Purple to Blue</Button>
@@ -24,7 +24,7 @@ function Component() {
 const codeRSC = `
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button gradientDuoTone="purpleToBlue">Purple to Blue</Button>
@@ -39,7 +39,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button gradientDuoTone="purpleToBlue">Purple to Blue</Button>

--- a/apps/web/examples/button/button.gradientMono.tsx
+++ b/apps/web/examples/button/button.gradientMono.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button gradientMonochrome="info">Info</Button>
@@ -25,7 +25,7 @@ function Component() {
 const codeRSC = `
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button gradientMonochrome="info">Info</Button>
@@ -41,7 +41,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button gradientMonochrome="info">Info</Button>

--- a/apps/web/examples/button/button.iconOnly.tsx
+++ b/apps/web/examples/button/button.iconOnly.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Button } from "flowbite-react";
 import { HiOutlineArrowRight } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button>
@@ -32,7 +32,7 @@ const codeRSC = `
 import { Button } from "flowbite-react";
 import { HiOutlineArrowRight } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button>
@@ -52,7 +52,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button>

--- a/apps/web/examples/button/button.loading.tsx
+++ b/apps/web/examples/button/button.loading.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-start gap-2">
       <Button size="xs" isProcessing>
@@ -32,7 +32,7 @@ function Component() {
 const codeRSC = `
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-start gap-2">
       <Button size="xs" isProcessing>
@@ -55,7 +55,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-start gap-2">
       <Button size="xs" isProcessing>

--- a/apps/web/examples/button/button.loadingSpinner.tsx
+++ b/apps/web/examples/button/button.loadingSpinner.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Button } from "flowbite-react";
 import { AiOutlineLoading } from "react-icons/ai";
 
-function Component() {
+export function Component() {
   return (
     <Button size="md" isProcessing processingSpinner={<AiOutlineLoading className="h-6 w-6 animate-spin" />}>
       Click me!
@@ -21,7 +21,7 @@ const codeRSC = `
 import { Button } from "flowbite-react";
 import { AiOutlineLoading } from "react-icons/ai";
 
-function Component() {
+export function Component() {
   return (
     <Button size="md" isProcessing processingSpinner={<AiOutlineLoading className="h-6 w-6 animate-spin" />}>
       Click me!
@@ -30,7 +30,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Button size="md" isProcessing processingSpinner={<AiOutlineLoading className="h-6 w-6 animate-spin" />}>
       Click me!

--- a/apps/web/examples/button/button.outline.tsx
+++ b/apps/web/examples/button/button.outline.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button outline gradientDuoTone="purpleToBlue">
@@ -38,7 +38,7 @@ function Component() {
 const codeRSC = `
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button outline gradientDuoTone="purpleToBlue">
@@ -67,7 +67,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button outline gradientDuoTone="purpleToBlue">

--- a/apps/web/examples/button/button.pill.tsx
+++ b/apps/web/examples/button/button.pill.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button pill>Default</Button>
@@ -42,7 +42,7 @@ function Component() {
 const codeRSC = `
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button pill>Default</Button>
@@ -75,7 +75,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button pill>Default</Button>

--- a/apps/web/examples/button/button.polymorph.tsx
+++ b/apps/web/examples/button/button.polymorph.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Button } from "flowbite-react";
 import Link from "next/link";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button as="span" className="cursor-pointer">
@@ -26,7 +26,7 @@ const codeRSC = `
 import { Button } from "flowbite-react";
 import Link from "next/link";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button as="span" className="cursor-pointer">
@@ -40,7 +40,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button as="span" className="cursor-pointer">

--- a/apps/web/examples/button/button.root.tsx
+++ b/apps/web/examples/button/button.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button>Default</Button>
@@ -26,7 +26,7 @@ function Component() {
 const codeRSC = `
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button>Default</Button>
@@ -43,7 +43,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button>Default</Button>

--- a/apps/web/examples/button/button.sizes.tsx
+++ b/apps/web/examples/button/button.sizes.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-start gap-2">
       <Button size="xs">Extra small</Button>
@@ -22,7 +22,7 @@ function Component() {
 const codeRSC = `
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-start gap-2">
       <Button size="xs">Extra small</Button>
@@ -35,7 +35,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-start gap-2">
       <Button size="xs">Extra small</Button>

--- a/apps/web/examples/button/button.withIcon.tsx
+++ b/apps/web/examples/button/button.withIcon.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Button } from "flowbite-react";
 import { HiOutlineArrowRight, HiShoppingCart } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button>
@@ -28,7 +28,7 @@ const codeRSC = `
 import { Button } from "flowbite-react";
 import { HiOutlineArrowRight, HiShoppingCart } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button>
@@ -44,7 +44,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button>

--- a/apps/web/examples/button/button.withLabel.tsx
+++ b/apps/web/examples/button/button.withLabel.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Button label="2">Messages</Button>;
 }
 `;
@@ -14,12 +14,12 @@ function Component() {
 const codeRSC = `
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Button label="2">Messages</Button>;
 }
 `;
 
-function Component() {
+export function Component() {
   return <Button label="2">Messages</Button>;
 }
 

--- a/apps/web/examples/buttonGroup/buttonGroup.colorOptions.tsx
+++ b/apps/web/examples/buttonGroup/buttonGroup.colorOptions.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button.Group>
@@ -32,7 +32,7 @@ function Component() {
 const codeRSC = `
 import { Button, ButtonGroup } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <ButtonGroup>
@@ -55,7 +55,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <ButtonGroup>

--- a/apps/web/examples/buttonGroup/buttonGroup.outline.tsx
+++ b/apps/web/examples/buttonGroup/buttonGroup.outline.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button.Group outline>
@@ -32,7 +32,7 @@ function Component() {
 const codeRSC = `
 import { Button, ButtonGroup } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <ButtonGroup outline>
@@ -55,7 +55,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <ButtonGroup outline>

--- a/apps/web/examples/buttonGroup/buttonGroup.outlineWithIcons.tsx
+++ b/apps/web/examples/buttonGroup/buttonGroup.outlineWithIcons.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Button } from "flowbite-react";
 import { HiAdjustments, HiCloudDownload, HiUserCircle } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Button.Group outline>
@@ -62,7 +62,7 @@ const codeRSC = `
 import { Button, ButtonGroup } from "flowbite-react";
 import { HiAdjustments, HiCloudDownload, HiUserCircle } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <ButtonGroup outline>
@@ -112,7 +112,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <ButtonGroup outline>

--- a/apps/web/examples/buttonGroup/buttonGroup.root.tsx
+++ b/apps/web/examples/buttonGroup/buttonGroup.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Button.Group>
       <Button color="gray">Profile</Button>
@@ -20,7 +20,7 @@ function Component() {
 const codeRSC = `
 import { Button, ButtonGroup } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <ButtonGroup>
       <Button color="gray">Profile</Button>
@@ -31,7 +31,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <ButtonGroup>
       <Button color="gray">Profile</Button>

--- a/apps/web/examples/buttonGroup/buttonGroup.withIcons.tsx
+++ b/apps/web/examples/buttonGroup/buttonGroup.withIcons.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Button } from "flowbite-react";
 import { HiAdjustments, HiCloudDownload, HiUserCircle } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Button.Group>
       <Button color="gray">
@@ -32,7 +32,7 @@ const codeRSC = `
 import { Button, ButtonGroup } from "flowbite-react";
 import { HiAdjustments, HiCloudDownload, HiUserCircle } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <ButtonGroup>
       <Button color="gray">
@@ -52,7 +52,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <ButtonGroup>
       <Button color="gray">

--- a/apps/web/examples/card/card.CTA.tsx
+++ b/apps/web/examples/card/card.CTA.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <h5 className="mb-2 text-3xl font-bold text-gray-900 dark:text-white">Work fast from anywhere</h5>
@@ -71,7 +71,7 @@ function Component() {
 const codeRSC = `
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <h5 className="mb-2 text-3xl font-bold text-gray-900 dark:text-white">Work fast from anywhere</h5>
@@ -133,7 +133,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <h5 className="mb-2 text-3xl font-bold text-gray-900 dark:text-white">Work fast from anywhere</h5>

--- a/apps/web/examples/card/card.CTAButton.tsx
+++ b/apps/web/examples/card/card.CTAButton.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -33,7 +33,7 @@ function Component() {
 const codeRSC = `
 import { Button, Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -57,7 +57,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/web/examples/card/card.crypto.tsx
+++ b/apps/web/examples/card/card.crypto.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card href="#" className="max-w-sm">
       <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -23,7 +23,7 @@ function Component() {
 const codeRSC = `
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card href="#" className="max-w-sm">
       <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -37,7 +37,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <h5 className="mb-3 text-base font-semibold text-gray-900 lg:text-xl dark:text-white">Connect wallet</h5>

--- a/apps/web/examples/card/card.eCommerce.tsx
+++ b/apps/web/examples/card/card.eCommerce.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card
       className="max-w-sm"
@@ -80,7 +80,7 @@ function Component() {
 const codeRSC = `
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card
       className="max-w-sm"
@@ -151,7 +151,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card
       className="max-w-sm"

--- a/apps/web/examples/card/card.horizontal.tsx
+++ b/apps/web/examples/card/card.horizontal.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm" imgSrc="/images/blog/image-4.jpg" horizontal>
       <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -23,7 +23,7 @@ function Component() {
 const codeRSC = `
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm" imgSrc="/images/blog/image-4.jpg" horizontal>
       <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -37,7 +37,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm" imgSrc="/images/blog/image-4.jpg" horizontal>
       <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -66,4 +66,5 @@ export const horizontal: CodeData = {
   ],
   githubSlug: "card/card.horizontal.tsx",
   component: <Component />,
+  iframe: 630,
 };

--- a/apps/web/examples/card/card.pricing.tsx
+++ b/apps/web/examples/card/card.pricing.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card className='max-w-sm'>
       <h5 className="mb-4 text-xl font-medium text-gray-500 dark:text-gray-400">Standard plan</h5>
@@ -138,7 +138,7 @@ function Component() {
 const codeRSC = `
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card className='max-w-sm'>
       <h5 className="mb-4 text-xl font-medium text-gray-500 dark:text-gray-400">Standard plan</h5>
@@ -267,7 +267,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <h5 className="mb-4 text-xl font-medium text-gray-500 dark:text-gray-400">Standard plan</h5>

--- a/apps/web/examples/card/card.renderImage.tsx
+++ b/apps/web/examples/card/card.renderImage.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Card } from "flowbite-react";
 import Image from "next/image";
 
-function Component() {
+export function Component() {
   return (
     <Card
       className="max-w-sm"
@@ -29,7 +29,7 @@ const codeRSC = `
 import { Card } from "flowbite-react";
 import Image from "next/image";
 
-function Component() {
+export function Component() {
   return (
     <Card
       className="max-w-sm"
@@ -46,7 +46,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card
       className="max-w-sm"

--- a/apps/web/examples/card/card.root.tsx
+++ b/apps/web/examples/card/card.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card href="#" className="max-w-sm">
       <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -23,7 +23,7 @@ function Component() {
 const codeRSC = `
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card href="#" className="max-w-sm">
       <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -37,7 +37,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card href="#" className="max-w-sm">
       <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/web/examples/card/card.userProfile.tsx
+++ b/apps/web/examples/card/card.userProfile.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Card, Dropdown } from "flowbite-react";
 import Image from "next/image";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <div className="flex justify-end px-4 pt-4">
@@ -73,7 +73,7 @@ const codeRSC = `
 import { Card, Dropdown, DropdownItem } from "flowbite-react";
 import Image from "next/image";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <div className="flex justify-end px-4 pt-4">
@@ -134,7 +134,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <div className="flex justify-end px-4 pt-4">

--- a/apps/web/examples/card/card.withForm.tsx
+++ b/apps/web/examples/card/card.withForm.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Card, Checkbox, Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <form className="flex flex-col gap-4">
@@ -36,7 +36,7 @@ function Component() {
 const codeRSC = `
 import { Button, Card, Checkbox, Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <form className="flex flex-col gap-4">
@@ -63,7 +63,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <form className="flex flex-col gap-4">

--- a/apps/web/examples/card/card.withImage.tsx
+++ b/apps/web/examples/card/card.withImage.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card
       className="max-w-sm"
@@ -27,7 +27,7 @@ function Component() {
 const codeRSC = `
 import { Card } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Card
       className="max-w-sm"
@@ -45,7 +45,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card
       className="max-w-sm"

--- a/apps/web/examples/card/card.withList.tsx
+++ b/apps/web/examples/card/card.withList.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Card } from "flowbite-react";
 import Image from "next/image";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <div className="mb-4 flex items-center justify-between">
@@ -124,7 +124,7 @@ const codeRSC = `
 import { Card } from "flowbite-react";
 import Image from "next/image";
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <div className="mb-4 flex items-center justify-between">
@@ -236,7 +236,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Card className="max-w-sm">
       <div className="mb-4 flex items-center justify-between">

--- a/apps/web/examples/carousel/carousel.controls.tsx
+++ b/apps/web/examples/carousel/carousel.controls.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel leftControl="left" rightControl="right">
@@ -24,7 +24,7 @@ function Component() {
 const codeRSC = `
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel leftControl="left" rightControl="right">
@@ -39,7 +39,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel leftControl="left" rightControl="right">

--- a/apps/web/examples/carousel/carousel.events.tsx
+++ b/apps/web/examples/carousel/carousel.events.tsx
@@ -8,7 +8,7 @@ const code = `
 
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel onSlideChange={(index) => console.log('onSlideChange()', index)}>
@@ -27,7 +27,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel onSlideChange={(index) => console.log("onSlideChange()", index)}>

--- a/apps/web/examples/carousel/carousel.indicators.tsx
+++ b/apps/web/examples/carousel/carousel.indicators.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="grid h-56 grid-cols-2 gap-4 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel>
@@ -31,7 +31,7 @@ function Component() {
 const codeRSC = `
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="grid h-56 grid-cols-2 gap-4 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel>
@@ -53,7 +53,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="grid h-56 grid-cols-2 gap-4 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel>

--- a/apps/web/examples/carousel/carousel.pauseOnHover.tsx
+++ b/apps/web/examples/carousel/carousel.pauseOnHover.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel pauseOnHover>
@@ -24,7 +24,7 @@ function Component() {
 const codeRSC = `
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel pauseOnHover>
@@ -39,7 +39,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel pauseOnHover>

--- a/apps/web/examples/carousel/carousel.root.tsx
+++ b/apps/web/examples/carousel/carousel.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel>
@@ -24,7 +24,7 @@ function Component() {
 const codeRSC = `
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel>
@@ -39,7 +39,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel>

--- a/apps/web/examples/carousel/carousel.slide.tsx
+++ b/apps/web/examples/carousel/carousel.slide.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel slide={false}>
@@ -24,7 +24,7 @@ function Component() {
 const codeRSC = `
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel slide={false}>
@@ -39,7 +39,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel slide={false}>

--- a/apps/web/examples/carousel/carousel.slideInterval.tsx
+++ b/apps/web/examples/carousel/carousel.slideInterval.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel slideInterval={5000}>
@@ -24,7 +24,7 @@ function Component() {
 const codeRSC = `
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel slideInterval={5000}>
@@ -39,7 +39,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel slideInterval={5000}>

--- a/apps/web/examples/carousel/carousel.sliderContent.tsx
+++ b/apps/web/examples/carousel/carousel.sliderContent.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel>
@@ -28,7 +28,7 @@ function Component() {
 const codeRSC = `
 import { Carousel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel>
@@ -47,7 +47,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="h-56 sm:h-64 xl:h-80 2xl:h-96">
       <Carousel>

--- a/apps/web/examples/datepicker/datepicker.autoHide.tsx
+++ b/apps/web/examples/datepicker/datepicker.autoHide.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker autoHide={false} />;
 }
 `;
@@ -14,12 +14,12 @@ function Component() {
 const codeRSC = `
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker autoHide={false} />;
 }
 `;
 
-function Component() {
+export function Component() {
   return <Datepicker autoHide={false} />;
 }
 

--- a/apps/web/examples/datepicker/datepicker.inline.tsx
+++ b/apps/web/examples/datepicker/datepicker.inline.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker inline />;
 }
 `;
@@ -14,12 +14,12 @@ function Component() {
 const codeRSC = `
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker inline />;
 }
 `;
 
-function Component() {
+export function Component() {
   return <Datepicker inline />;
 }
 

--- a/apps/web/examples/datepicker/datepicker.localization.tsx
+++ b/apps/web/examples/datepicker/datepicker.localization.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker language="pt-BR" labelTodayButton="Hoje" labelClearButton="Limpar" />;
 }
 `;
@@ -14,12 +14,12 @@ function Component() {
 const codeRSC = `
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker language="pt-BR" labelTodayButton="Hoje" labelClearButton="Limpar" />;
 }
 `;
 
-function Component() {
+export function Component() {
   return <Datepicker language="pt-BR" labelTodayButton="Hoje" labelClearButton="Limpar" />;
 }
 

--- a/apps/web/examples/datepicker/datepicker.range.tsx
+++ b/apps/web/examples/datepicker/datepicker.range.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker minDate={new Date(2023, 0, 1)} maxDate={new Date(2023, 3, 30)} />;
 }
 `;
@@ -14,12 +14,12 @@ function Component() {
 const codeRSC = `
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker minDate={new Date(2023, 0, 1)} maxDate={new Date(2023, 3, 30)} />;
 }
 `;
 
-function Component() {
+export function Component() {
   return <Datepicker minDate={new Date(2023, 0, 1)} maxDate={new Date(2023, 3, 30)} />;
 }
 

--- a/apps/web/examples/datepicker/datepicker.root.tsx
+++ b/apps/web/examples/datepicker/datepicker.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker />;
 }
 `;
@@ -14,12 +14,12 @@ function Component() {
 const codeRSC = `
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker />;
 }
 `;
 
-function Component() {
+export function Component() {
   return <Datepicker />;
 }
 

--- a/apps/web/examples/datepicker/datepicker.title.tsx
+++ b/apps/web/examples/datepicker/datepicker.title.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker title="Flowbite Datepicker" />
 }
 `;
@@ -14,12 +14,12 @@ function Component() {
 const codeRSC = `
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Datepicker title="Flowbite Datepicker" />
 }
 `;
 
-function Component() {
+export function Component() {
   return <Datepicker title="Flowbite Datepicker" />;
 }
 

--- a/apps/web/examples/datepicker/datepicker.weekStart.tsx
+++ b/apps/web/examples/datepicker/datepicker.weekStart.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Datepicker
       weekStart={1} // Monday
@@ -18,7 +18,7 @@ function Component() {
 const codeRSC = `
 import { Datepicker } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Datepicker
       weekStart={1} // Monday
@@ -27,7 +27,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Datepicker
       weekStart={1} // Monday

--- a/apps/web/examples/dropdown/dropdown.customItem.tsx
+++ b/apps/web/examples/dropdown/dropdown.customItem.tsx
@@ -7,7 +7,7 @@ const code = `
 
 import { Dropdown } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown dismissOnClick={false} label="My custom item">
       <Dropdown.Item as={Link} href="#">
@@ -24,7 +24,7 @@ function Component() {
 const codeRSC = `
 import { Dropdown, DropdownItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown dismissOnClick={false} label="My custom item">
       <DropdownItem as={Link} href="#">
@@ -38,7 +38,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Dropdown dismissOnClick={false} label="My custom item">
       <DropdownItem as={Link} href="#">

--- a/apps/web/examples/dropdown/dropdown.customTrigger.tsx
+++ b/apps/web/examples/dropdown/dropdown.customTrigger.tsx
@@ -8,7 +8,7 @@ const code = `
 
 import { Dropdown } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="" dismissOnClick={false} renderTrigger={() => <span>My custom trigger</span>}>
       <Dropdown.Item>Dashboard</Dropdown.Item>
@@ -20,7 +20,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="" dismissOnClick={false} renderTrigger={() => <span>My custom trigger</span>}>
       <Dropdown.Item>Dashboard</Dropdown.Item>

--- a/apps/web/examples/dropdown/dropdown.divider.tsx
+++ b/apps/web/examples/dropdown/dropdown.divider.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Dropdown } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown button">
       <Dropdown.Item>Dashboard</Dropdown.Item>
@@ -22,7 +22,7 @@ function Component() {
 const codeRSC = `
 import { Dropdown, DropdownDivider, DropdownItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown button" dismissOnClick={false}>
       <DropdownItem>Dashboard</DropdownItem>
@@ -34,7 +34,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown button">
       <DropdownItem>Dashboard</DropdownItem>

--- a/apps/web/examples/dropdown/dropdown.events.tsx
+++ b/apps/web/examples/dropdown/dropdown.events.tsx
@@ -8,7 +8,7 @@ const code = `
 
 import { Dropdown } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown">
       <Dropdown.Item onClick={() => alert('Dashboard!')}>Dashboard</Dropdown.Item>
@@ -20,7 +20,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown">
       <Dropdown.Item onClick={() => alert("Dashboard!")}>Dashboard</Dropdown.Item>

--- a/apps/web/examples/dropdown/dropdown.header.tsx
+++ b/apps/web/examples/dropdown/dropdown.header.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Dropdown } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown button">
       <Dropdown.Header>
@@ -26,7 +26,7 @@ function Component() {
 const codeRSC = `
 import { Dropdown, DropdownDivider, DropdownHeader, DropdownItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown button" dismissOnClick={false}>
       <DropdownItem>Dashboard</DropdownItem>
@@ -38,7 +38,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown button">
       <DropdownHeader>

--- a/apps/web/examples/dropdown/dropdown.inline.tsx
+++ b/apps/web/examples/dropdown/dropdown.inline.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Dropdown } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown" inline>
       <Dropdown.Item>Dashboard</Dropdown.Item>
@@ -21,7 +21,7 @@ function Component() {
 const codeRSC = `
 import { Dropdown, DropdownItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown" inline>
       <DropdownItem>Dashboard</DropdownItem>
@@ -33,7 +33,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown" inline>
       <DropdownItem>Dashboard</DropdownItem>

--- a/apps/web/examples/dropdown/dropdown.itemsWithIcon.tsx
+++ b/apps/web/examples/dropdown/dropdown.itemsWithIcon.tsx
@@ -10,7 +10,7 @@ const code = `
 import { Dropdown } from "flowbite-react";
 import { HiCog, HiCurrencyDollar, HiLogout, HiViewGrid } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown">
       <Dropdown.Header>
@@ -27,7 +27,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown">
       <Dropdown.Header>

--- a/apps/web/examples/dropdown/dropdown.placement.tsx
+++ b/apps/web/examples/dropdown/dropdown.placement.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Dropdown } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-4">
       <Dropdown label="Dropdown top" placement="top">
@@ -53,7 +53,7 @@ function Component() {
 const codeRSC = `
 import { Dropdown, DropdownItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-4">
       <Dropdown label="Dropdown top" placement="top">
@@ -97,7 +97,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-4">
       <Dropdown label="Dropdown top" placement="top">

--- a/apps/web/examples/dropdown/dropdown.root.tsx
+++ b/apps/web/examples/dropdown/dropdown.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Dropdown } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown button" dismissOnClick={false}>
       <Dropdown.Item>Dashboard</Dropdown.Item>
@@ -21,7 +21,7 @@ function Component() {
 const codeRSC = `
 import { Dropdown, DropdownItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown button" dismissOnClick={false}>
       <DropdownItem>Dashboard</DropdownItem>
@@ -33,7 +33,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Dropdown label="Dropdown button" dismissOnClick={false}>
       <DropdownItem>Dashboard</DropdownItem>

--- a/apps/web/examples/dropdown/dropdown.sizes.tsx
+++ b/apps/web/examples/dropdown/dropdown.sizes.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Dropdown } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex items-center gap-4">
       <Dropdown label="Small dropdown" size="sm">
@@ -29,7 +29,7 @@ function Component() {
 const codeRSC = `
 import { Dropdown, DropdownItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex items-center gap-4">
       <Dropdown label="Small dropdown" size="sm">
@@ -49,7 +49,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex items-center gap-4">
       <Dropdown label="Small dropdown" size="sm">

--- a/apps/web/examples/fileInput/fileInput.dropzone.tsx
+++ b/apps/web/examples/fileInput/fileInput.dropzone.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { FileInput, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex w-full items-center justify-center">
       <Label
@@ -45,7 +45,7 @@ const codeRSC = `
 
 import { FileInput, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex w-full items-center justify-center">
       <Label
@@ -80,7 +80,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex w-full items-center justify-center">
       <Label

--- a/apps/web/examples/fileInput/fileInput.helper.tsx
+++ b/apps/web/examples/fileInput/fileInput.helper.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { FileInput, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div>
       <div>
@@ -22,7 +22,7 @@ const codeRSC = `
 
 import { FileInput, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div>
       <div>
@@ -34,7 +34,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div>
       <div>

--- a/apps/web/examples/fileInput/fileInput.multiple.tsx
+++ b/apps/web/examples/fileInput/fileInput.multiple.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { FileInput, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div>
       <div>
@@ -22,7 +22,7 @@ const codeRSC = `
 
 import { FileInput, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div>
       <div>
@@ -34,7 +34,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div>
       <div>

--- a/apps/web/examples/fileInput/fileInput.root.tsx
+++ b/apps/web/examples/fileInput/fileInput.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { FileInput, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div>
       <div className="mb-2 block">
@@ -19,7 +19,7 @@ function Component() {
 `;
 
 const codeRSC = `
-function Component() {
+export function Component() {
 
   import { FileInput, Label } from "flowbite-react";
 
@@ -34,7 +34,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div>
       <div className="mb-2 block">

--- a/apps/web/examples/fileInput/fileInput.sizes.tsx
+++ b/apps/web/examples/fileInput/fileInput.sizes.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { FileInput, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div>
       <div className="mb-2">
@@ -36,7 +36,7 @@ const codeRSC = `
 
 import { FileInput, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div>
       <div className="mb-2">
@@ -62,7 +62,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div>
       <div className="mb-2">

--- a/apps/web/examples/floatingLabel/floatingLabel.disabled.tsx
+++ b/apps/web/examples/floatingLabel/floatingLabel.disabled.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { FloatingLabel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="grid grid-flow-col justify-stretch space-x-4">
       <FloatingLabel variant="filled" label="Label" disabled={true} />
@@ -20,7 +20,7 @@ function Component() {
 const codeRSC = `
 import { FloatingLabel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="grid grid-flow-col justify-stretch space-x-4">
       <FloatingLabel variant="filled" label="Label" disabled={true} />
@@ -31,7 +31,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="grid grid-flow-col justify-stretch space-x-4">
       <FloatingLabel variant="filled" label="Label" disabled={true} />

--- a/apps/web/examples/floatingLabel/floatingLabel.helperText.tsx
+++ b/apps/web/examples/floatingLabel/floatingLabel.helperText.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { FloatingLabel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <FloatingLabel
       variant="filled"
@@ -20,7 +20,7 @@ function Component() {
 const codeRSC = `
 import { FloatingLabel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <FloatingLabel
       variant="filled"
@@ -31,7 +31,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <FloatingLabel
       variant="filled"

--- a/apps/web/examples/floatingLabel/floatingLabel.root.tsx
+++ b/apps/web/examples/floatingLabel/floatingLabel.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { FloatingLabel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="grid grid-flow-col justify-stretch space-x-4">
       <FloatingLabel variant="filled" label="Label" />
@@ -20,7 +20,7 @@ function Component() {
 const codeRSC = `
 import { FloatingLabel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="grid grid-flow-col justify-stretch space-x-4">
       <FloatingLabel variant="filled" label="Label" />
@@ -31,7 +31,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="grid grid-flow-col justify-stretch space-x-4">
       <FloatingLabel variant="filled" label="Label" />

--- a/apps/web/examples/floatingLabel/floatingLabel.sizes.tsx
+++ b/apps/web/examples/floatingLabel/floatingLabel.sizes.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { FloatingLabel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       <div className="grid grid-flow-col justify-stretch space-x-4">
@@ -27,7 +27,7 @@ function Component() {
 const codeRSC = `
 import { FloatingLabel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       <div className="grid grid-flow-col justify-stretch space-x-4">
@@ -45,7 +45,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <>
       <div className="grid grid-flow-col justify-stretch space-x-4">

--- a/apps/web/examples/floatingLabel/floatingLabel.validation.tsx
+++ b/apps/web/examples/floatingLabel/floatingLabel.validation.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { FloatingLabel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       <div className="grid grid-flow-col justify-stretch space-x-4">
@@ -27,7 +27,7 @@ function Component() {
 const codeRSC = `
 import { FloatingLabel } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       <div className="grid grid-flow-col justify-stretch space-x-4">
@@ -45,7 +45,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <>
       <div className="grid grid-flow-col justify-stretch space-x-4">

--- a/apps/web/examples/footer/footer.root.tsx
+++ b/apps/web/examples/footer/footer.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Footer } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Footer container>
       <Footer.Copyright href="#" by="Flowbite™" year={2022} />
@@ -24,7 +24,7 @@ function Component() {
 const codeRSC = `
 import { Footer, FooterCopyright, FooterLink, FooterLinkGroup } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Footer container>
       <FooterCopyright href="#" by="Flowbite™" year={2022} />
@@ -39,7 +39,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Footer container>
       <FooterCopyright href="#" by="Flowbite™" year={2022} />
@@ -69,4 +69,5 @@ export const root: CodeData = {
   ],
   githubSlug: "footer/footer.root.tsx",
   component: <Component />,
+  iframe: 130,
 };

--- a/apps/web/examples/footer/footer.sitemapLinks.tsx
+++ b/apps/web/examples/footer/footer.sitemapLinks.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Footer } from "flowbite-react";
 import { BsDribbble, BsFacebook, BsGithub, BsInstagram, BsTwitter } from "react-icons/bs";
 
-function Component() {
+export function Component() {
   return (
     <Footer bgDark>
       <div className="w-full">
@@ -69,7 +69,7 @@ const codeRSC = `
 import { Footer, FooterCopyright, FooterIcon, FooterLink, FooterLinkGroup, FooterTitle } from "flowbite-react";
 import { BsDribbble, BsFacebook, BsGithub, BsInstagram, BsTwitter } from "react-icons/bs";
 
-function Component() {
+export function Component() {
   return (
     <Footer bgDark>
       <div className="w-full">
@@ -126,7 +126,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Footer bgDark>
       <div className="w-full">
@@ -198,4 +198,5 @@ export const sitemapLinks: CodeData = {
   ],
   githubSlug: "footer/footer.sitemapLinks.tsx",
   component: <Component />,
+  iframe: 580,
 };

--- a/apps/web/examples/footer/footer.socialMediaIcons.tsx
+++ b/apps/web/examples/footer/footer.socialMediaIcons.tsx
@@ -17,7 +17,7 @@ const code = `
 import { Footer } from "flowbite-react";
 import { BsDribbble, BsFacebook, BsGithub, BsInstagram, BsTwitter } from "react-icons/bs";
 
-function Component() {
+export function Component() {
   return (
     <Footer container>
       <div className="w-full">
@@ -84,7 +84,7 @@ import {
 } from "flowbite-react";
 import { BsDribbble, BsFacebook, BsGithub, BsInstagram, BsTwitter } from "react-icons/bs";
 
-function Component() {
+export function Component() {
   return (
     <Footer container>
       <div className="w-full">
@@ -138,7 +138,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Footer container>
       <div className="w-full">
@@ -207,4 +207,5 @@ export const socialMediaIcons: CodeData = {
   ],
   githubSlug: "footer/footer.socialMediaIcons.tsx",
   component: <Component />,
+  iframe: 470,
 };

--- a/apps/web/examples/footer/footer.withLogo.tsx
+++ b/apps/web/examples/footer/footer.withLogo.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Footer } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Footer container>
       <div className="w-full text-center">
@@ -35,7 +35,7 @@ function Component() {
 const codeRSC = `
 import { Footer, FooterBrand, FooterCopyright, FooterDivider, FooterLink, FooterLinkGroup } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Footer container>
       <div className="w-full text-center">
@@ -61,7 +61,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Footer container>
       <div className="w-full text-center">
@@ -102,4 +102,5 @@ export const withLogo: CodeData = {
   ],
   githubSlug: "footer/footer.withLogo.tsx",
   component: <Component />,
+  iframe: 220,
 };

--- a/apps/web/examples/forms/forms.checkbox.tsx
+++ b/apps/web/examples/forms/forms.checkbox.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Checkbox, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4" id="checkbox">
       <div className="flex items-center gap-2">
@@ -54,7 +54,7 @@ function Component() {
 const codeRSC = `
 import { Checkbox, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4" id="checkbox">
       <div className="flex items-center gap-2">
@@ -99,7 +99,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4" id="checkbox">
       <div className="flex items-center gap-2">

--- a/apps/web/examples/forms/forms.disabledInputs.tsx
+++ b/apps/web/examples/forms/forms.disabledInputs.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <Label htmlFor="disabledInput1">API token</Label>
@@ -21,7 +21,7 @@ function Component() {
 const codeRSC = `
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <Label htmlFor="disabledInput1">API token</Label>
@@ -33,7 +33,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <Label htmlFor="disabledInput1">API token</Label>

--- a/apps/web/examples/forms/forms.fileInput.tsx
+++ b/apps/web/examples/forms/forms.fileInput.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { FileInput, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div id="fileUpload" className="max-w-md">
       <div className="mb-2 block">
@@ -21,7 +21,7 @@ function Component() {
 const codeRSC = `
 import { FileInput, Label } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div id="fileUpload" className="max-w-md">
       <div className="mb-2 block">
@@ -33,7 +33,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div id="fileUpload" className="max-w-md">
       <div className="mb-2 block">

--- a/apps/web/examples/forms/forms.helperText.tsx
+++ b/apps/web/examples/forms/forms.helperText.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -35,7 +35,7 @@ function Component() {
 const codeRSC = `
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -61,7 +61,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">

--- a/apps/web/examples/forms/forms.inputAddon.tsx
+++ b/apps/web/examples/forms/forms.inputAddon.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -21,7 +21,7 @@ function Component() {
 const codeRSC = `
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -33,7 +33,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">

--- a/apps/web/examples/forms/forms.inputColors.tsx
+++ b/apps/web/examples/forms/forms.inputColors.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>
@@ -47,7 +47,7 @@ function Component() {
 const codeRSC = `
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>
@@ -85,7 +85,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>

--- a/apps/web/examples/forms/forms.inputLeftIcon.tsx
+++ b/apps/web/examples/forms/forms.inputLeftIcon.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Label, TextInput } from "flowbite-react";
 import { HiMail } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -24,7 +24,7 @@ const codeRSC = `
 import { Label, TextInput } from "flowbite-react";
 import { HiMail } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -36,7 +36,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">

--- a/apps/web/examples/forms/forms.inputLeftRightIcon.tsx
+++ b/apps/web/examples/forms/forms.inputLeftRightIcon.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Label, TextInput } from "flowbite-react";
 import { HiMail } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -24,7 +24,7 @@ const codeRSC = `
 import { Label, TextInput } from "flowbite-react";
 import { HiMail } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -36,7 +36,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">

--- a/apps/web/examples/forms/forms.inputRightIcon.tsx
+++ b/apps/web/examples/forms/forms.inputRightIcon.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Label, TextInput } from "flowbite-react";
 import { HiMail } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -24,7 +24,7 @@ const codeRSC = `
 import { Label, TextInput } from "flowbite-react";
 import { HiMail } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -36,7 +36,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">

--- a/apps/web/examples/forms/forms.inputSizing.tsx
+++ b/apps/web/examples/forms/forms.inputSizing.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>
@@ -35,7 +35,7 @@ function Component() {
 const codeRSC = `
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>
@@ -61,7 +61,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>

--- a/apps/web/examples/forms/forms.radioButton.tsx
+++ b/apps/web/examples/forms/forms.radioButton.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Label, Radio } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <fieldset className="flex max-w-md flex-col gap-4">
       <legend className="mb-4">Choose your favorite country</legend>
@@ -40,7 +40,7 @@ function Component() {
 const codeRSC = `
 import { Label, Radio } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <fieldset className="flex max-w-md flex-col gap-4">
       <legend className="mb-4">Choose your favorite country</legend>
@@ -71,7 +71,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <fieldset className="flex max-w-md flex-col gap-4">
       <legend className="mb-4">Choose your favorite country</legend>

--- a/apps/web/examples/forms/forms.rangeSlider.tsx
+++ b/apps/web/examples/forms/forms.rangeSlider.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Label, RangeSlider } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>
@@ -47,7 +47,7 @@ function Component() {
 const codeRSC = `
 import { Label, RangeSlider } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>
@@ -85,7 +85,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>

--- a/apps/web/examples/forms/forms.root.tsx
+++ b/apps/web/examples/forms/forms.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Checkbox, Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <form className="flex max-w-md flex-col gap-4">
       <div>
@@ -34,7 +34,7 @@ function Component() {
 const codeRSC = `
 import { Button, Checkbox, Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <form className="flex max-w-md flex-col gap-4">
       <div>
@@ -59,7 +59,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <form className="flex max-w-md flex-col gap-4">
       <div>

--- a/apps/web/examples/forms/forms.select.tsx
+++ b/apps/web/examples/forms/forms.select.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Label, Select } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -26,7 +26,7 @@ function Component() {
 const codeRSC = `
 import { Label, Select } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -43,7 +43,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">

--- a/apps/web/examples/forms/forms.shadowInputs.tsx
+++ b/apps/web/examples/forms/forms.shadowInputs.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Button, Checkbox, Label, TextInput } from "flowbite-react";
 import Link from "next/link";
 
-function Component() {
+export function Component() {
   return (
     <form className="flex max-w-md flex-col gap-4">
       <div>
@@ -48,7 +48,7 @@ const codeRSC = `
 import { Button, Checkbox, Label, TextInput } from "flowbite-react";
 import Link from "next/link";
 
-function Component() {
+export function Component() {
   return (
     <form className="flex max-w-md flex-col gap-4">
       <div>
@@ -84,7 +84,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <form className="flex max-w-md flex-col gap-4">
       <div>

--- a/apps/web/examples/forms/forms.textarea.tsx
+++ b/apps/web/examples/forms/forms.textarea.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Label, Textarea } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -21,7 +21,7 @@ function Component() {
 const codeRSC = `
 import { Label, Textarea } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">
@@ -33,7 +33,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="max-w-md">
       <div className="mb-2 block">

--- a/apps/web/examples/forms/forms.toggleSwitch.tsx
+++ b/apps/web/examples/forms/forms.toggleSwitch.tsx
@@ -10,7 +10,7 @@ const code = `
 import { ToggleSwitch } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
+export function Component() {
   const [switch1, setSwitch1] = useState(false);
   const [switch2, setSwitch2] = useState(true);
   const [switch3, setSwitch3] = useState(true);
@@ -27,7 +27,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const [switch1, setSwitch1] = useState(false);
   const [switch2, setSwitch2] = useState(true);
   const [switch3, setSwitch3] = useState(true);

--- a/apps/web/examples/forms/forms.validation.tsx
+++ b/apps/web/examples/forms/forms.validation.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>
@@ -49,7 +49,7 @@ function Component() {
 const codeRSC = `
 import { Label, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>
@@ -89,7 +89,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex max-w-md flex-col gap-4">
       <div>

--- a/apps/web/examples/kbd/kbd.arrowKeys.tsx
+++ b/apps/web/examples/kbd/kbd.arrowKeys.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Kbd } from "flowbite-react";
 import { MdKeyboardArrowDown, MdKeyboardArrowLeft, MdKeyboardArrowRight, MdKeyboardArrowUp } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd icon={MdKeyboardArrowUp} />
@@ -24,7 +24,7 @@ const codeRSC = `
 import { Kbd } from "flowbite-react";
 import { MdKeyboardArrowDown, MdKeyboardArrowLeft, MdKeyboardArrowRight, MdKeyboardArrowUp } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd icon={MdKeyboardArrowUp} />
@@ -36,7 +36,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd icon={MdKeyboardArrowUp} />

--- a/apps/web/examples/kbd/kbd.functionKeys.tsx
+++ b/apps/web/examples/kbd/kbd.functionKeys.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Kbd } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>F1</Kbd>
@@ -29,7 +29,7 @@ function Component() {
 const codeRSC = `
 import { Kbd } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>F1</Kbd>
@@ -49,7 +49,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>F1</Kbd>

--- a/apps/web/examples/kbd/kbd.insideTable.tsx
+++ b/apps/web/examples/kbd/kbd.insideTable.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Kbd, Table } from "flowbite-react";
 import { MdKeyboardArrowDown, MdKeyboardArrowLeft, MdKeyboardArrowRight, MdKeyboardArrowUp } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <Table>
       <Table.Head>
@@ -52,7 +52,7 @@ const codeRSC = `
 import { Kbd, Table, TableBody, TableCell, TableHead, TableHeadCell, TableRow } from "flowbite-react";
 import { MdKeyboardArrowDown, MdKeyboardArrowLeft, MdKeyboardArrowRight, MdKeyboardArrowUp } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <Table>
       <TableHead>
@@ -92,7 +92,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Table>
       <TableHead>

--- a/apps/web/examples/kbd/kbd.insideText.tsx
+++ b/apps/web/examples/kbd/kbd.insideText.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Kbd } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       Please press <Kbd>Ctrl</Kbd> + <Kbd>Shift</Kbd> + <Kbd>R</Kbd> to re-render an MDN page.
@@ -18,7 +18,7 @@ function Component() {
 const codeRSC = `
 import { Kbd } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       Please press <Kbd>Ctrl</Kbd> + <Kbd>Shift</Kbd> + <Kbd>R</Kbd> to re-render an MDN page.
@@ -27,7 +27,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <>
       Please press <Kbd>Ctrl</Kbd> + <Kbd>Shift</Kbd> + <Kbd>R</Kbd> to re-render an MDN page.

--- a/apps/web/examples/kbd/kbd.letterKeys.tsx
+++ b/apps/web/examples/kbd/kbd.letterKeys.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Kbd } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>Q</Kbd>
@@ -42,7 +42,7 @@ function Component() {
 const codeRSC = `
 import { Kbd } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>Q</Kbd>
@@ -75,7 +75,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>Q</Kbd>

--- a/apps/web/examples/kbd/kbd.numberKeys.tsx
+++ b/apps/web/examples/kbd/kbd.numberKeys.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Kbd } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>1</Kbd>
@@ -27,7 +27,7 @@ function Component() {
 const codeRSC = `
 import { Kbd } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>1</Kbd>
@@ -45,7 +45,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>1</Kbd>

--- a/apps/web/examples/kbd/kbd.root.tsx
+++ b/apps/web/examples/kbd/kbd.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Kbd } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>Shift</Kbd>
@@ -24,7 +24,7 @@ function Component() {
 const codeRSC = `
 import { Kbd } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>Shift</Kbd>
@@ -39,7 +39,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-1">
       <Kbd>Shift</Kbd>

--- a/apps/web/examples/list/list.advanced.tsx
+++ b/apps/web/examples/list/list.advanced.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { List, Avatar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List unstyled className="max-w-md divide-y divide-gray-200 dark:divide-gray-700">
       <List.Item className="pb-3 sm:pb-4">
@@ -67,7 +67,7 @@ function Component() {
 const codeRSC = `
 import { Avatar, List, ListItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List unstyled className="max-w-md divide-y divide-gray-200 dark:divide-gray-700">
       <ListItem className="pb-3 sm:pb-4">
@@ -125,7 +125,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <List unstyled className="max-w-md divide-y divide-gray-200 dark:divide-gray-700">
       <ListItem className="pb-3 sm:pb-4">

--- a/apps/web/examples/list/list.horizontal.tsx
+++ b/apps/web/examples/list/list.horizontal.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { List } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List horizontal>
       <List.Item>About</List.Item>
@@ -24,7 +24,7 @@ function Component() {
 const codeRSC = `
 import { List, ListItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List horizontal>
       <ListItem>About</ListItem>
@@ -39,7 +39,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <List horizontal>
       <ListItem>About</ListItem>

--- a/apps/web/examples/list/list.icon.tsx
+++ b/apps/web/examples/list/list.icon.tsx
@@ -8,7 +8,7 @@ const code = `
 import { List } from "flowbite-react";
 import { HiCheckCircle } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <List>
       <List.Item icon={HiCheckCircle}>At least 10 characters (and up to 100 characters)</List.Item>
@@ -23,7 +23,7 @@ const codeRSC = `
 import { List, ListItem } from "flowbite-react";
 import { HiCheckCircle } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <List>
       <ListItem icon={HiCheckCircle}>At least 10 characters (and up to 100 characters)</ListItem>
@@ -34,7 +34,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <List>
       <ListItem icon={HiCheckCircle}>At least 10 characters (and up to 100 characters)</ListItem>

--- a/apps/web/examples/list/list.nested.tsx
+++ b/apps/web/examples/list/list.nested.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { List } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List>
       <List.Item>
@@ -41,7 +41,7 @@ function Component() {
 const codeRSC = `
 import { List, ListItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List>
       <ListItem>
@@ -73,7 +73,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <List>
       <ListItem>

--- a/apps/web/examples/list/list.ordered.tsx
+++ b/apps/web/examples/list/list.ordered.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { List } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List ordered>
       <List.Item>At least 10 characters (and up to 100 characters)</List.Item>
@@ -20,7 +20,7 @@ function Component() {
 const codeRSC = `
 import { List, ListItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List ordered>
       <ListItem>At least 10 characters (and up to 100 characters)</ListItem>
@@ -31,7 +31,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <List ordered>
       <ListItem>At least 10 characters (and up to 100 characters)</ListItem>

--- a/apps/web/examples/list/list.root.tsx
+++ b/apps/web/examples/list/list.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { List } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List>
       <List.Item>At least 10 characters (and up to 100 characters)</List.Item>
@@ -20,7 +20,7 @@ function Component() {
 const codeRSC = `
 import { List, ListItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List>
       <ListItem>At least 10 characters (and up to 100 characters)</ListItem>
@@ -31,7 +31,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <List>
       <ListItem>At least 10 characters (and up to 100 characters)</ListItem>

--- a/apps/web/examples/list/list.unstyled.tsx
+++ b/apps/web/examples/list/list.unstyled.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { List } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List unstyled>
       <List.Item>At least 10 characters (and up to 100 characters)</List.Item>
@@ -20,7 +20,7 @@ function Component() {
 const codeRSC = `
 import { List, ListItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <List unstyled>
       <ListItem>At least 10 characters (and up to 100 characters)</ListItem>
@@ -31,7 +31,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <List unstyled>
       <ListItem>At least 10 characters (and up to 100 characters)</ListItem>

--- a/apps/web/examples/listGroup/listGroup.itemsAsLink.tsx
+++ b/apps/web/examples/listGroup/listGroup.itemsAsLink.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { ListGroup } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex justify-center">
       <ListGroup className="w-48">
@@ -25,7 +25,7 @@ function Component() {
 const codeRSC = `
 import { ListGroup, ListGroupItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex justify-center">
       <ListGroup className="w-48">
@@ -41,7 +41,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex justify-center">
       <ListGroup className="w-48">

--- a/apps/web/examples/listGroup/listGroup.root.tsx
+++ b/apps/web/examples/listGroup/listGroup.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { ListGroup } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex justify-center">
       <ListGroup className="w-48">
@@ -23,7 +23,7 @@ function Component() {
 const codeRSC = `
 import { ListGroup, ListGroupItem } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex justify-center">
       <ListGroup className="w-48">
@@ -37,7 +37,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex justify-center">
       <ListGroup className="w-48">

--- a/apps/web/examples/listGroup/listGroup.withButtons.tsx
+++ b/apps/web/examples/listGroup/listGroup.withButtons.tsx
@@ -8,7 +8,7 @@ const code = `
 
 import { ListGroup } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex justify-center">
       <ListGroup className="w-48">
@@ -24,7 +24,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex justify-center">
       <ListGroup className="w-48">

--- a/apps/web/examples/listGroup/listGroup.withIcons.tsx
+++ b/apps/web/examples/listGroup/listGroup.withIcons.tsx
@@ -8,7 +8,7 @@ const code = `
 import { ListGroup } from "flowbite-react";
 import { HiCloudDownload, HiInbox, HiOutlineAdjustments, HiUserCircle } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex justify-center">
       <ListGroup className="w-48">
@@ -28,7 +28,7 @@ const codeRSC = `
 import { ListGroup, ListGroupItem } from "flowbite-react";
 import { HiCloudDownload, HiInbox, HiOutlineAdjustments, HiUserCircle } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex justify-center">
       <ListGroup className="w-48">
@@ -44,7 +44,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex justify-center">
       <ListGroup className="w-48">

--- a/apps/web/examples/modal/modal.dismissible.tsx
+++ b/apps/web/examples/modal/modal.dismissible.tsx
@@ -10,8 +10,8 @@ const code = `
 import { Button, Modal } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
 
   return (
     <>
@@ -43,8 +43,8 @@ function Component() {
 }
 `;
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
 
   return (
     <>
@@ -84,4 +84,5 @@ export const dismissible: CodeData = {
   },
   githubSlug: "modal/modal.dismissible.tsx",
   component: <Component />,
+  iframe: 600,
 };

--- a/apps/web/examples/modal/modal.initialFocus.tsx
+++ b/apps/web/examples/modal/modal.initialFocus.tsx
@@ -10,8 +10,8 @@ const code = `
 import { Button, Checkbox, Label, Modal, TextInput } from "flowbite-react";
 import { useRef, useState } from "react";
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
   const emailInputRef = useRef<HTMLInputElement>(null);
 
   return (
@@ -60,8 +60,8 @@ function Component() {
 }
 `;
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
   const emailInputRef = useRef<HTMLInputElement>(null);
 
   return (
@@ -118,4 +118,5 @@ export const initialFocus: CodeData = {
   },
   githubSlug: "modal/modal.initialFocus.tsx",
   component: <Component />,
+  iframe: 600,
 };

--- a/apps/web/examples/modal/modal.popup.tsx
+++ b/apps/web/examples/modal/modal.popup.tsx
@@ -12,8 +12,8 @@ import { Button, Modal } from "flowbite-react";
 import { useState } from "react";
 import { HiOutlineExclamationCircle } from "react-icons/hi";
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
 
   return (
     <>
@@ -42,8 +42,8 @@ function Component() {
 }
 `;
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
 
   return (
     <>
@@ -80,4 +80,5 @@ export const popup: CodeData = {
   },
   githubSlug: "modal/modal.popup.tsx",
   component: <Component />,
+  iframe: 600,
 };

--- a/apps/web/examples/modal/modal.position.tsx
+++ b/apps/web/examples/modal/modal.position.tsx
@@ -10,8 +10,8 @@ const code = `
 import { Button, Modal, Select } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
   const [modalPlacement, setModalPlacement] = useState('center')
 
   return (
@@ -63,8 +63,8 @@ function Component() {
 }
 `;
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
   const [modalPlacement, setModalPlacement] = useState("center");
 
   return (
@@ -120,4 +120,5 @@ export const position: CodeData = {
   },
   githubSlug: "modal/modal.position.tsx",
   component: <Component />,
+  iframe: 600,
 };

--- a/apps/web/examples/modal/modal.root.tsx
+++ b/apps/web/examples/modal/modal.root.tsx
@@ -10,8 +10,8 @@ const code = `
 import { Button, Modal } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
 
   return (
     <>
@@ -43,8 +43,8 @@ function Component() {
 }
 `;
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
 
   return (
     <>
@@ -84,4 +84,5 @@ export const root: CodeData = {
   },
   githubSlug: "modal/modal.root.tsx",
   component: <Component />,
+  iframe: 600,
 };

--- a/apps/web/examples/modal/modal.sizes.tsx
+++ b/apps/web/examples/modal/modal.sizes.tsx
@@ -10,8 +10,8 @@ const code = `
 import { Button, Modal, Select } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
   const [modalSize, setModalSize] = useState<string>('md');
 
   return (
@@ -60,8 +60,8 @@ function Component() {
 }
 `;
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
   const [modalSize, setModalSize] = useState<string>("md");
 
   return (
@@ -118,4 +118,5 @@ export const sizes: CodeData = {
   },
   githubSlug: "modal/modal.sizes.tsx",
   component: <Component />,
+  iframe: 600,
 };

--- a/apps/web/examples/modal/modal.withFormElements.tsx
+++ b/apps/web/examples/modal/modal.withFormElements.tsx
@@ -10,8 +10,8 @@ const code = `
 import { Button, Checkbox, Label, Modal, TextInput } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
   const [email, setEmail] = useState('');
 
   function onCloseModal() {
@@ -71,8 +71,8 @@ function Component() {
 }
 `;
 
-function Component() {
-  const [openModal, setOpenModal] = useState(false);
+export function Component() {
+  const [openModal, setOpenModal] = useState(true);
   const [email, setEmail] = useState("");
 
   function onCloseModal() {
@@ -140,4 +140,5 @@ export const withFormElements: CodeData = {
   },
   githubSlug: "modal/modal.withFormElements.tsx",
   component: <Component />,
+  iframe: 600,
 };

--- a/apps/web/examples/navbar/navbar.root.tsx
+++ b/apps/web/examples/navbar/navbar.root.tsx
@@ -8,7 +8,7 @@ const code = `
 import Link from "next/link";
 import { Navbar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Navbar fluid rounded>
       <Navbar.Brand as={Link} href="https://flowbite-react.com">
@@ -36,7 +36,7 @@ const codeRSC = `
 import Link from "next/link";
 import { Navbar, NavbarBrand, NavbarCollapse, NavbarLink, NavbarToggle } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Navbar fluid rounded>
       <NavbarBrand as={Link} href="https://flowbite-react.com">
@@ -60,7 +60,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Navbar fluid rounded>
       <NavbarBrand as={Link} href="https://flowbite-react.com">
@@ -99,4 +99,8 @@ export const root: CodeData = {
   ],
   githubSlug: "navbar/navbar.root.tsx",
   component: <Component />,
+  iframe: {
+    height: 300,
+    noPadding: true,
+  },
 };

--- a/apps/web/examples/navbar/navbar.withCTAButton.tsx
+++ b/apps/web/examples/navbar/navbar.withCTAButton.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Navbar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Navbar fluid rounded>
       <Navbar.Brand href="https://flowbite-react.com">
@@ -34,7 +34,7 @@ function Component() {
 const codeRSC = `
 import { Button, Navbar, NavbarBrand, NavbarCollapse, NavbarLink, NavbarToggle } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Navbar fluid rounded>
       <NavbarBrand href="https://flowbite-react.com">
@@ -59,7 +59,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Navbar fluid rounded>
       <NavbarBrand href="https://flowbite-react.com">
@@ -99,4 +99,8 @@ export const withCTAButton: CodeData = {
   ],
   githubSlug: "navbar/navbar.withCTAButton.tsx",
   component: <Component />,
+  iframe: {
+    height: 300,
+    noPadding: true,
+  },
 };

--- a/apps/web/examples/navbar/navbar.withDropdown.tsx
+++ b/apps/web/examples/navbar/navbar.withDropdown.tsx
@@ -17,7 +17,7 @@ const code = `
 
 import { Avatar, Dropdown, Navbar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Navbar fluid rounded>
       <Navbar.Brand href="https://flowbite-react.com">
@@ -72,7 +72,7 @@ import {
   NavbarToggle,
 } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Navbar fluid rounded>
       <NavbarBrand href="https://flowbite-react.com">
@@ -113,7 +113,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Navbar fluid rounded>
       <NavbarBrand href="https://flowbite-react.com">
@@ -169,4 +169,8 @@ export const withDropdown: CodeData = {
   ],
   githubSlug: "navbar/navbar.withDropdown.tsx",
   component: <Component />,
+  iframe: {
+    height: 300,
+    noPadding: true,
+  },
 };

--- a/apps/web/examples/pagination/pagination.controlButtonText.tsx
+++ b/apps/web/examples/pagination/pagination.controlButtonText.tsx
@@ -10,7 +10,7 @@ const code = `
 import { Pagination } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);
@@ -31,7 +31,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);

--- a/apps/web/examples/pagination/pagination.navigation.tsx
+++ b/apps/web/examples/pagination/pagination.navigation.tsx
@@ -10,7 +10,7 @@ const code = `
 import { Pagination } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);
@@ -23,7 +23,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);

--- a/apps/web/examples/pagination/pagination.navigationWithIcons.tsx
+++ b/apps/web/examples/pagination/pagination.navigationWithIcons.tsx
@@ -10,7 +10,7 @@ const code = `
 import { Pagination } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);

--- a/apps/web/examples/pagination/pagination.root.tsx
+++ b/apps/web/examples/pagination/pagination.root.tsx
@@ -10,7 +10,7 @@ const code = `
 import { Pagination } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);
@@ -23,7 +23,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);

--- a/apps/web/examples/pagination/pagination.table.tsx
+++ b/apps/web/examples/pagination/pagination.table.tsx
@@ -10,7 +10,7 @@ const code = `
 import { Pagination } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);
@@ -23,7 +23,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);

--- a/apps/web/examples/pagination/pagination.tableWithIcons.tsx
+++ b/apps/web/examples/pagination/pagination.tableWithIcons.tsx
@@ -10,7 +10,7 @@ const code = `
 import { Pagination } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);
@@ -23,7 +23,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);

--- a/apps/web/examples/pagination/pagination.withIcons.tsx
+++ b/apps/web/examples/pagination/pagination.withIcons.tsx
@@ -10,7 +10,7 @@ const code = `
 import { Pagination } from "flowbite-react";
 import { useState } from "react";
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);
@@ -23,7 +23,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const [currentPage, setCurrentPage] = useState(1);
 
   const onPageChange = (page: number) => setCurrentPage(page);

--- a/apps/web/examples/popover/popover.controlled.tsx
+++ b/apps/web/examples/popover/popover.controlled.tsx
@@ -12,7 +12,7 @@ import { useState } from "react";
 import { BiCaretDown } from "react-icons/bi";
 import { Button, Popover, Label, TextInput  } from "flowbite-react";
 
-function Component() {
+export function Component() {
   const [open, setOpen] = useState(false);
 
   return (
@@ -52,7 +52,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const [open, setOpen] = useState(false);
 
   return (

--- a/apps/web/examples/popover/popover.disableArrow.tsx
+++ b/apps/web/examples/popover/popover.disableArrow.tsx
@@ -4,7 +4,7 @@ import { type CodeData } from "~/components/code-demo";
 const code = `
 import { Button, Popover } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Popover
       aria-labelledby="default-popover"
@@ -26,7 +26,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Popover
       aria-labelledby="default-popover"

--- a/apps/web/examples/popover/popover.image.tsx
+++ b/apps/web/examples/popover/popover.image.tsx
@@ -4,7 +4,7 @@ import { type CodeData } from "~/components/code-demo";
 const code = `
 import { Popover } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <p className="text-gray-500 dark:text-gray-400">
       Due to its central geographic location in Southern Europe,{' '}
@@ -65,7 +65,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <p className="text-gray-500 dark:text-gray-400">
       Due to its central geographic location in Southern Europe,{" "}

--- a/apps/web/examples/popover/popover.password.tsx
+++ b/apps/web/examples/popover/popover.password.tsx
@@ -8,7 +8,7 @@ const code = `
 
 import { Button, Checkbox, Label, Popover, TextInput } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <form className="flex max-w-md flex-col gap-4">
       <div>
@@ -105,7 +105,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <form className="flex max-w-md flex-col gap-4">
       <div>

--- a/apps/web/examples/popover/popover.placement.tsx
+++ b/apps/web/examples/popover/popover.placement.tsx
@@ -4,7 +4,7 @@ import { type CodeData } from "~/components/code-demo";
 const code = `
 import { Button, Popover } from "flowbite-react";
 
-function Component() {
+export function Component() {
   const content = (
     <div className="w-64 text-sm text-gray-500 dark:text-gray-400">
       <div className="border-b border-gray-200 bg-gray-100 px-3 py-2 dark:border-gray-600 dark:bg-gray-700">
@@ -35,7 +35,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const content = (
     <div className="w-64 text-sm text-gray-500 dark:text-gray-400">
       <div className="border-b border-gray-200 bg-gray-100 px-3 py-2 dark:border-gray-600 dark:bg-gray-700">

--- a/apps/web/examples/popover/popover.profile.tsx
+++ b/apps/web/examples/popover/popover.profile.tsx
@@ -4,7 +4,7 @@ import { type CodeData } from "~/components/code-demo";
 const code = `
 import { Button, Popover } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Popover
       aria-labelledby="profile-popover"
@@ -65,7 +65,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Popover
       aria-labelledby="profile-popover"

--- a/apps/web/examples/popover/popover.root.tsx
+++ b/apps/web/examples/popover/popover.root.tsx
@@ -4,7 +4,7 @@ import { type CodeData } from "~/components/code-demo";
 const code = `
 import { Button, Popover } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Popover
       aria-labelledby="default-popover"
@@ -25,7 +25,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Popover
       aria-labelledby="default-popover"

--- a/apps/web/examples/popover/popover.trigger.tsx
+++ b/apps/web/examples/popover/popover.trigger.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Popover } from "flowbite-react";
 
-function Component() {
+export function Component() {
   const content = (
     <div className="w-64 text-sm text-gray-500 dark:text-gray-400">
       <div className="border-b border-gray-200 bg-gray-100 px-3 py-2 dark:border-gray-600 dark:bg-gray-700">
@@ -34,7 +34,7 @@ function Component() {
 const codeRSC = `
 import { Button, Popover } from "flowbite-react";
 
-function Component() {
+export function Component() {
   const content = (
     <div className="w-64 text-sm text-gray-500 dark:text-gray-400">
       <div className="border-b border-gray-200 bg-gray-100 px-3 py-2 dark:border-gray-600 dark:bg-gray-700">
@@ -59,7 +59,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const content = (
     <div className="w-64 text-sm text-gray-500 dark:text-gray-400">
       <div className="border-b border-gray-200 bg-gray-100 px-3 py-2 dark:border-gray-600 dark:bg-gray-700">

--- a/apps/web/examples/progress/progress.colors.tsx
+++ b/apps/web/examples/progress/progress.colors.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Progress } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-2">
       <div className="text-base font-medium">Dark</div>
@@ -41,7 +41,7 @@ function Component() {
 const codeRSC = `
 import { Progress } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-2">
       <div className="text-base font-medium">Dark</div>
@@ -73,7 +73,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-2">
       <div className="text-base font-medium">Dark</div>

--- a/apps/web/examples/progress/progress.positioning.tsx
+++ b/apps/web/examples/progress/progress.positioning.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Progress } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Progress
       progress={45}
@@ -24,7 +24,7 @@ function Component() {
 const codeRSC = `
 import { Progress } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Progress
       progress={45}
@@ -39,7 +39,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Progress
       progress={45}

--- a/apps/web/examples/progress/progress.root.tsx
+++ b/apps/web/examples/progress/progress.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Progress } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Progress progress={45} />;
 }
 `;
@@ -14,12 +14,12 @@ function Component() {
 const codeRSC = `
 import { Progress } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Progress progress={45} />;
 }
 `;
 
-function Component() {
+export function Component() {
   return <Progress progress={45} />;
 }
 

--- a/apps/web/examples/progress/progress.sizing.tsx
+++ b/apps/web/examples/progress/progress.sizing.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Progress } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-2">
       <div className="text-base font-medium dark:text-white">Small</div>
@@ -25,7 +25,7 @@ function Component() {
 const codeRSC = `
 import { Progress } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-2">
       <div className="text-base font-medium dark:text-white">Small</div>
@@ -41,7 +41,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-2">
       <div className="text-base font-medium dark:text-white">Small</div>

--- a/apps/web/examples/progress/progress.withLabels.tsx
+++ b/apps/web/examples/progress/progress.withLabels.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Progress } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Progress progress={50} textLabel="Flowbite" size="lg" labelProgress labelText />;
 }
 `;
@@ -14,12 +14,12 @@ function Component() {
 const codeRSC = `
 import { Progress } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Progress progress={50} textLabel="Flowbite" size="lg" labelProgress labelText />;
 }
 `;
 
-function Component() {
+export function Component() {
   return <Progress progress={50} textLabel="Flowbite" size="lg" labelProgress labelText />;
 }
 

--- a/apps/web/examples/rating/rating.advanced.tsx
+++ b/apps/web/examples/rating/rating.advanced.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Rating } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       <Rating className="mb-2">
@@ -39,7 +39,7 @@ function Component() {
 const codeRSC = `
 import { Rating, RatingAdvanced, RatingStar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <>
       <Rating className="mb-2">
@@ -69,7 +69,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <>
       <Rating className="mb-2">

--- a/apps/web/examples/rating/rating.count.tsx
+++ b/apps/web/examples/rating/rating.count.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Rating } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Rating>
       <Rating.Star />
@@ -23,7 +23,7 @@ function Component() {
 const codeRSC = `
 import { Rating, RatingStar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Rating>
       <RatingStar />
@@ -37,7 +37,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Rating>
       <RatingStar />

--- a/apps/web/examples/rating/rating.root.tsx
+++ b/apps/web/examples/rating/rating.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Rating } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Rating>
       <Rating.Star />
@@ -22,7 +22,7 @@ function Component() {
 const codeRSC = `
 import { Rating, RatingStar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Rating>
       <RatingStar />
@@ -35,7 +35,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Rating>
       <RatingStar />

--- a/apps/web/examples/rating/rating.sizing.tsx
+++ b/apps/web/examples/rating/rating.sizing.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Rating } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-2">
       <Rating>
@@ -38,7 +38,7 @@ function Component() {
 const codeRSC = `
 import { Rating, RatingStar } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-2">
       <Rating>
@@ -67,7 +67,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-2">
       <Rating>

--- a/apps/web/examples/rating/rating.withText.tsx
+++ b/apps/web/examples/rating/rating.withText.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Rating } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Rating>
       <Rating.Star />
@@ -23,7 +23,7 @@ function Component() {
 const codeRSC = `
 import { Rating } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Rating>
       <RatingStar />
@@ -37,7 +37,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Rating>
       <RatingStar />

--- a/apps/web/examples/sidebar/sidebar.dropdown.tsx
+++ b/apps/web/examples/sidebar/sidebar.dropdown.tsx
@@ -12,7 +12,7 @@ const code = `
 import { Sidebar } from "flowbite-react";
 import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Sidebar with multi-level dropdown example">
       <Sidebar.Items>
@@ -48,7 +48,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Sidebar with multi-level dropdown example">
       <Sidebar.Items>

--- a/apps/web/examples/sidebar/sidebar.dropdownWithChevron.tsx
+++ b/apps/web/examples/sidebar/sidebar.dropdownWithChevron.tsx
@@ -32,7 +32,7 @@ import {
 } from "react-icons/hi";
 import { twMerge } from "tailwind-merge";
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Sidebar with multi-level dropdown example">
       <Sidebar.Items>
@@ -76,7 +76,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Sidebar with multi-level dropdown example">
       <Sidebar.Items>

--- a/apps/web/examples/sidebar/sidebar.root.tsx
+++ b/apps/web/examples/sidebar/sidebar.root.tsx
@@ -12,7 +12,7 @@ const code = `
 import { Sidebar } from "flowbite-react";
 import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, HiViewBoards } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Default sidebar example">
       <Sidebar.Items>
@@ -45,7 +45,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Default sidebar example">
       <Sidebar.Items>

--- a/apps/web/examples/sidebar/sidebar.separator.tsx
+++ b/apps/web/examples/sidebar/sidebar.separator.tsx
@@ -14,7 +14,7 @@ import { Sidebar } from "flowbite-react";
 import { BiBuoy } from "react-icons/bi";
 import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, HiViewBoards } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Sidebar with content separator example">
       <Sidebar.Items>
@@ -58,7 +58,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Sidebar with content separator example">
       <Sidebar.Items>

--- a/apps/web/examples/sidebar/sidebar.withButton.tsx
+++ b/apps/web/examples/sidebar/sidebar.withButton.tsx
@@ -12,7 +12,7 @@ const code = `
 import { Badge, Sidebar } from "flowbite-react";
 import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, HiViewBoards } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Sidebar with call to action button example">
       <Sidebar.Items>
@@ -79,7 +79,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Sidebar with call to action button example">
       <Sidebar.Items>

--- a/apps/web/examples/sidebar/sidebar.withLogo.tsx
+++ b/apps/web/examples/sidebar/sidebar.withLogo.tsx
@@ -12,7 +12,7 @@ const code = `
 import { Sidebar } from "flowbite-react";
 import { HiArrowSmRight, HiChartPie, HiInbox, HiShoppingBag, HiTable, HiUser, HiViewBoards } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Sidebar with logo branding example">
       <Sidebar.Logo href="#" img="/favicon.svg" imgAlt="Flowbite logo">
@@ -48,7 +48,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Sidebar aria-label="Sidebar with logo branding example">
       <Sidebar.Logo href="#" img="/favicon.svg" imgAlt="Flowbite logo">

--- a/apps/web/examples/spinner/spinner.alignment.tsx
+++ b/apps/web/examples/spinner/spinner.alignment.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Spinner } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <div className="text-left">
@@ -26,7 +26,7 @@ function Component() {
 const codeRSC = `
 import { Spinner } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <div className="text-left">
@@ -43,7 +43,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-2">
       <div className="text-left">

--- a/apps/web/examples/spinner/spinner.colors.tsx
+++ b/apps/web/examples/spinner/spinner.colors.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Spinner } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Spinner color="info" aria-label="Info spinner example" />
@@ -23,7 +23,7 @@ function Component() {
 const codeRSC = `
 import { Spinner } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Spinner color="info" aria-label="Info spinner example" />
@@ -37,7 +37,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Spinner color="info" aria-label="Info spinner example" />

--- a/apps/web/examples/spinner/spinner.loadingButtons.tsx
+++ b/apps/web/examples/spinner/spinner.loadingButtons.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Spinner } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-row gap-3">
       <Button>
@@ -25,7 +25,7 @@ function Component() {
 const codeRSC = `
 import { Button, Spinner } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-row gap-3">
       <Button>
@@ -41,7 +41,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-row gap-3">
       <Button>

--- a/apps/web/examples/spinner/spinner.root.tsx
+++ b/apps/web/examples/spinner/spinner.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Spinner } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Spinner aria-label="Default status example" />;
 }
 `;
@@ -14,12 +14,12 @@ function Component() {
 const codeRSC = `
 import { Spinner } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return <Spinner aria-label="Default status example" />;
 }
 `;
 
-function Component() {
+export function Component() {
   return <Spinner aria-label="Default status example" />;
 }
 

--- a/apps/web/examples/spinner/spinner.sizing.tsx
+++ b/apps/web/examples/spinner/spinner.sizing.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Spinner } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Spinner aria-label="Extra small spinner example" size="xs" />
@@ -22,7 +22,7 @@ function Component() {
 const codeRSC = `
 import { Spinner } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Spinner aria-label="Extra small spinner example" size="xs" />
@@ -35,7 +35,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Spinner aria-label="Extra small spinner example" size="xs" />

--- a/apps/web/examples/table/table.hover.tsx
+++ b/apps/web/examples/table/table.hover.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Table } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table hoverable>
@@ -67,7 +67,7 @@ function Component() {
 const codeRSC = `
 import { Table, TableBody, TableCell, TableHead, TableHeadCell, TableRow } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table hoverable>
@@ -125,7 +125,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table hoverable>

--- a/apps/web/examples/table/table.root.tsx
+++ b/apps/web/examples/table/table.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Table } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table>
@@ -67,7 +67,7 @@ function Component() {
 const codeRSC = `
 import { Table, TableBody, TableCell, TableHead, TableHeadCell, TableRow } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table>
@@ -125,7 +125,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table>

--- a/apps/web/examples/table/table.striped.tsx
+++ b/apps/web/examples/table/table.striped.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Table } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table striped>
@@ -91,7 +91,7 @@ function Component() {
 const codeRSC = `
 import { Table, TableBody, TableCell, TableHead, TableHeadCell, TableRow } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table striped>
@@ -173,7 +173,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table striped>

--- a/apps/web/examples/table/table.withCheckboxes.tsx
+++ b/apps/web/examples/table/table.withCheckboxes.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Checkbox, Table } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table hoverable>
@@ -79,7 +79,7 @@ function Component() {
 const codeRSC = `
 import { Checkbox, Table, TableBody, TableCell, TableHead, TableHeadCell, TableRow } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table hoverable>
@@ -149,7 +149,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Table hoverable>

--- a/apps/web/examples/tabs/tabs.fullWidth.tsx
+++ b/apps/web/examples/tabs/tabs.fullWidth.tsx
@@ -10,7 +10,7 @@ import { Tabs } from "flowbite-react";
 import { HiAdjustments, HiClipboardList, HiUserCircle } from "react-icons/hi";
 import { MdDashboard } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Tabs aria-label="Full width tabs" style="fullWidth">
@@ -43,7 +43,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="overflow-x-auto">
       <Tabs aria-label="Full width tabs" style="fullWidth">

--- a/apps/web/examples/tabs/tabs.root.tsx
+++ b/apps/web/examples/tabs/tabs.root.tsx
@@ -10,7 +10,7 @@ import { Tabs } from "flowbite-react";
 import { HiAdjustments, HiClipboardList, HiUserCircle } from "react-icons/hi";
 import { MdDashboard } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <Tabs aria-label="Default tabs" style="default">
       <Tabs.Item active title="Profile" icon={HiUserCircle}>
@@ -41,7 +41,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Tabs aria-label="Default tabs" style="default">
       <Tabs.Item active title="Profile" icon={HiUserCircle}>

--- a/apps/web/examples/tabs/tabs.stateOptions.tsx
+++ b/apps/web/examples/tabs/tabs.stateOptions.tsx
@@ -14,7 +14,7 @@ import { useRef, useState } from "react";
 import { HiAdjustments, HiClipboardList, HiUserCircle } from "react-icons/hi";
 import { MdDashboard } from "react-icons/md";
 
-function Component() {
+export function Component() {
   const tabsRef = useRef<TabsRef>(null);
   const [activeTab, setActiveTab] = useState(0);
 
@@ -65,7 +65,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const tabsRef = useRef<TabsRef>(null);
   const [activeTab, setActiveTab] = useState(0);
 

--- a/apps/web/examples/tabs/tabs.withIcons.tsx
+++ b/apps/web/examples/tabs/tabs.withIcons.tsx
@@ -10,7 +10,7 @@ import { Tabs } from "flowbite-react";
 import { HiAdjustments, HiClipboardList, HiUserCircle } from "react-icons/hi";
 import { MdDashboard } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <Tabs aria-label="Tabs with icons" style="underline">
       <Tabs.Item active title="Profile" icon={HiUserCircle}>
@@ -41,7 +41,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Tabs aria-label="Tabs with icons" style="underline">
       <Tabs.Item active title="Profile" icon={HiUserCircle}>

--- a/apps/web/examples/tabs/tabs.withPills.tsx
+++ b/apps/web/examples/tabs/tabs.withPills.tsx
@@ -6,7 +6,7 @@ import { type CodeData } from "~/components/code-demo";
 const code = `
 import { Tabs } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Tabs aria-label="Pills" style="pills">
       <Tabs.Item active title="Tab 1">
@@ -29,7 +29,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Tabs aria-label="Pills" style="pills">
       <Tabs.Item active title="Tab 1">

--- a/apps/web/examples/tabs/tabs.withUnderline.tsx
+++ b/apps/web/examples/tabs/tabs.withUnderline.tsx
@@ -10,7 +10,7 @@ import { Tabs } from "flowbite-react";
 import { HiAdjustments, HiClipboardList, HiUserCircle } from "react-icons/hi";
 import { MdDashboard } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <Tabs aria-label="Tabs with underline" style="underline">
       <Tabs.Item active title="Profile" icon={HiUserCircle}>
@@ -41,7 +41,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Tabs aria-label="Tabs with underline" style="underline">
       <Tabs.Item active title="Profile" icon={HiUserCircle}>

--- a/apps/web/examples/timeline/timeline.horizontal.tsx
+++ b/apps/web/examples/timeline/timeline.horizontal.tsx
@@ -21,7 +21,7 @@ const code = `
 import { Button, Timeline } from "flowbite-react";
 import { HiArrowNarrowRight, HiCalendar } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Timeline horizontal>
       <Timeline.Item>
@@ -78,7 +78,7 @@ function Component() {
 // } from "flowbite-react";
 // import { HiArrowNarrowRight, HiCalendar } from "react-icons/hi";
 
-// function Component() {
+// export function Component() {
 //   return (
 //     <Timeline horizontal>
 //       <TimelineItem>
@@ -122,7 +122,7 @@ function Component() {
 // }
 // `;
 
-function Component() {
+export function Component() {
   return (
     <Timeline horizontal>
       <TimelineItem>
@@ -181,4 +181,5 @@ export const horizontal: CodeData = {
   ],
   githubSlug: "timeline/timeline.horizontal.tsx",
   component: <Component />,
+  iframe: 500,
 };

--- a/apps/web/examples/timeline/timeline.root.tsx
+++ b/apps/web/examples/timeline/timeline.root.tsx
@@ -17,7 +17,7 @@ const code = `
 import { Button, Timeline } from "flowbite-react";
 import { HiArrowNarrowRight } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Timeline>
       <Timeline.Item>
@@ -74,7 +74,7 @@ import {
 } from "flowbite-react";
 import { HiArrowNarrowRight } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Timeline>
       <TimelineItem>
@@ -118,7 +118,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Timeline>
       <TimelineItem>

--- a/apps/web/examples/timeline/timeline.vertical.tsx
+++ b/apps/web/examples/timeline/timeline.vertical.tsx
@@ -21,7 +21,7 @@ const code = `
 import { Button, Timeline } from "flowbite-react";
 import { HiArrowNarrowRight, HiCalendar } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Timeline>
       <Timeline.Item>
@@ -78,7 +78,7 @@ function Component() {
 // } from "flowbite-react";
 // import { HiArrowNarrowRight, HiCalendar } from "react-icons/hi";
 
-// function Component() {
+// export function Component() {
 //   return (
 //     <Timeline>
 //       <TimelineItem>
@@ -122,7 +122,7 @@ function Component() {
 // }
 // `;
 
-function Component() {
+export function Component() {
   return (
     <Timeline>
       <TimelineItem>

--- a/apps/web/examples/toast/toast.colors.tsx
+++ b/apps/web/examples/toast/toast.colors.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Toast } from "flowbite-react";
 import { HiCheck, HiExclamation, HiX } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-4">
       <Toast>
@@ -41,7 +41,7 @@ const codeRSC = `
 import { Toast, ToastToggle} from "flowbite-react";
 import { HiCheck, HiExclamation, HiX } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-4">
       <Toast>
@@ -70,7 +70,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-col gap-4">
       <Toast>

--- a/apps/web/examples/toast/toast.customDismissal.tsx
+++ b/apps/web/examples/toast/toast.customDismissal.tsx
@@ -12,7 +12,7 @@ import { Button, Toast } from "flowbite-react";
 import { useState } from "react";
 import { HiFire } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   const [showToast, setShowToast] = useState(false);
 
   return (
@@ -32,7 +32,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   const [showToast, setShowToast] = useState(false);
 
   return (

--- a/apps/web/examples/toast/toast.feedback.tsx
+++ b/apps/web/examples/toast/toast.feedback.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Toast } from "flowbite-react";
 import { FaTelegramPlane } from "react-icons/fa";
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <FaTelegramPlane className="h-5 w-5 text-cyan-600 dark:text-cyan-500" />
@@ -22,7 +22,7 @@ const codeRSC = `
 import { Toast } from "flowbite-react";
 import { FaTelegramPlane } from "react-icons/fa";
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <FaTelegramPlane className="h-5 w-5 text-cyan-600 dark:text-cyan-500" />
@@ -32,7 +32,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <FaTelegramPlane className="h-5 w-5 text-cyan-600 dark:text-cyan-500" />

--- a/apps/web/examples/toast/toast.interactive.tsx
+++ b/apps/web/examples/toast/toast.interactive.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Button, Toast } from "flowbite-react";
 import { MdLoop } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <div className="flex items-start">
@@ -40,7 +40,7 @@ const codeRSC = `
 import { Button, Toast, ToastToggle } from "flowbite-react";
 import { MdLoop } from "react-icons/md";
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <div className="flex items-start">
@@ -68,7 +68,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <div className="flex items-start">

--- a/apps/web/examples/toast/toast.root.tsx
+++ b/apps/web/examples/toast/toast.root.tsx
@@ -8,7 +8,7 @@ const code = `
 import { Toast } from "flowbite-react";
 import { HiFire } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-cyan-100 text-cyan-500 dark:bg-cyan-800 dark:text-cyan-200">
@@ -25,7 +25,7 @@ const codeRSC = `
 import { Toast, ToastToggle } from "flowbite-react";
 import { HiFire } from "react-icons/hi";
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-cyan-100 text-cyan-500 dark:bg-cyan-800 dark:text-cyan-200">
@@ -38,7 +38,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <div className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-cyan-100 text-cyan-500 dark:bg-cyan-800 dark:text-cyan-200">

--- a/apps/web/examples/toast/toast.withButton.tsx
+++ b/apps/web/examples/toast/toast.withButton.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Toast } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <div className="text-sm font-normal">Conversation archived.</div>
@@ -27,7 +27,7 @@ function Component() {
 const codeRSC = `
 import { Toast, ToastToggle } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <div className="text-sm font-normal">Conversation archived.</div>
@@ -45,7 +45,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Toast>
       <div className="text-sm font-normal">Conversation archived.</div>

--- a/apps/web/examples/tooltip/tooltip.animation.tsx
+++ b/apps/web/examples/tooltip/tooltip.animation.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Tooltip content="Tooltip content" animation={false}>
@@ -32,7 +32,7 @@ function Component() {
 const codeRSC = `
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Tooltip content="Tooltip content" animation={false}>
@@ -55,7 +55,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex flex-wrap gap-2">
       <Tooltip content="Tooltip content" animation={false}>

--- a/apps/web/examples/tooltip/tooltip.disableArrow.tsx
+++ b/apps/web/examples/tooltip/tooltip.disableArrow.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Tooltip content="Tooltip content" arrow={false}>
       <Button>Default tooltip</Button>
@@ -18,7 +18,7 @@ function Component() {
 const codeRSC = `
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Tooltip content="Tooltip content" arrow={false}>
       <Button>Default tooltip</Button>
@@ -27,7 +27,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Tooltip content="Tooltip content" arrow={false}>
       <Button>Default tooltip</Button>

--- a/apps/web/examples/tooltip/tooltip.placement.tsx
+++ b/apps/web/examples/tooltip/tooltip.placement.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex gap-2">
       <Tooltip content="Tooltip content" placement="top">
@@ -29,7 +29,7 @@ function Component() {
 const codeRSC = `
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex gap-2">
       <Tooltip content="Tooltip content" placement="top">
@@ -49,7 +49,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex gap-2">
       <Tooltip content="Tooltip content" placement="top">

--- a/apps/web/examples/tooltip/tooltip.root.tsx
+++ b/apps/web/examples/tooltip/tooltip.root.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Tooltip content="Tooltip content">
       <Button>Default tooltip</Button>
@@ -18,7 +18,7 @@ function Component() {
 const codeRSC = `
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <Tooltip content="Tooltip content">
       <Button>Default tooltip</Button>
@@ -27,7 +27,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <Tooltip content="Tooltip content">
       <Button>Default tooltip</Button>

--- a/apps/web/examples/tooltip/tooltip.styles.tsx
+++ b/apps/web/examples/tooltip/tooltip.styles.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex gap-2">
       <Tooltip content="Tooltip content" style="light">
@@ -23,7 +23,7 @@ function Component() {
 const codeRSC = `
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex gap-2">
       <Tooltip content="Tooltip content" style="light">
@@ -37,7 +37,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex gap-2">
       <Tooltip content="Tooltip content" style="light">

--- a/apps/web/examples/tooltip/tooltip.trigger.tsx
+++ b/apps/web/examples/tooltip/tooltip.trigger.tsx
@@ -6,7 +6,7 @@ const code = `
 
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex gap-2">
       <Tooltip content="Tooltip content" trigger="hover">
@@ -23,7 +23,7 @@ function Component() {
 const codeRSC = `
 import { Button, Tooltip } from "flowbite-react";
 
-function Component() {
+export function Component() {
   return (
     <div className="flex gap-2">
       <Tooltip content="Tooltip content" trigger="hover">
@@ -37,7 +37,7 @@ function Component() {
 }
 `;
 
-function Component() {
+export function Component() {
   return (
     <div className="flex gap-2">
       <Tooltip content="Tooltip content" trigger="hover">


### PR DESCRIPTION
### Description

Due to CSS media queries working on the root reference of the window size, some component examples are broken since the media queries reference the docs window and not the narrower preview container.

This PR brings isolation using `iframe` within the `code-demo` component, configurable at the code example level (granular), it is an opt-in config.

### Changes

- [x] create new `/examples/<NAME>` page for the `code-demo` iframe to consume
- [x] modify `code-demo` component to support iframe (opt in)
- [x] isolate `navbar`, `modal`, `timeline` examples in iframe

### Result

**Before**

<img width="866" alt="Screenshot 2024-04-16 at 14 11 36" src="https://github.com/themesberg/flowbite-react/assets/41998826/a6f2af83-b29d-4708-980c-67ea279ed869">

**After**

<img width="865" alt="Screenshot 2024-04-16 at 14 12 11" src="https://github.com/themesberg/flowbite-react/assets/41998826/e45d78d8-dda6-45c7-9d79-a1cf5e8d523f">
<img width="888" alt="Screenshot 2024-04-16 at 14 12 14" src="https://github.com/themesberg/flowbite-react/assets/41998826/5a06f22d-0f8e-48e0-9a4a-8eea23964a83">
<img width="864" alt="Screenshot 2024-04-16 at 14 12 16" src="https://github.com/themesberg/flowbite-react/assets/41998826/8944822c-df3a-46de-845d-65ab1cbc47ec">
<img width="863" alt="Screenshot 2024-04-16 at 14 14 28" src="https://github.com/themesberg/flowbite-react/assets/41998826/8b57aa21-bf56-4273-92e8-d105b5251a53">
