### PR TITLE
refactor(setup-init): relax checks on React imports

### DIFF
--- a/.changeset/cute-breads-attack.md
+++ b/.changeset/cute-breads-attack.md
@@ -1,0 +1,7 @@
+---
+"flowbite-react": patch
+---
+
+refactor(setup-init): relax checks on React imports due to IDE formatters removing it if not necessary
+
+- filter out `import React from "react"` from the AST when parsing current and new content


### PR DESCRIPTION
### Description

Relax checks on React imports due to IDE formatters removing it if not necessary which leads to formatting conflict.

### Changes

- [x] filter out `import React from "react"` from the AST when parsing current and new content
