### PR TITLE
Feat: Add 'onRightIconClick' prop on TextInput

### DIFF
--- a/packages/ui/src/components/TextInput/TextInput.tsx
+++ b/packages/ui/src/components/TextInput/TextInput.tsx
@@ -84,7 +84,11 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
               </div>
             )}
             {RightIcon && (
-              <div data-testid="right-icon" className={theme.field.rightIcon.base} onClick={onRightIconClick}>
+              <div
+                data-testid="right-icon"
+                className={`${theme.field.rightIcon.base} ${!onRightIconClick ? "pointer-events-none" : ""}`}
+                onClick={onRightIconClick}
+              >
                 <RightIcon className={theme.field.rightIcon.svg} />
               </div>
             )}

--- a/packages/ui/src/components/TextInput/TextInput.tsx
+++ b/packages/ui/src/components/TextInput/TextInput.tsx
@@ -46,6 +46,7 @@ export interface TextInputProps extends Omit<ComponentProps<"input">, "ref" | "c
   color?: DynamicStringEnumKeysOf<FlowbiteTextInputColors>;
   helperText?: ReactNode;
   icon?: FC<ComponentProps<"svg">>;
+  onRightIconClick?: () => void;
   rightIcon?: FC<ComponentProps<"svg">>;
   shadow?: boolean;
   sizing?: DynamicStringEnumKeysOf<FlowbiteTextInputSizes>;
@@ -60,6 +61,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       color = "gray",
       helperText,
       icon: Icon,
+      onRightIconClick,
       rightIcon: RightIcon,
       shadow,
       sizing = "md",
@@ -82,7 +84,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
               </div>
             )}
             {RightIcon && (
-              <div data-testid="right-icon" className={theme.field.rightIcon.base}>
+              <div data-testid="right-icon" className={theme.field.rightIcon.base} onClick={onRightIconClick}>
                 <RightIcon className={theme.field.rightIcon.svg} />
               </div>
             )}

--- a/packages/ui/src/components/TextInput/theme.ts
+++ b/packages/ui/src/components/TextInput/theme.ts
@@ -12,7 +12,7 @@ export const textInputTheme: FlowbiteTextInputTheme = createTheme({
       svg: "h-5 w-5 text-gray-500 dark:text-gray-400",
     },
     rightIcon: {
-      base: "pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3",
+      base: "absolute inset-y-0 right-0 flex items-center pr-3",
       svg: "h-5 w-5 text-gray-500 dark:text-gray-400",
     },
     input: {


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

## Summary

This PR adds a prop on `TextInput` to support onClick for the right icon.
This allows users to easily create password inputs with the use of `rightIcon` prop.

## Demo
![password-input-example](https://github.com/user-attachments/assets/a349eb72-c14d-4fd2-8867-225358f41560)

## Code Example

```jsx
const PasswordInput = () => {
  const [showPass, setShowPass] = useState(false);

  return (
    <TextInput
      type={showPass ? "text" : "password"}
      rightIcon={showPass ? EyeOffIcon : EyeIcon}
      onRightIconClick={() => setShowPass(!showPass)}
    />
  );
};
```
