### PR TITLE
Correct date handling for minDate in month selection

### DIFF
--- a/.changeset/proud-spoons-joke.md
+++ b/.changeset/proud-spoons-joke.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": major
+---
+
+Correct date handling for minDate in month selection

--- a/.changeset/proud-spoons-joke.md
+++ b/.changeset/proud-spoons-joke.md
@@ -3,3 +3,13 @@
 ---
 
 Correct date handling for minDate in month selection
+
+What's Changed
+
+- Fixed a bug where month selection wasn't respecting minDate constraints
+- Month buttons are now correctly enabled/disabled based on minDate
+
+Impact
+
+- Users will see more accurate month selection behavior when minDate is set
+- No breaking changes or migration steps required

--- a/packages/ui/src/components/Datepicker/Views/Months.tsx
+++ b/packages/ui/src/components/Datepicker/Views/Months.tsx
@@ -37,8 +37,10 @@ export const DatepickerViewsMonth: FC<DatepickerViewsMonthsProps> = ({ theme: cu
     <div className={theme.items.base}>
       {[...Array(12)].map((_month, index) => {
         const newDate = new Date();
-        // setting day to 1 to avoid overflow issues
-        newDate.setMonth(index, 1);
+        // Set newDate to the last day of the month based on the provided index.
+        // This is necessary for enabling the month button when minDate is set (e.g., minDate = 1/23/2025).
+        newDate.setMonth(index + 1, 1);
+        newDate.setDate(newDate.getDate() - 1);
         newDate.setFullYear(viewDate.getFullYear());
         const month = getFormattedDate(language, newDate, { month: "short" });
 


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

Summarize the changes made and the motivation behind them.

Reference related issues using `#` followed by the issue number.

If there are breaking API changes - like adding or removing props, or changing the structure of the theme - describe them, and provide steps to update existing code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved month selection logic in the Datepicker component to prevent date overflow and ensure correct month button enabling when a minimum date is specified.
	- Updated handling of minimum dates in the "flowbite-react" package for enhanced date selection functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->