### PR TITLE
Fix/dropdown label optional

### DIFF
--- a/packages/ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/components/Dropdown/Dropdown.tsx
@@ -45,7 +45,7 @@ export interface DropdownProps extends Pick<FloatingProps, "placement" | "trigge
   dismissOnClick?: boolean;
   floatingArrow?: boolean;
   inline?: boolean;
-  label: ReactNode;
+  label?: ReactNode;
   theme?: DeepPartial<FlowbiteDropdownTheme>;
   enableTypeAhead?: boolean;
   renderTrigger?: (theme: FlowbiteDropdownTheme) => ReactElement;

--- a/packages/ui/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/ui/src/components/Dropdown/DropdownItem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useListItem, useMergeRefs } from "@floating-ui/react";
-import { forwardRef, type ComponentProps, type ElementType, type FC, type RefCallback } from "react";
+import { forwardRef, type ComponentProps, type ElementType, type FC, type RefCallback, MouseEvent } from "react";
 import { twMerge } from "tailwind-merge";
 import type { PolymorphicComponentPropWithRef, PolymorphicRef } from "../../helpers/generic-as-prop";
 import { mergeDeep } from "../../helpers/merge-deep";
@@ -20,7 +20,7 @@ export type DropdownItemProps<T extends ElementType = "button"> = PolymorphicCom
   {
     href?: string;
     icon?: FC<ComponentProps<"svg">>;
-    onClick?: () => void;
+    onClick?: (event: MouseEvent<HTMLElement>) => void;
     theme?: DeepPartial<FlowbiteDropdownItemTheme>;
   }
 >;
@@ -49,8 +49,8 @@ export const DropdownItem = forwardRef(
           className={twMerge(theme.base, className)}
           {...theirProps}
           {...getItemProps({
-            onClick: () => {
-              onClick?.();
+            onClick: (event) => {
+              onClick?.(event);
               dismissOnClick && handleSelect(null);
             },
           })}


### PR DESCRIPTION
This commit resolves issue #1402 where the MouseEvent was not being passed through the DropdownItem's onClick handler. 

- Updated the DropdownItem component to correctly pass the MouseEvent to the onClick handler.
- This change allows for proper event handling, including scenarios where event propagation needs to be stopped, such as when the dropdown is a descendant of another clickable item.
- Ensured consistency with NavbarLink, which already passes the event through.

By addressing this, we improve the flexibility and usability of the Dropdown component within the UI, enabling better integration with other interactive elements.
