### PR TITLE
bugfix: when we hover item with icon on side menu the icon doesn't sh…

### DIFF
--- a/packages/ui/src/components/Sidebar/theme.ts
+++ b/packages/ui/src/components/Sidebar/theme.ts
@@ -49,7 +49,7 @@ export const sidebarTheme: FlowbiteSidebarTheme = createTheme({
     },
   },
   item: {
-    base: "flex items-center justify-center rounded-lg p-2 text-base font-normal text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700",
+    base: "flex items-center justify-center rounded-lg p-2 text-base font-normal text-gray-900 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700 group",
     active: "bg-gray-100 dark:bg-gray-700",
     collapsed: {
       insideCollapse: "group w-full pl-8 transition duration-75",


### PR DESCRIPTION
- [ ] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

When we hover an item with an icon on the sidebar the icon doesn't show its hover styling. It happens because the group class has not been applied before.

Before fix:

<img width="310" alt="Screenshot 2024-09-25 at 00 08 23" src="https://github.com/user-attachments/assets/22215a80-5083-4cb6-90f2-061d704fc2b5">

After fix:

<img width="318" alt="Screenshot 2024-09-25 at 00 08 10" src="https://github.com/user-attachments/assets/a4895ae9-4418-4abe-a7bb-9bbd1328b859">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced sidebar item styling with the addition of a new class for improved visual grouping.
  
- **Bug Fixes**
	- No specific bug fixes were included in this release. 

- **Documentation**
	- Updated styling rules for the sidebar items to reflect the new class addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->