### PR TITLE
fix: Customize Theme was showing wrong example for color

### DIFF
--- a/apps/web/content/docs/customize/theme.mdx
+++ b/apps/web/content/docs/customize/theme.mdx
@@ -39,7 +39,7 @@ import { Flowbite } from "flowbite-react";
 const customTheme: CustomFlowbiteTheme = {
   button: {
     color: {
-      primary: "bg-red-500 hover:bg-red-600",
+      failure: "bg-red-500 hover:bg-red-600",
     },
   },
 };
@@ -47,7 +47,7 @@ const customTheme: CustomFlowbiteTheme = {
 export default function MyPage() {
   return (
     <Flowbite theme={{ theme: customTheme }}>
-      <Button color="primary">Click me</Button>
+      <Button color="failure">Click me</Button>
     </Flowbite>
   );
 }
@@ -63,13 +63,13 @@ import { Button } from "flowbite-react";
 
 const customTheme: CustomFlowbiteTheme["button"] = {
   color: {
-    primary: "bg-red-500 hover:bg-red-600",
+    failure: "bg-red-500 hover:bg-red-600",
   },
 };
 
 export default function MyPage() {
   return (
-    <Button theme={customTheme} color="primary">
+    <Button theme={customTheme} color="failure">
       Click me
     </Button>
   );


### PR DESCRIPTION
This PR is fixing a documentation error specifically for the `Button` component. As we don't have any `color` option called as ` Primary`

![image](https://github.com/themesberg/flowbite-react/assets/32231977/e17e3fbf-49ad-4610-9cee-06da6f34bd3f)
[Customize Theme - Option 3](https://flowbite-react.com/docs/customize/theme#option-3-create-a-reusable-component-with-a-custom-theme)

the below is the fix of the documentation with the correct color option in the custom theme option.

![image](https://github.com/themesberg/flowbite-react/assets/32231977/ef34def2-ee10-4b82-b6f6-af4921bae06a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the custom theme documentation to reflect the renaming of the color key from "primary" to "failure" for button styling, enhancing semantic clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->