### PR TITLE
feat: Add 'filterDate' prop function on Datepicker

### DIFF
--- a/.changeset/hip-pants-run.md
+++ b/.changeset/hip-pants-run.md
@@ -1,5 +1,5 @@
 ---
-"flowbite-react": minor
+"flowbite-react": patch
 ---
 
 feat(Datepicker): Implemented a filter function prop

--- a/.changeset/hip-pants-run.md
+++ b/.changeset/hip-pants-run.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": minor
+---
+
+feat(Datepicker): Implemented a filter function prop

--- a/apps/storybook/src/Datepicker.stories.tsx
+++ b/apps/storybook/src/Datepicker.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from "@storybook/react";
 import type { DatepickerProps } from "flowbite-react";
-import { Datepicker, getFirstDateInRange, WeekStart } from "flowbite-react";
+import { Datepicker, getFirstDateInRange, Views, WeekStart } from "flowbite-react";
 import { useEffect, useState } from "react";
 
 export default {
@@ -146,4 +146,49 @@ EmptyDates.args = {
   weekStart: WeekStart.Sunday,
   theme: {},
   label: "No date selected",
+};
+
+export const FilterWeekdaysOnly = Template.bind({});
+FilterWeekdaysOnly.args = {
+  open: true,
+  autoHide: false,
+  showClearButton: true,
+  showTodayButton: true,
+  defaultValue: undefined,
+  value: undefined,
+  minDate: undefined,
+  maxDate: undefined,
+  filterDate: (date: Date, view: Views) => {
+    if (view === Views.Days) {
+      const day = date.getDay();
+      return day >= 1 && day <= 5;
+    }
+    return true;
+  },
+  language: "en",
+  weekStart: WeekStart.Sunday,
+  theme: {},
+  label: "Filter: Weekdays only",
+};
+
+export const FilterEvenDatesOnly = Template.bind({});
+FilterEvenDatesOnly.args = {
+  open: true,
+  autoHide: false,
+  showClearButton: true,
+  showTodayButton: true,
+  defaultValue: undefined,
+  value: undefined,
+  minDate: undefined,
+  maxDate: undefined,
+  filterDate: (date: Date, view: Views) => {
+    if (view === Views.Days) {
+      return date.getDate() % 2 === 0;
+    }
+    return true;
+  },
+  language: "en",
+  weekStart: WeekStart.Sunday,
+  theme: {},
+  label: "Filter: Even dates only",
 };

--- a/apps/web/content/docs/components/datepicker.mdx
+++ b/apps/web/content/docs/components/datepicker.mdx
@@ -27,6 +27,14 @@ The `labelTodayButton` and `labelClearButton` can also be used to update the tex
 
 <Example name="datepicker.localization" />
 
+## Filter dates
+
+You can use the `filterDate` prop to filter out specific dates from the datepicker component. This is useful if you want to disable certain dates or only allow selection of weekdays, for example.
+
+The `Views` enum can be used to determine the current view of the datepicker, such as `Days`, `Months`, or `Years`.
+
+<Example name="datepicker.filter" />
+
 ## Limit the date
 
 By using the `minDate` and `maxDate` props you can limit the date range that the user can select.

--- a/apps/web/content/docs/components/datepicker.mdx
+++ b/apps/web/content/docs/components/datepicker.mdx
@@ -31,7 +31,7 @@ The `labelTodayButton` and `labelClearButton` can also be used to update the tex
 
 You can use the `filterDate` prop to filter out specific dates from the datepicker component. This is useful if you want to disable certain dates or only allow selection of weekdays, for example.
 
-The `Views` enum can be used to determine the current view of the datepicker, such as `Days`, `Months`, or `Years`.
+The `Views` enum can be used to determine the current view of the datepicker, such as `Days`, `Months`, `Years` or `Decades`.
 
 <Example name="datepicker.filter" />
 

--- a/apps/web/examples/datepicker/datepicker.filter.tsx
+++ b/apps/web/examples/datepicker/datepicker.filter.tsx
@@ -1,10 +1,14 @@
+"use client";
+
 import { Datepicker, Views } from "flowbite-react";
 import type { CodeData } from "~/components/code-demo";
 
 const code = `
+"use client";
+
 import { Datepicker, Views } from "flowbite-react";
 
-export function Component() {s
+export function Component() {
   const filterFn = (date: Date, view: Views) => {
     if (view === Views.Days) {
       const day = date.getDay();

--- a/apps/web/examples/datepicker/datepicker.filter.tsx
+++ b/apps/web/examples/datepicker/datepicker.filter.tsx
@@ -2,7 +2,7 @@ import { Datepicker, Views } from "flowbite-react";
 import type { CodeData } from "~/components/code-demo";
 
 const code = `
-import { Datepicker } from "flowbite-react";
+import { Datepicker, Views } from "flowbite-react";
 
 const filterFn = (date: Date, view: Views) => {
   if (view === Views.Days) {

--- a/apps/web/examples/datepicker/datepicker.filter.tsx
+++ b/apps/web/examples/datepicker/datepicker.filter.tsx
@@ -1,0 +1,41 @@
+import { Datepicker, Views } from "flowbite-react";
+import type { CodeData } from "~/components/code-demo";
+
+const code = `
+import { Datepicker } from "flowbite-react";
+
+const filterFn = (date: Date, view: Views) => {
+  if (view === Views.Days) {
+    const day = date.getDay();
+    return day >= 1 && day <= 5;
+  }
+  return true;
+};
+
+export function Component() {
+  return <Datepicker filterDate={filterFn} />;
+}
+`;
+
+const filterFn = (date: Date, view: Views) => {
+  if (view === Views.Days) {
+    const day = date.getDay();
+    return day >= 1 && day <= 5;
+  }
+  return true;
+};
+
+export function Component() {
+  return <Datepicker filterDate={filterFn} />;
+}
+
+export const filter: CodeData = {
+  type: "single",
+  code: {
+    fileName: "index",
+    language: "tsx",
+    code,
+  },
+  githubSlug: "datepicker/datepicker.filter.tsx",
+  component: <Component />,
+};

--- a/apps/web/examples/datepicker/datepicker.filter.tsx
+++ b/apps/web/examples/datepicker/datepicker.filter.tsx
@@ -4,28 +4,28 @@ import type { CodeData } from "~/components/code-demo";
 const code = `
 import { Datepicker, Views } from "flowbite-react";
 
-const filterFn = (date: Date, view: Views) => {
-  if (view === Views.Days) {
-    const day = date.getDay();
-    return day >= 1 && day <= 5;
-  }
-  return true;
-};
+export function Component() {s
+  const filterFn = (date: Date, view: Views) => {
+    if (view === Views.Days) {
+      const day = date.getDay();
+      return day >= 1 && day <= 5;
+    }
+    return true;
+  };
 
-export function Component() {
   return <Datepicker filterDate={filterFn} />;
 }
 `;
 
-const filterFn = (date: Date, view: Views) => {
-  if (view === Views.Days) {
-    const day = date.getDay();
-    return day >= 1 && day <= 5;
-  }
-  return true;
-};
-
 export function Component() {
+  const filterFn = (date: Date, view: Views) => {
+    if (view === Views.Days) {
+      const day = date.getDay();
+      return day >= 1 && day <= 5;
+    }
+    return true;
+  };
+
   return <Datepicker filterDate={filterFn} />;
 }
 

--- a/apps/web/examples/datepicker/index.ts
+++ b/apps/web/examples/datepicker/index.ts
@@ -1,6 +1,7 @@
 export { autoHide } from "./datepicker.autoHide";
 export { inline } from "./datepicker.inline";
 export { localization } from "./datepicker.localization";
+export { filter } from "./datepicker.filter";
 export { range } from "./datepicker.range";
 export { root } from "./datepicker.root";
 export { title } from "./datepicker.title";

--- a/packages/ui/src/components/Datepicker/Datepicker.test.tsx
+++ b/packages/ui/src/components/Datepicker/Datepicker.test.tsx
@@ -191,7 +191,7 @@ describe("Components / Datepicker", () => {
 
     const filter = (date: Date, view: Views) => {
       if (view === Views.Days) {
-        return date !== tomorrow;
+        return date.toDateString() !== tomorrow.toDateString();
       }
       return true;
     };

--- a/packages/ui/src/components/Datepicker/Datepicker.test.tsx
+++ b/packages/ui/src/components/Datepicker/Datepicker.test.tsx
@@ -186,20 +186,21 @@ describe("Components / Datepicker", () => {
   });
 
   it("the filter function should allow to disable a certain date", async () => {
-    const today = new Date();
+    const tomorrow = new Date();
+    tomorrow.setDate(new Date().getDate() + 1);
 
     const filter = (date: Date, view: Views) => {
       if (view === Views.Days) {
-        return date !== today;
+        return date !== tomorrow;
       }
       return true;
     };
 
     render(<Datepicker filterDate={filter} />);
 
-    await userEvent.click(screen.getByText("Today"));
+    await userEvent.click(screen.getByRole("textbox"));
 
-    expect(screen.getByText(today.getDate())).toBeDisabled();
+    expect(screen.getByText(tomorrow.getDate())).toBeDisabled();
   });
 
   it("should focus the input when ref.current.focus is called", () => {

--- a/packages/ui/src/components/Datepicker/Datepicker.test.tsx
+++ b/packages/ui/src/components/Datepicker/Datepicker.test.tsx
@@ -187,11 +187,10 @@ describe("Components / Datepicker", () => {
 
   it("the filter function should allow to disable a certain date", async () => {
     const today = new Date();
-    const todaysDateInDefaultLanguage = getFormattedDate("en", today);
 
     const filter = (date: Date, view: Views) => {
       if (view === Views.Days) {
-        return date === today;
+        return date !== today;
       }
       return true;
     };
@@ -200,7 +199,7 @@ describe("Components / Datepicker", () => {
 
     await userEvent.click(screen.getByText("Today"));
 
-    expect(screen.getByDisplayValue(todaysDateInDefaultLanguage)).toBeDisabled();
+    expect(screen.getByText(today.getDate())).toBeDisabled();
   });
 
   it("should focus the input when ref.current.focus is called", () => {

--- a/packages/ui/src/components/Datepicker/Datepicker.test.tsx
+++ b/packages/ui/src/components/Datepicker/Datepicker.test.tsx
@@ -4,7 +4,7 @@ import { useRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { DatepickerRef } from "./Datepicker";
 import { Datepicker } from "./Datepicker";
-import { getFormattedDate } from "./helpers";
+import { getFormattedDate, Views } from "./helpers";
 
 describe("Components / Datepicker", () => {
   it("should display today's date by default", () => {
@@ -183,6 +183,24 @@ describe("Components / Datepicker", () => {
     const outsideRange = screen.getByText("2000");
     expect(outsideRange).toBeInstanceOf(HTMLButtonElement);
     expect(outsideRange).toBeDisabled();
+  });
+
+  it("the filter function should allow to disable a certain date", async () => {
+    const today = new Date();
+    const todaysDateInDefaultLanguage = getFormattedDate("en", today);
+
+    const filter = (date: Date, view: Views) => {
+      if (view === Views.Days) {
+        return date === today;
+      }
+      return true;
+    };
+
+    render(<Datepicker filterDate={filter} />);
+
+    await userEvent.click(screen.getByText("Today"));
+
+    expect(screen.getByDisplayValue(todaysDateInDefaultLanguage)).toBeDisabled();
   });
 
   it("should focus the input when ref.current.focus is called", () => {

--- a/packages/ui/src/components/Datepicker/Datepicker.tsx
+++ b/packages/ui/src/components/Datepicker/Datepicker.tsx
@@ -100,6 +100,7 @@ export interface DatepickerProps
   labelTodayButton?: string;
   minDate?: Date;
   maxDate?: Date;
+  filterDate?: (date: Date, view: Views) => boolean;
   language?: string;
   weekStart?: WeekStart;
   onChange?: (date: Date | null) => void;
@@ -127,6 +128,7 @@ export const Datepicker = forwardRef<DatepickerRef, DatepickerProps>((props, ref
     defaultValue,
     minDate,
     maxDate,
+    filterDate,
     language = "en",
     weekStart = WeekStart.Sunday,
     className,
@@ -277,6 +279,7 @@ export const Datepicker = forwardRef<DatepickerRef, DatepickerProps>((props, ref
         language,
         minDate,
         maxDate,
+        filterDate,
         weekStart,
         isOpen,
         setIsOpen,

--- a/packages/ui/src/components/Datepicker/DatepickerContext.tsx
+++ b/packages/ui/src/components/Datepicker/DatepickerContext.tsx
@@ -10,6 +10,7 @@ export interface DatepickerContextValue {
   weekStart: WeekStart;
   minDate?: Date;
   maxDate?: Date;
+  filterDate?: (date: Date, view: Views) => boolean;
   isOpen?: boolean;
   setIsOpen: (isOpen: boolean) => void;
   view: Views;

--- a/packages/ui/src/components/Datepicker/Views/Days.tsx
+++ b/packages/ui/src/components/Datepicker/Views/Days.tsx
@@ -2,7 +2,15 @@
 
 import { twMerge } from "../../../helpers/tailwind-merge";
 import { useDatePickerContext } from "../DatepickerContext";
-import { addDays, getFirstDayOfTheMonth, getFormattedDate, getWeekDays, isDateEqual, isDateInRange } from "../helpers";
+import {
+  addDays,
+  getFirstDayOfTheMonth,
+  getFormattedDate,
+  getWeekDays,
+  isDateEqual,
+  isDateInRange,
+  Views,
+} from "../helpers";
 
 export interface DatepickerViewsDaysTheme {
   header: {
@@ -25,6 +33,7 @@ export function DatepickerViewsDays() {
     weekStart,
     minDate,
     maxDate,
+    filterDate,
     viewDate,
     selectedDate,
     changeSelectedDate,
@@ -51,7 +60,8 @@ export function DatepickerViewsDays() {
           const day = getFormattedDate(language, currentDate, { day: "numeric" });
 
           const isSelected = selectedDate && isDateEqual(selectedDate, currentDate);
-          const isDisabled = !isDateInRange(currentDate, minDate, maxDate);
+          const isDisabled =
+            !isDateInRange(currentDate, minDate, maxDate) || (filterDate && !filterDate(currentDate, Views.Days));
 
           return (
             <button

--- a/packages/ui/src/components/Datepicker/Views/Decades.tsx
+++ b/packages/ui/src/components/Datepicker/Views/Decades.tsx
@@ -16,7 +16,16 @@ export interface DatepickerViewsDecadesTheme {
 }
 
 export function DatepickerViewsDecades() {
-  const { theme: rootTheme, viewDate, selectedDate, minDate, maxDate, setViewDate, setView } = useDatePickerContext();
+  const {
+    theme: rootTheme,
+    viewDate,
+    selectedDate,
+    minDate,
+    maxDate,
+    filterDate,
+    setViewDate,
+    setView,
+  } = useDatePickerContext();
 
   const theme = rootTheme.views.decades;
   const first = startOfYearPeriod(viewDate, 100);
@@ -31,7 +40,9 @@ export function DatepickerViewsDecades() {
         const lastDate = addYears(firstDate, 9);
 
         const isSelected = selectedDate && isDateInDecade(selectedDate, year);
-        const isDisabled = !isDateInRange(firstDate, minDate, maxDate) && !isDateInRange(lastDate, minDate, maxDate);
+        const isDisabled =
+          (!isDateInRange(firstDate, minDate, maxDate) && !isDateInRange(lastDate, minDate, maxDate)) ||
+          (filterDate && !filterDate(newDate, Views.Decades));
 
         return (
           <button

--- a/packages/ui/src/components/Datepicker/Views/Months.tsx
+++ b/packages/ui/src/components/Datepicker/Views/Months.tsx
@@ -20,6 +20,7 @@ export function DatepickerViewsMonth() {
     theme: rootTheme,
     minDate,
     maxDate,
+    filterDate,
     selectedDate,
     viewDate,
     language,
@@ -39,7 +40,8 @@ export function DatepickerViewsMonth() {
         const month = getFormattedDate(language, newDate, { month: "short" });
 
         const isSelected = selectedDate && isDateEqual(selectedDate, newDate);
-        const isDisabled = !isDateInRange(newDate, minDate, maxDate);
+        const isDisabled =
+          !isDateInRange(newDate, minDate, maxDate) || (filterDate && !filterDate(newDate, Views.Months));
 
         return (
           <button

--- a/packages/ui/src/components/Datepicker/Views/Years.tsx
+++ b/packages/ui/src/components/Datepicker/Views/Years.tsx
@@ -16,7 +16,16 @@ export interface DatepickerViewsYearsTheme {
 }
 
 export function DatepickerViewsYears() {
-  const { theme: rootTheme, selectedDate, minDate, maxDate, viewDate, setViewDate, setView } = useDatePickerContext();
+  const {
+    theme: rootTheme,
+    selectedDate,
+    minDate,
+    maxDate,
+    filterDate,
+    viewDate,
+    setViewDate,
+    setView,
+  } = useDatePickerContext();
 
   const theme = rootTheme.views.years;
 
@@ -29,7 +38,8 @@ export function DatepickerViewsYears() {
         newDate.setFullYear(year);
 
         const isSelected = selectedDate && isDateEqual(selectedDate, newDate);
-        const isDisabled = !isDateInRange(newDate, minDate, maxDate);
+        const isDisabled =
+          !isDateInRange(newDate, minDate, maxDate) || (filterDate && !filterDate(newDate, Views.Years));
 
         return (
           <button

--- a/packages/ui/src/components/Datepicker/index.ts
+++ b/packages/ui/src/components/Datepicker/index.ts
@@ -2,5 +2,5 @@ export { Datepicker } from "./Datepicker";
 export type { DatepickerPopupTheme, DatepickerProps, DatepickerTheme } from "./Datepicker";
 export { DatepickerContext, useDatePickerContext } from "./DatepickerContext";
 export type { DatepickerContextValue } from "./DatepickerContext";
-export { getFirstDateInRange, WeekStart } from "./helpers";
+export { getFirstDateInRange, WeekStart, Views } from "./helpers";
 export { datePickerTheme } from "./theme";


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)

# Summary

This PR implements an optional `filterDate` function prop for the Datepicker, allowing specific dates to be disabled across different views. This functionality can be used in combination with the existing min and max date filtering.

I require this behavior for a project, and I also noticed that it has been a long-requested feature (see issue #1201).

# Demo

This demo filters only weekdays in the days view of the datepicker. All other views are left untouched. If defined, the filter function must return true to enable a date, month, or year. The function is called for each element across the different views.

```ts
const filter = (date: Date, view: Views) => {
 if (view === Views.Days) {
  const day = date.getDay();
  return day >= 1 && day <= 5;
 }
 return true;
};

<Datepicker filterDate={filter} />
```

<img width="360" height="463" alt="picker_demo" src="https://github.com/user-attachments/assets/49f54def-943d-4843-94ef-840668749361" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom date filtering in the Datepicker component, allowing you to enable or disable selectable dates based on your own logic.
  * Introduced new Storybook examples demonstrating how to restrict selectable dates to weekdays or even-numbered dates.
  * Added documentation and code examples explaining how to use the new date filtering feature.

* **Bug Fixes**
  * None.

* **Documentation**
  * Expanded the Datepicker documentation with a new section and example for date filtering.

* **Tests**
  * Added tests to verify the correct behavior of the date filtering functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->