### PR TITLE
chore: Make label prop optional in Dropdown component

### DIFF
--- a/packages/ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.tsx
@@ -45,7 +45,7 @@ export interface DropdownProps extends Pick<FloatingProps, "placement" | "trigge
   dismissOnClick?: boolean;
   floatingArrow?: boolean;
   inline?: boolean;
-  label: ReactNode;
+  label?: ReactNode;
   theme?: DeepPartial<FlowbiteDropdownTheme>;
   enableTypeAhead?: boolean;
   renderTrigger?: (theme: FlowbiteDropdownTheme) => ReactElement;


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

Reference related issues using `#` followed by the issue number.

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.

---

https://github.com/themesberg/flowbite-react/issues/1466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `label` property in the Dropdown component is now optional, enhancing flexibility for developers when using the component.

- **Bug Fixes**
	- Adjustments to the Dropdown interface improve compatibility for various use cases, ensuring components function correctly without a specified label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->