### PR TITLE
Exclude analytics from `examples` page

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,8 +1,8 @@
 import { ThemeModeScript } from "flowbite-react";
 import { Inter as InterFont } from "next/font/google";
-import { headers } from "next/headers";
-import type { Metadata, NextPage, Viewport } from "next/types";
-import type { FC, PropsWithChildren } from "react";
+import type { Metadata, Viewport } from "next/types";
+import type { PropsWithChildren } from "react";
+import { FathomScript } from "~/components/fathom-script";
 
 import "~/styles/globals.css";
 
@@ -54,10 +54,7 @@ export const viewport: Viewport = {
   ],
 };
 
-const RootLayout: NextPage<PropsWithChildren> = ({ children }) => {
-  const pathname = headers().get("next-url");
-  const isExamplesPage = pathname?.startsWith("/examples/");
-
+export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en" className={`${interFont.variable} font-sans`}>
       <head>
@@ -65,14 +62,8 @@ const RootLayout: NextPage<PropsWithChildren> = ({ children }) => {
       </head>
       <body className="bg-white text-gray-600 antialiased dark:bg-gray-900 dark:text-gray-400">
         {children}
-        {!isExamplesPage && <FathomScript />}
+        <FathomScript />
       </body>
     </html>
   );
-};
-
-const FathomScript: FC = () => {
-  return <script data-site="UXMSXUQI" defer src="https://cdn.usefathom.com/script.js" />;
-};
-
-export default RootLayout;
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import { ThemeModeScript } from "flowbite-react";
 import { Inter as InterFont } from "next/font/google";
+import { headers } from "next/headers";
 import type { Metadata, NextPage, Viewport } from "next/types";
 import type { FC, PropsWithChildren } from "react";
 
@@ -54,6 +55,9 @@ export const viewport: Viewport = {
 };
 
 const RootLayout: NextPage<PropsWithChildren> = ({ children }) => {
+  const pathname = headers().get("next-url");
+  const isExamplesPage = pathname?.startsWith("/examples/");
+
   return (
     <html lang="en" className={`${interFont.variable} font-sans`}>
       <head>
@@ -61,7 +65,7 @@ const RootLayout: NextPage<PropsWithChildren> = ({ children }) => {
       </head>
       <body className="bg-white text-gray-600 antialiased dark:bg-gray-900 dark:text-gray-400">
         {children}
-        <FathomScript />
+        {!isExamplesPage && <FathomScript />}
       </body>
     </html>
   );

--- a/apps/web/components/fathom-script.tsx
+++ b/apps/web/components/fathom-script.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+export function FathomScript() {
+  const pathname = usePathname();
+  const isExamplesPage = pathname.startsWith("/examples/");
+
+  if (isExamplesPage) return null;
+
+  return <script data-site="UXMSXUQI" defer src="https://cdn.usefathom.com/script.js" />;
+}


### PR DESCRIPTION
### Changes

- [x] exclude analytics from `examples` page leading to page-load-count inception due to code preview examples iframe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved analytics script inclusion by conditionally adding it to example pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->