### PR TITLE
feat: add theme exports to components

### DIFF
--- a/.changeset/healthy-crabs-melt.md
+++ b/.changeset/healthy-crabs-melt.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+Add theme exports to all components.

--- a/packages/ui/src/components/Accordion/index.ts
+++ b/packages/ui/src/components/Accordion/index.ts
@@ -6,3 +6,4 @@ export { AccordionPanel } from "./AccordionPanel";
 export type { AccordionPanelProps } from "./AccordionPanel";
 export { AccordionTitle } from "./AccordionTitle";
 export type { AccordionTitleProps, FlowbiteAccordionTitleTheme } from "./AccordionTitle";
+export { accordionTheme } from "./theme";

--- a/packages/ui/src/components/Alert/index.ts
+++ b/packages/ui/src/components/Alert/index.ts
@@ -1,2 +1,3 @@
 export { Alert } from "./Alert";
 export type { AlertProps, FlowbiteAlertCloseButtonTheme, FlowbiteAlertTheme } from "./Alert";
+export { alertTheme } from "./theme";

--- a/packages/ui/src/components/Avatar/index.ts
+++ b/packages/ui/src/components/Avatar/index.ts
@@ -14,3 +14,4 @@ export { AvatarGroup } from "./AvatarGroup";
 export type { AvatarGroupProps, FlowbiteAvatarGroupTheme } from "./AvatarGroup";
 export { AvatarGroupCounter } from "./AvatarGroupCounter";
 export type { AvatarGroupCounterProps, FlowbiteAvatarGroupCounterTheme } from "./AvatarGroupCounter";
+export { avatarTheme } from "./theme";

--- a/packages/ui/src/components/Badge/index.ts
+++ b/packages/ui/src/components/Badge/index.ts
@@ -6,3 +6,4 @@ export type {
   FlowbiteBadgeRootTheme,
   FlowbiteBadgeTheme,
 } from "./Badge";
+export { badgeTheme } from "./theme";

--- a/packages/ui/src/components/Banner/index.ts
+++ b/packages/ui/src/components/Banner/index.ts
@@ -2,3 +2,4 @@ export { Banner } from "./Banner";
 export type { BannerComponentProps } from "./Banner";
 export { BannerCollapseButton } from "./BannerCollapseButton";
 export type { BannerCollapseButtonProps } from "./BannerCollapseButton";
+export { bannerTheme } from "./theme";

--- a/packages/ui/src/components/Blockquote/index.ts
+++ b/packages/ui/src/components/Blockquote/index.ts
@@ -1,2 +1,3 @@
 export { Blockquote } from "./Blockquote";
 export type { BlockquoteProps, FlowbiteBlockquoteRootTheme, FlowbiteBlockquoteTheme } from "./Blockquote";
+export { blockquoteTheme } from "./theme";

--- a/packages/ui/src/components/Breadcrumb/index.ts
+++ b/packages/ui/src/components/Breadcrumb/index.ts
@@ -2,3 +2,4 @@ export { Breadcrumb } from "./Breadcrumb";
 export type { BreadcrumbComponentProps, FlowbiteBreadcrumbRootTheme, FlowbiteBreadcrumbTheme } from "./Breadcrumb";
 export { BreadcrumbItem } from "./BreadcrumbItem";
 export type { BreadcrumbItemProps, FlowbiteBreadcrumbItemTheme } from "./BreadcrumbItem";
+export { breadcrumbTheme } from "./theme";

--- a/packages/ui/src/components/Button/index.ts
+++ b/packages/ui/src/components/Button/index.ts
@@ -12,3 +12,4 @@ export type {
 } from "./Button";
 export { ButtonGroup } from "./ButtonGroup";
 export type { ButtonGroupProps, FlowbiteButtonGroupTheme, PositionInButtonGroup } from "./ButtonGroup";
+export { buttonTheme } from "./theme";

