### PR TITLE
1531: Fix/DatePicker month view error: selected month not highlighted

### DIFF
--- a/packages/ui/src/components/Datepicker/Views/Months.tsx
+++ b/packages/ui/src/components/Datepicker/Views/Months.tsx
@@ -33,8 +33,9 @@ export function DatepickerViewsMonth() {
     <div className={theme.items.base}>
       {[...Array(12)].map((_month, index) => {
         const newDate = new Date();
-        // setting day to 1 to avoid overflow issues
-        newDate.setMonth(index, 1);
+        // if selectedDate is non-null, align days to accurately detect if month is selected
+        // else if selectedDate is null, set day to 1 to avoid overflow
+        newDate.setMonth(index, selectedDate ? selectedDate.getDate() : 1);
         newDate.setFullYear(viewDate.getFullYear());
         const month = getFormattedDate(language, newDate, { month: "short" });
 


### PR DESCRIPTION
Fixed error where the DataPicker component Month view does not highlight the month of the selected Date.

This is because the date of newDate is automatically set to 1, and hence when compared against the selectedDate, they would always be different.

Have modified one line of code to set the newDate to have the same date as selectedDate if the latter is not null.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved month selection accuracy in the date picker by aligning the selected month with the day from the currently selected date, when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->