### PR TITLE
fix: not allowing to select other year

### DIFF
--- a/packages/ui/src/components/Datepicker/Views/Months.tsx
+++ b/packages/ui/src/components/Datepicker/Views/Months.tsx
@@ -20,7 +20,7 @@ export interface DatepickerViewsMonthsProps {
 }
 
 export const DatepickerViewsMonth: FC<DatepickerViewsMonthsProps> = ({ theme: customTheme = {} }) => {
-  const { theme: rootTheme, minDate, maxDate, selectedDate, language, setViewDate, setView } = useDatePickerContext();
+  const { theme: rootTheme, minDate, maxDate, selectedDate, viewDate, language, setViewDate, setView } = useDatePickerContext();
 
   const theme = mergeDeep(rootTheme.views.months, customTheme);
 
@@ -30,6 +30,7 @@ export const DatepickerViewsMonth: FC<DatepickerViewsMonthsProps> = ({ theme: cu
         const newDate = new Date();
         // setting day to 1 to avoid overflow issues
         newDate.setMonth(index, 1);
+        newDate.setFullYear(viewDate.getFullYear());
         const month = getFormattedDate(language, newDate, { month: "short" });
 
         const isSelected = isMonthEqual(selectedDate, newDate);

--- a/packages/ui/src/components/Datepicker/Views/Months.tsx
+++ b/packages/ui/src/components/Datepicker/Views/Months.tsx
@@ -20,7 +20,16 @@ export interface DatepickerViewsMonthsProps {
 }
 
 export const DatepickerViewsMonth: FC<DatepickerViewsMonthsProps> = ({ theme: customTheme = {} }) => {
-  const { theme: rootTheme, minDate, maxDate, selectedDate, viewDate, language, setViewDate, setView } = useDatePickerContext();
+  const {
+    theme: rootTheme,
+    minDate,
+    maxDate,
+    selectedDate,
+    viewDate,
+    language,
+    setViewDate,
+    setView,
+  } = useDatePickerContext();
 
   const theme = mergeDeep(rootTheme.views.months, customTheme);
 


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

This fixes a bug introduced by https://github.com/themesberg/flowbite-react/pull/1457 not being able to select any other year except for 2024.

Related issues https://github.com/themesberg/flowbite-react/issues/1456


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `Datepicker` component for improved date selection accuracy.
	- Added functionality to ensure selected months align with the current view date, enhancing user experience.
- **Bug Fixes**
	- Corrected issues with date handling in the `Datepicker` to ensure consistency in year selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->