--- a/packages/ui/src/components/Card/index.ts
+++ b/packages/ui/src/components/Card/index.ts
@@ -1,2 +1,3 @@
 export { Card } from "./Card";
 export type { CardProps, FlowbiteCardImageTheme, FlowbiteCardRootTheme, FlowbiteCardTheme } from "./Card";
+export { cardTheme } from "./theme";

--- a/packages/ui/src/components/Carousel/index.ts
+++ b/packages/ui/src/components/Carousel/index.ts
@@ -9,3 +9,4 @@ export type {
   FlowbiteCarouselScrollContainer,
   FlowbiteCarouselTheme,
 } from "./Carousel";
+export { carouselTheme } from "./theme";

--- a/packages/ui/src/components/Checkbox/index.ts
+++ b/packages/ui/src/components/Checkbox/index.ts
@@ -1,2 +1,3 @@
 export { Checkbox } from "./Checkbox";
 export type { CheckboxProps, FlowbiteCheckboxRootTheme, FlowbiteCheckboxTheme } from "./Checkbox";
+export { checkboxTheme } from "./theme";

--- a/packages/ui/src/components/Clipboard/index.ts
+++ b/packages/ui/src/components/Clipboard/index.ts
@@ -6,3 +6,4 @@ export type { ClipboardWithIconProps, FlowbiteClipboardWithIconTheme } from "./C
 
 export { ClipboardWithIconText } from "./ClipboardWithIconText";
 export type { ClipboardWithIconTextProps, FlowbiteClipboardWithIconTextTheme } from "./ClipboardWithIconText";
+export { clipboardTheme } from "./theme";

--- a/packages/ui/src/components/DarkThemeToggle/index.ts
+++ b/packages/ui/src/components/DarkThemeToggle/index.ts
@@ -4,3 +4,4 @@ export type {
   FlowbiteDarkThemeToggleRootTheme,
   FlowbiteDarkThemeToggleTheme,
 } from "./DarkThemeToggle";
+export { darkThemeToggleTheme } from "./theme";

--- a/packages/ui/src/components/Datepicker/index.ts
+++ b/packages/ui/src/components/Datepicker/index.ts
@@ -1,3 +1,4 @@
 export { Datepicker } from "./Datepicker";
 export type { DatepickerProps, FlowbiteDatepickerPopupTheme, FlowbiteDatepickerTheme } from "./Datepicker";
 export { WeekStart } from "./helpers";
+export { datePickerTheme } from "./theme";

--- a/packages/ui/src/components/Drawer/index.ts
+++ b/packages/ui/src/components/Drawer/index.ts
@@ -6,3 +6,4 @@ export type { DrawerHeaderProps, FlowbiteDrawerHeaderTheme } from "./DrawerHeade
 
 export { DrawerItems } from "./DrawerItems";
 export type { DrawerItemsProps, FlowbiteDrawerItemsTheme } from "./DrawerItems";
+export { drawerTheme } from "./theme";

--- a/packages/ui/src/components/Dropdown/index.ts
+++ b/packages/ui/src/components/Dropdown/index.ts
@@ -6,3 +6,4 @@ export { DropdownHeader } from "./DropdownHeader";
 export type { DropdownHeaderProps, FlowbiteDropdownHeaderTheme } from "./DropdownHeader";
 export { DropdownItem } from "./DropdownItem";
 export type { DropdownItemProps, FlowbiteDropdownItemTheme } from "./DropdownItem";
+export { dropdownTheme } from "./theme";

--- a/packages/ui/src/components/FileInput/index.ts
+++ b/packages/ui/src/components/FileInput/index.ts
@@ -6,3 +6,4 @@ export type {
   FlowbiteFileInputRootTheme,
   FlowbiteFileInputTheme,
 } from "./FileInput";
+export { fileInputTheme } from "./theme";

--- a/packages/ui/src/components/FloatingLabel/index.ts
+++ b/packages/ui/src/components/FloatingLabel/index.ts
@@ -6,3 +6,4 @@ export type {
   FloatingLabelVariant,
 } from "./FloatingLabel";
 export type { FlowbiteFloatingLabelTheme } from "./theme";
