### PR TITLE
fix(ui): make drawer close button type button

### DIFF
--- a/.changeset/hungry-camels-make.md
+++ b/.changeset/hungry-camels-make.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+make drawer close button type button

--- a/bun.lock
+++ b/bun.lock
@@ -91,7 +91,7 @@
     },
     "packages/cli": {
       "name": "create-flowbite-react",
-      "version": "1.0.8",
+      "version": "1.1.1",
       "bin": {
         "create-flowbite-react": "./dist/index.js",
       },
@@ -109,7 +109,7 @@
     },
     "packages/ui": {
       "name": "flowbite-react",
-      "version": "0.10.2",
+      "version": "0.11.5",
       "bin": {
         "flowbite-react": "./dist/cli/bin.js",
       },

--- a/packages/ui/src/components/Drawer/DrawerHeader.tsx
+++ b/packages/ui/src/components/Drawer/DrawerHeader.tsx
@@ -63,7 +63,7 @@ export const DrawerHeader = forwardRef<HTMLDivElement, DrawerHeaderProps>((props
         <TitleIcon aria-hidden className={theme.inner.titleIcon} />
         {title}
       </h5>
-      <button onClick={onClose} data-testid="close-drawer" className={theme.inner.closeButton}>
+      <button onClick={onClose} type="button" data-testid="close-drawer" className={theme.inner.closeButton}>
         <CloseIcon aria-hidden className={theme.inner.closeIcon} />
         <span className={theme.inner.titleCloseIcon}>Close menu</span>
       </button>


### PR DESCRIPTION
- [X] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

I have added a `type="button"` to the Drawer component's close button. If a button does not have a type, and is part of a form, then by default it is a submit button. [See here](https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element). Therefore if the Drawer component forms part of a form flow, closing the drawer triggers the form's submit behaviour.

This also brings Flowbite React in line with vanilla Flowbite Drawer which uses `type="button"` on its close button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the behavior of a button in the navigation panel header by explicitly defining its type, enhancing proper form interactions and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->