### PR TITLE
fix(schema): include `dark`

### DIFF
--- a/.changeset/petite-toys-fold.md
+++ b/.changeset/petite-toys-fold.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+fix `schema.json`: add missing `dark` field in `required`

--- a/apps/web/content/docs/customize/config.mdx
+++ b/apps/web/content/docs/customize/config.mdx
@@ -53,7 +53,7 @@ The configuration file follows this JSON Schema:
       "default": true
     }
   },
-  "required": ["components", "path", "prefix", "rsc", "tsx"]
+  "required": ["components", "dark", "path", "prefix", "rsc", "tsx"]
 }
 ```
 

--- a/packages/ui/scripts/generate-metadata.ts
+++ b/packages/ui/scripts/generate-metadata.ts
@@ -249,7 +249,7 @@ async function generateSchema(components: string[]): Promise<void> {
           default: true,
         },
       },
-      required: ["components", "path", "prefix", "rsc", "tsx"],
+      required: ["components", "dark", "path", "prefix", "rsc", "tsx"],
     };
 
     defaultSchema.properties.components.items.enum.push(...components);


### PR DESCRIPTION
### Changes

- [x] Update configuration schema to include `dark` as a required field inconfig.mdx and generate-metadata.ts