+export { floatingLabelTheme } from "./theme";

--- a/packages/ui/src/components/Footer/index.ts
+++ b/packages/ui/src/components/Footer/index.ts
@@ -14,3 +14,4 @@ export { FooterLinkGroup } from "./FooterLinkGroup";
 export type { FlowbiteFooterLinkGroupTheme, FooterLinkGroupProps } from "./FooterLinkGroup";
 export { FooterTitle } from "./FooterTitle";
 export type { FlowbiteFooterTitleTheme, FooterTitleProps } from "./FooterTitle";
+export { footerTheme } from "./theme";

--- a/packages/ui/src/components/HR/index.ts
+++ b/packages/ui/src/components/HR/index.ts
@@ -12,3 +12,5 @@ export type { FlowbiteHRTextTheme, HRTextProps } from "./HRText";
 
 export { HRTrimmed } from "./HRTrimmed";
 export type { FlowbiteHRTrimmedTheme, HRTrimmedProps } from "./HRTrimmed";
+
+export { hrTheme } from "./theme";

--- a/packages/ui/src/components/HelperText/index.ts
+++ b/packages/ui/src/components/HelperText/index.ts
@@ -1,2 +1,3 @@
 export { HelperText } from "./HelperText";
 export type { FlowbiteHelperTextRootTheme, FlowbiteHelperTextTheme, HelperColors, HelperTextProps } from "./HelperText";
+export { helperTextTheme } from "./theme";

--- a/packages/ui/src/components/Kbd/index.ts
+++ b/packages/ui/src/components/Kbd/index.ts
@@ -1,2 +1,3 @@
 export { Kbd } from "./Kbd";
 export type { FlowbiteKbdRootTheme, FlowbiteKbdTheme, KbdProps } from "./Kbd";
+export { kbdTheme } from "./theme";

--- a/packages/ui/src/components/Label/index.ts
+++ b/packages/ui/src/components/Label/index.ts
@@ -1,2 +1,3 @@
 export { Label } from "./Label";
 export type { FlowbiteLabelRootTheme, FlowbiteLabelTheme, LabelColors, LabelProps } from "./Label";
+export { labelTheme } from "./theme";

--- a/packages/ui/src/components/List/index.ts
+++ b/packages/ui/src/components/List/index.ts
@@ -2,3 +2,4 @@ export { List } from "./List";
 export type { FlowbiteListRootTheme, FlowbiteListTheme, ListProps } from "./List";
 export { ListItem } from "./ListItem";
 export type { FlowbiteListItemTheme, ListItemProps } from "./ListItem";
+export { listTheme } from "./theme";

--- a/packages/ui/src/components/ListGroup/index.ts
+++ b/packages/ui/src/components/ListGroup/index.ts
@@ -2,3 +2,4 @@ export { ListGroup } from "./ListGroup";
 export type { FlowbiteListGroupRootTheme, FlowbiteListGroupTheme, ListGroupProps } from "./ListGroup";
 export { ListGroupItem } from "./ListGroupItem";
 export type { FlowbiteListGroupItemTheme, ListGroupItemProps } from "./ListGroupItem";
+export { listGroupTheme } from "./theme";

--- a/packages/ui/src/components/MegaMenu/index.ts
+++ b/packages/ui/src/components/MegaMenu/index.ts
@@ -4,3 +4,4 @@ export { MegaMenuDropdown } from "./MegaMenuDropdown";
 export type { FlowbiteMegaMenuDropdownTheme, MegaMenuDropdownProps } from "./MegaMenuDropdown";
 export { MegaMenuDropdownToggle } from "./MegaMenuDropdownToggle";
 export type { FlowbiteMegaMenuDropdownToggleTheme, MegaMenuDropdownToggleProps } from "./MegaMenuDropdownToggle";
+export { megaMenuTheme } from "./theme";

