### PR TITLE
fix(docs): examples

### DIFF
--- a/apps/web/examples/modal/modal.dismissible.tsx
+++ b/apps/web/examples/modal/modal.dismissible.tsx
@@ -33,7 +33,7 @@ export function Component() {
         </ModalBody>
         <ModalFooter>
           <Button onClick={() => setOpenModal(false)}>I accept</Button>
-          <Button color="gray" onClick={() => setOpenModal(false)}>
+          <Button color="alternative" onClick={() => setOpenModal(false)}>
             Decline
           </Button>
         </ModalFooter>
@@ -66,7 +66,7 @@ export function Component() {
         </ModalBody>
         <ModalFooter>
           <Button onClick={() => setOpenModal(false)}>I accept</Button>
-          <Button color="gray" onClick={() => setOpenModal(false)}>
+          <Button color="alternative" onClick={() => setOpenModal(false)}>
             Decline
           </Button>
         </ModalFooter>

--- a/apps/web/examples/modal/modal.initialFocus.tsx
+++ b/apps/web/examples/modal/modal.initialFocus.tsx
@@ -39,7 +39,7 @@ export function Component() {
                 <Checkbox id="remember" />
                 <Label htmlFor="remember">Remember me</Label>
               </div>
-              <a href="#" className="text-sm text-cyan-700 hover:underline dark:text-cyan-500">
+              <a href="#" className="text-sm text-primary-700 hover:underline dark:text-primary-500">
                 Lost Password?
               </a>
             </div>
@@ -48,7 +48,7 @@ export function Component() {
             </div>
             <div className="flex justify-between text-sm font-medium text-gray-500 dark:text-gray-300">
               Not registered?&nbsp;
-              <a href="#" className="text-cyan-700 hover:underline dark:text-cyan-500">
+              <a href="#" className="text-primary-700 hover:underline dark:text-primary-500">
                 Create account
               </a>
             </div>
@@ -89,7 +89,7 @@ export function Component() {
                 <Checkbox id="remember" />
                 <Label htmlFor="remember">Remember me</Label>
               </div>
-              <a href="#" className="text-sm text-cyan-700 hover:underline dark:text-cyan-500">
+              <a href="#" className="text-sm text-primary-700 hover:underline dark:text-primary-500">
                 Lost Password?
               </a>
             </div>
@@ -98,7 +98,7 @@ export function Component() {
             </div>
             <div className="flex justify-between text-sm font-medium text-gray-500 dark:text-gray-300">
               Not registered?&nbsp;
-              <a href="#" className="text-cyan-700 hover:underline dark:text-cyan-500">
+              <a href="#" className="text-primary-700 hover:underline dark:text-primary-500">
                 Create account
               </a>
             </div>

--- a/apps/web/examples/modal/modal.popup.tsx
+++ b/apps/web/examples/modal/modal.popup.tsx
@@ -27,10 +27,10 @@ export function Component() {
               Are you sure you want to delete this product?
             </h3>
             <div className="flex justify-center gap-4">
-              <Button color="failure" onClick={() => setOpenModal(false)}>
-                {"Yes, I'm sure"}
+              <Button color="red" onClick={() => setOpenModal(false)}>
+                Yes, I'm sure
               </Button>
-              <Button color="gray" onClick={() => setOpenModal(false)}>
+              <Button color="alternative" onClick={() => setOpenModal(false)}>
                 No, cancel
               </Button>
             </div>
@@ -57,10 +57,10 @@ export function Component() {
               Are you sure you want to delete this product?
             </h3>
             <div className="flex justify-center gap-4">
-              <Button color="failure" onClick={() => setOpenModal(false)}>
-                {"Yes, I'm sure"}
+              <Button color="red" onClick={() => setOpenModal(false)}>
+                Yes, I'm sure
               </Button>
-              <Button color="gray" onClick={() => setOpenModal(false)}>
+              <Button color="alternative" onClick={() => setOpenModal(false)}>
                 No, cancel
               </Button>
             </div>

--- a/apps/web/examples/modal/modal.position.tsx
+++ b/apps/web/examples/modal/modal.position.tsx
@@ -49,7 +49,7 @@ export function Component() {
         </ModalBody>
         <ModalFooter>
           <Button onClick={() => setOpenModal(false)}>I accept</Button>
-          <Button color="gray" onClick={() => setOpenModal(false)}>
+          <Button color="alternative" onClick={() => setOpenModal(false)}>
             Decline
           </Button>
         </ModalFooter>
@@ -98,7 +98,7 @@ export function Component() {
         </ModalBody>
         <ModalFooter>
           <Button onClick={() => setOpenModal(false)}>I accept</Button>
-          <Button color="gray" onClick={() => setOpenModal(false)}>
+          <Button color="alternative" onClick={() => setOpenModal(false)}>
             Decline
           </Button>
         </ModalFooter>

--- a/apps/web/examples/modal/modal.root.tsx
+++ b/apps/web/examples/modal/modal.root.tsx
@@ -33,7 +33,7 @@ export function Component() {
         </ModalBody>
         <ModalFooter>
           <Button onClick={() => setOpenModal(false)}>I accept</Button>
-          <Button color="gray" onClick={() => setOpenModal(false)}>
+          <Button color="alternative" onClick={() => setOpenModal(false)}>
             Decline
           </Button>
         </ModalFooter>
@@ -66,7 +66,7 @@ export function Component() {
         </ModalBody>
         <ModalFooter>
           <Button onClick={() => setOpenModal(false)}>I accept</Button>
-          <Button color="gray" onClick={() => setOpenModal(false)}>
+          <Button color="alternative" onClick={() => setOpenModal(false)}>
             Decline
           </Button>
         </ModalFooter>

--- a/apps/web/examples/modal/modal.sizes.tsx
+++ b/apps/web/examples/modal/modal.sizes.tsx
@@ -50,7 +50,7 @@ export function Component() {
         </ModalBody>
         <ModalFooter>
           <Button onClick={() => setOpenModal(false)}>I accept</Button>
-          <Button color="gray" onClick={() => setOpenModal(false)}>
+          <Button color="alternative" onClick={() => setOpenModal(false)}>
             Decline
           </Button>
         </ModalFooter>
@@ -100,7 +100,7 @@ export function Component() {
         </ModalBody>
         <ModalFooter>
           <Button onClick={() => setOpenModal(false)}>I accept</Button>
-          <Button color="gray" onClick={() => setOpenModal(false)}>
+          <Button color="alternative" onClick={() => setOpenModal(false)}>
             Decline
           </Button>
         </ModalFooter>

--- a/apps/web/examples/modal/modal.withFormElements.tsx
+++ b/apps/web/examples/modal/modal.withFormElements.tsx
@@ -50,7 +50,7 @@ export function Component() {
                 <Checkbox id="remember" />
                 <Label htmlFor="remember">Remember me</Label>
               </div>
-              <a href="#" className="text-sm text-cyan-700 hover:underline dark:text-cyan-500">
+              <a href="#" className="text-sm text-primary-700 hover:underline dark:text-primary-500">
                 Lost Password?
               </a>
             </div>
@@ -59,7 +59,7 @@ export function Component() {
             </div>
             <div className="flex justify-between text-sm font-medium text-gray-500 dark:text-gray-300">
               Not registered?&nbsp;
-              <a href="#" className="text-cyan-700 hover:underline dark:text-cyan-500">
+              <a href="#" className="text-primary-700 hover:underline dark:text-primary-500">
                 Create account
               </a>
             </div>
@@ -111,7 +111,7 @@ export function Component() {
                 <Checkbox id="remember" />
                 <Label htmlFor="remember">Remember me</Label>
               </div>
-              <a href="#" className="text-sm text-cyan-700 hover:underline dark:text-cyan-500">
+              <a href="#" className="text-sm text-primary-700 hover:underline dark:text-primary-500">
                 Lost Password?
               </a>
             </div>
@@ -120,7 +120,7 @@ export function Component() {
             </div>
             <div className="flex justify-between text-sm font-medium text-gray-500 dark:text-gray-300">
               Not registered?&nbsp;
-              <a href="#" className="text-cyan-700 hover:underline dark:text-cyan-500">
+              <a href="#" className="text-primary-700 hover:underline dark:text-primary-500">
                 Create account
               </a>
             </div>

--- a/apps/web/examples/table/table.hover.tsx
+++ b/apps/web/examples/table/table.hover.tsx
@@ -28,7 +28,7 @@ export function Component() {
             <TableCell>Laptop</TableCell>
             <TableCell>$2999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -41,7 +41,7 @@ export function Component() {
             <TableCell>Laptop PC</TableCell>
             <TableCell>$1999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -52,7 +52,7 @@ export function Component() {
             <TableCell>Accessories</TableCell>
             <TableCell>$99</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -88,7 +88,7 @@ export function Component() {
             <TableCell>Laptop</TableCell>
             <TableCell>$2999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -101,7 +101,7 @@ export function Component() {
             <TableCell>Laptop PC</TableCell>
             <TableCell>$1999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -112,7 +112,7 @@ export function Component() {
             <TableCell>Accessories</TableCell>
             <TableCell>$99</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>

--- a/apps/web/examples/table/table.root.tsx
+++ b/apps/web/examples/table/table.root.tsx
@@ -28,7 +28,7 @@ export function Component() {
             <TableCell>Laptop</TableCell>
             <TableCell>$2999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -41,7 +41,7 @@ export function Component() {
             <TableCell>Laptop PC</TableCell>
             <TableCell>$1999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -52,7 +52,7 @@ export function Component() {
             <TableCell>Accessories</TableCell>
             <TableCell>$99</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -88,7 +88,7 @@ export function Component() {
             <TableCell>Laptop</TableCell>
             <TableCell>$2999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -101,7 +101,7 @@ export function Component() {
             <TableCell>Laptop PC</TableCell>
             <TableCell>$1999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -112,7 +112,7 @@ export function Component() {
             <TableCell>Accessories</TableCell>
             <TableCell>$99</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>

--- a/apps/web/examples/table/table.striped.tsx
+++ b/apps/web/examples/table/table.striped.tsx
@@ -26,7 +26,7 @@ export function Component() {
             <TableCell>Laptop</TableCell>
             <TableCell>$2999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -39,7 +39,7 @@ export function Component() {
             <TableCell>Laptop PC</TableCell>
             <TableCell>$1999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -50,7 +50,7 @@ export function Component() {
             <TableCell>Accessories</TableCell>
             <TableCell>$99</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -63,7 +63,7 @@ export function Component() {
             <TableCell>Phone</TableCell>
             <TableCell>$799</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -74,7 +74,7 @@ export function Component() {
             <TableCell>Wearables</TableCell>
             <TableCell>$999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -110,7 +110,7 @@ export function Component() {
             <TableCell>Laptop</TableCell>
             <TableCell>$2999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -123,7 +123,7 @@ export function Component() {
             <TableCell>Laptop PC</TableCell>
             <TableCell>$1999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -134,7 +134,7 @@ export function Component() {
             <TableCell>Accessories</TableCell>
             <TableCell>$99</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -147,7 +147,7 @@ export function Component() {
             <TableCell>Phone</TableCell>
             <TableCell>$799</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -158,7 +158,7 @@ export function Component() {
             <TableCell>Wearables</TableCell>
             <TableCell>$999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>

--- a/apps/web/examples/table/table.withCheckboxes.tsx
+++ b/apps/web/examples/table/table.withCheckboxes.tsx
@@ -34,7 +34,7 @@ export function Component() {
             <TableCell>Laptop</TableCell>
             <TableCell>$2999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -50,7 +50,7 @@ export function Component() {
             <TableCell>Laptop PC</TableCell>
             <TableCell>$1999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -64,7 +64,7 @@ export function Component() {
             <TableCell>Accessories</TableCell>
             <TableCell>$99</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -106,7 +106,7 @@ export function Component() {
             <TableCell>Laptop</TableCell>
             <TableCell>$2999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -122,7 +122,7 @@ export function Component() {
             <TableCell>Laptop PC</TableCell>
             <TableCell>$1999</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>
@@ -136,7 +136,7 @@ export function Component() {
             <TableCell>Accessories</TableCell>
             <TableCell>$99</TableCell>
             <TableCell>
-              <a href="#" className="font-medium text-cyan-600 hover:underline dark:text-cyan-500">
+              <a href="#" className="font-medium text-primary-600 hover:underline dark:text-primary-500">
                 Edit
               </a>
             </TableCell>

--- a/apps/web/examples/toast/toast.withButton.tsx
+++ b/apps/web/examples/toast/toast.withButton.tsx
@@ -11,7 +11,7 @@ export function Component() {
       <div className="ml-auto flex items-center space-x-2">
         <a
           href="#"
-          className="rounded-lg p-1.5 text-sm font-medium text-cyan-600 hover:bg-cyan-100 dark:text-cyan-500 dark:hover:bg-gray-700"
+          className="rounded-lg p-1.5 text-sm font-medium text-primary-600 hover:bg-primary-100 dark:text-primary-500 dark:hover:bg-gray-700"
         >
           Undo
         </a>
@@ -29,7 +29,7 @@ export function Component() {
       <div className="ml-auto flex items-center space-x-2">
         <a
           href="#"
-          className="rounded-lg p-1.5 text-sm font-medium text-cyan-600 hover:bg-cyan-100 dark:text-cyan-500 dark:hover:bg-gray-700"
+          className="rounded-lg p-1.5 text-sm font-medium text-primary-600 hover:bg-primary-100 dark:text-primary-500 dark:hover:bg-gray-700"
         >
           Undo
         </a>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated button and link color schemes in modal, table, and toast examples to use "alternative," "red," or primary-themed colors instead of gray or cyan-based colors.
  - Adjusted text and hover color classes for "Edit," "Undo," "Lost Password?," and "Create account" elements to ensure visual consistency across light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->