### PR TITLE
fix: for blue color - cyan color was passed has been fixed

### DIFF
--- a/packages/ui/src/components/ToggleSwitch/ToggleSwitch.stories.tsx
+++ b/packages/ui/src/components/ToggleSwitch/ToggleSwitch.stories.tsx
@@ -27,10 +27,8 @@ DefaultToggleSwitch.args = {};
 DefaultToggleSwitch.argTypes = {
   color: {
     description: "Control defaults for colors",
-    control: {
-      type: "radio",
-      options: [...colors],
-    },
+    control: "radio",
+    options: [...colors],
   },
 };
 

--- a/packages/ui/src/components/ToggleSwitch/theme.ts
+++ b/packages/ui/src/components/ToggleSwitch/theme.ts
@@ -16,7 +16,7 @@ export const toggleSwitchTheme: FlowbiteToggleSwitchTheme = createTheme({
       on: "after:translate-x-full after:border-white rtl:after:-translate-x-full",
       off: "border-gray-200 bg-gray-200 dark:border-gray-600 dark:bg-gray-700",
       color: {
-        blue: "border-cyan-700 bg-cyan-700",
+        blue: "border-blue-600 bg-blue-600",
         dark: "bg-dark-700 border-dark-900",
         failure: "border-red-900 bg-red-700",
         gray: "border-gray-600 bg-gray-500",


### PR DESCRIPTION
This PR is fixed for Issue #1435 

in this PR 2 things are fixed:

- for Toggle Switch Color `blue` it was having value of `cyan` which is fixed & updated to `blue`
- for Storybook, color control option was not working and it wasn't passed the `argTypes` correctly, which has been fixed as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Simplified color control settings in ToggleSwitch component for better clarity and maintainability.

- **New Features**
  - Updated ToggleSwitch theme colors for improved visual consistency (changed blue shades).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->