--- a/packages/ui/src/components/Modal/index.ts
+++ b/packages/ui/src/components/Modal/index.ts
@@ -13,3 +13,4 @@ export { ModalFooter } from "./ModalFooter";
 export type { FlowbiteModalFooterTheme, ModalFooterProps } from "./ModalFooter";
 export { ModalHeader } from "./ModalHeader";
 export type { FlowbiteModalHeaderTheme, ModalHeaderProps } from "./ModalHeader";
+export { modalTheme } from "./theme";

--- a/packages/ui/src/components/Navbar/index.ts
+++ b/packages/ui/src/components/Navbar/index.ts
@@ -8,3 +8,4 @@ export { NavbarLink } from "./NavbarLink";
 export type { FlowbiteNavbarLinkTheme, NavbarLinkProps } from "./NavbarLink";
 export { NavbarToggle } from "./NavbarToggle";
 export type { FlowbiteNavbarToggleTheme, NavbarToggleProps } from "./NavbarToggle";
+export { navbarTheme } from "./theme";

--- a/packages/ui/src/components/Pagination/index.ts
+++ b/packages/ui/src/components/Pagination/index.ts
@@ -14,3 +14,4 @@ export type {
   PaginationNavigation,
   PaginationPrevButtonProps,
 } from "./PaginationButton";
+export { paginationTheme } from "./theme";

--- a/packages/ui/src/components/Popover/index.ts
+++ b/packages/ui/src/components/Popover/index.ts
@@ -1,2 +1,3 @@
 export { Popover } from "./Popover";
 export type { FlowbitePopoverTheme, PopoverProps } from "./Popover";
+export { popoverTheme } from "./theme";

--- a/packages/ui/src/components/Progress/index.ts
+++ b/packages/ui/src/components/Progress/index.ts
@@ -1,2 +1,3 @@
 export { Progress } from "./Progress";
 export type { FlowbiteProgressTheme, ProgressColor, ProgressProps, ProgressSizes } from "./Progress";
+export { progressTheme } from "./theme";

--- a/packages/ui/src/components/Radio/index.ts
+++ b/packages/ui/src/components/Radio/index.ts
@@ -1,2 +1,3 @@
 export { Radio } from "./Radio";
 export type { FlowbiteRadioRootTheme, FlowbiteRadioTheme, RadioProps } from "./Radio";
+export { radioTheme } from "./theme";

--- a/packages/ui/src/components/RangeSlider/index.ts
+++ b/packages/ui/src/components/RangeSlider/index.ts
@@ -5,3 +5,4 @@ export type {
   FlowbiteRangeSliderTheme,
   RangeSliderProps,
 } from "./RangeSlider";
+export { rangeSliderTheme } from "./theme";

--- a/packages/ui/src/components/Rating/index.ts
+++ b/packages/ui/src/components/Rating/index.ts
@@ -4,3 +4,4 @@ export { RatingAdvanced } from "./RatingAdvanced";
 export type { FlowbiteRatingAdvancedTheme, RatingAdvancedProps } from "./RatingAdvanced";
 export { RatingStar } from "./RatingStar";
 export type { FlowbiteRatingStarTheme, FlowbiteStarSizes, RatingStarProps } from "./RatingStar";
+export { ratingTheme } from "./theme";

--- a/packages/ui/src/components/Select/index.ts
+++ b/packages/ui/src/components/Select/index.ts
@@ -1,2 +1,3 @@
 export { Select } from "./Select";
 export type { FlowbiteSelectTheme, SelectColors, SelectProps, SelectSizes } from "./Select";
+export { selectTheme } from "./theme";

--- a/packages/ui/src/components/Sidebar/index.ts
+++ b/packages/ui/src/components/Sidebar/index.ts
@@ -12,3 +12,4 @@ export { SidebarItems } from "./SidebarItems";
 export type { FlowbiteSidebarItemsTheme, SidebarItemsProps } from "./SidebarItems";
 export { SidebarLogo } from "./SidebarLogo";
 export type { FlowbiteSidebarLogoTheme, SidebarLogoProps } from "./SidebarLogo";
+export { sidebarTheme } from "./theme";

--- a/packages/ui/src/components/Spinner/index.ts
+++ b/packages/ui/src/components/Spinner/index.ts
@@ -1,2 +1,3 @@
 export { Spinner } from "./Spinner";
 export type { FlowbiteSpinnerTheme, SpinnerColors, SpinnerProps, SpinnerSizes } from "./Spinner";
+export { spinnerTheme } from "./theme";

--- a/packages/ui/src/components/Table/index.ts
+++ b/packages/ui/src/components/Table/index.ts
@@ -10,3 +10,4 @@ export { TableHeadCell } from "./TableHeadCell";
 export type { FlowbiteTableHeadCellTheme, TableHeadCellProps } from "./TableHeadCell";
 export { TableRow } from "./TableRow";
 export type { FlowbiteTableRowTheme, TableRowProps } from "./TableRow";
+export { tableTheme } from "./theme";

--- a/packages/ui/src/components/Tabs/index.ts
+++ b/packages/ui/src/components/Tabs/index.ts
@@ -10,3 +10,4 @@ export type {
   TabsProps,
   TabsRef,
 } from "./Tabs";
+export { tabTheme } from "./theme";

--- a/packages/ui/src/components/TextInput/index.ts
+++ b/packages/ui/src/components/TextInput/index.ts
@@ -5,3 +5,4 @@ export type {
   FlowbiteTextInputTheme,
   TextInputProps,
 } from "./TextInput";
+export { textInputTheme } from "./theme";

--- a/packages/ui/src/components/Textarea/index.ts
+++ b/packages/ui/src/components/Textarea/index.ts
@@ -1,2 +1,3 @@
 export { Textarea } from "./Textarea";
 export type { FlowbiteTextareaTheme, TextareaColors, TextareaProps } from "./Textarea";
+export { textareaTheme } from "./theme";

--- a/packages/ui/src/components/Timeline/index.ts
+++ b/packages/ui/src/components/Timeline/index.ts
@@ -12,3 +12,4 @@ export { TimelineTime } from "./TimelineTime";
 export type { FlowbiteTimelineTimeTheme, TimelineTimeProps } from "./TimelineTime";
 export { TimelineTitle } from "./TimelineTitle";
 export type { FlowbiteTimelineTitleTheme, TimelineTitleProps } from "./TimelineTitle";
+export { timelineTheme } from "./theme";

--- a/packages/ui/src/components/Toast/index.ts
+++ b/packages/ui/src/components/Toast/index.ts
@@ -2,3 +2,4 @@ export { Toast } from "./Toast";
 export type { FlowbiteToastTheme, ToastProps } from "./Toast";
 export { ToastToggle } from "./ToastToggle";
 export type { FlowbiteToastToggleTheme, ToastToggleProps } from "./ToastToggle";
+export { toastTheme } from "./theme";

--- a/packages/ui/src/components/ToggleSwitch/index.ts
+++ b/packages/ui/src/components/ToggleSwitch/index.ts
@@ -5,3 +5,4 @@ export type {
   FlowbiteToggleSwitchToggleTheme,
   ToggleSwitchProps,
 } from "./ToggleSwitch";
+export { toggleSwitchTheme } from "./theme";

--- a/packages/ui/src/components/Tooltip/index.ts
+++ b/packages/ui/src/components/Tooltip/index.ts
@@ -1,2 +1,3 @@
 export { Tooltip } from "./Tooltip";
 export type { FlowbiteTooltipTheme, TooltipProps } from "./Tooltip";
+export { tooltipTheme } from "./theme";


### PR DESCRIPTION
- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

See: https://github.com/themesberg/flowbite-react/issues/1489

Summary: Next.js has extremely long compile times when starting up in dev mode as it will compile all exports for referenced imports. A majority of us will import components directly from `flowbite-react`, meaning that Next.js will compile all the exports found in the entrypoint file. The "proper" way to import in Next.js is to import items individually via their direct path. 

```typescript
import { Table } from "flowbite-react"
```

should be instead:

```typescript
import { Table } from "flowbite-react/components/Table
```

This PR adds component-specific theme exports into the component entrypoint files.