### PR TITLE
Search for `<ThemeInit />` in the project and warn if it's not found

### DIFF
--- a/.changeset/dull-ducks-give.md
+++ b/.changeset/dull-ducks-give.md
@@ -7,4 +7,4 @@ Search for `<ThemeInit />` in the project and warn if it's not found instead of 
 ### Changes
 
 - during commands `build` and `dev` check files content for custom configuration and display a warning if `<ThemeInit />` is not found
-- switch tests `src/cli` `src/helpers` from `vitest` -> `bun:test`
+- switch tests in `src/cli` and `src/helpers` from `vitest` -> `bun:test`

--- a/.changeset/dull-ducks-give.md
+++ b/.changeset/dull-ducks-give.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+Search for `<ThemeInit />` in the project and warn if it's not found instead of warning all the time

--- a/.changeset/dull-ducks-give.md
+++ b/.changeset/dull-ducks-give.md
@@ -3,3 +3,8 @@
 ---
 
 Search for `<ThemeInit />` in the project and warn if it's not found instead of warning all the time
+
+### Changes
+
+- during commands `build` and `dev` check files content for custom configuration and display a warning if `<ThemeInit />` is not found
+- switch tests `src/cli` `src/helpers` from `vitest` -> `bun:test`

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -257,7 +257,7 @@
     "prepack": "clean-package",
     "prepare": "bun run generate-metadata",
     "prepublishOnly": "bun run build",
-    "test": "bun test scripts && vitest",
+    "test": "bun test scripts src/cli src/helpers && vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/ui/scripts/generate-metadata.test.ts
+++ b/packages/ui/scripts/generate-metadata.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { extractClassList, extractDependencyList } from "./generate-metadata";
 
 describe("extractClassList", () => {

--- a/packages/ui/src/cli/commands/setup-config.ts
+++ b/packages/ui/src/cli/commands/setup-config.ts
@@ -3,18 +3,8 @@ import { klona } from "klona/json";
 import { isEqual } from "../../helpers/is-equal";
 import { COMPONENT_TO_CLASS_LIST_MAP } from "../../metadata/class-list";
 import { configFilePath } from "../consts";
+import { createConfig, type Config } from "../utils/create-config";
 import { getTailwindVersion } from "../utils/get-tailwind-version";
-
-export interface Config {
-  $schema: string;
-  components: string[];
-  dark: boolean;
-  path: string;
-  prefix: string;
-  rsc: boolean;
-  tsx: boolean;
-  version: 3 | 4;
-}
 
 /**
  * Sets up the `.flowbite-react/config.json` file in the project.
@@ -22,17 +12,9 @@ export interface Config {
  * This function creates or updates the configuration file with default values and validates existing configurations.
  */
 export async function setupConfig(): Promise<Config> {
-  const defaultConfig: Config = {
-    $schema: "https://unpkg.com/flowbite-react/schema.json",
-    components: [],
-    dark: true,
-    path: "src/components",
-    // TODO: infer from project
-    prefix: "",
-    rsc: true,
-    tsx: true,
+  const defaultConfig = createConfig({
     version: await getTailwindVersion(),
-  };
+  });
   const writeTimeout = 10;
 
   try {
@@ -100,19 +82,6 @@ export async function setupConfig(): Promise<Config> {
     if (!isEqual(config, newConfig) || !isSorted) {
       console.log(`Updating ${configFilePath} file...`);
       setTimeout(() => fs.writeFile(configFilePath, JSON.stringify(newConfig, null, 2)), writeTimeout);
-    }
-
-    if (
-      newConfig.dark !== defaultConfig.dark ||
-      newConfig.prefix !== defaultConfig.prefix ||
-      newConfig.version !== defaultConfig.version
-    ) {
-      // TODO: search for <ThemeInit /> in the project and warn if it's not found
-      console.info(
-        `\n[!] Custom values detected in ${configFilePath}, render <ThemeInit /> at root level of your app to sync runtime with node config values.`,
-        `\n[!] Otherwise, your app will use the default values instead of your custom configuration.`,
-        `\n[!] Example: In case of custom 'prefix' or 'version', the app will not display the correct class names.`,
-      );
     }
 
     return newConfig;

--- a/packages/ui/src/cli/commands/setup-init.ts
+++ b/packages/ui/src/cli/commands/setup-init.ts
@@ -3,7 +3,7 @@ import type { namedTypes } from "ast-types";
 import { parse } from "recast";
 import { initFilePath, initJsxFilePath } from "../consts";
 import { compareNodes } from "../utils/compare-nodes";
-import type { Config } from "./setup-config";
+import type { Config } from "../utils/create-config";
 
 /**
  * Sets up the `.flowbite-react/init.tsx` file in the project.

--- a/packages/ui/src/cli/utils/add-import.test.ts
+++ b/packages/ui/src/cli/utils/add-import.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { addImport } from "./add-import";
 
 describe("addImport", () => {

--- a/packages/ui/src/cli/utils/add-plugin.test.ts
+++ b/packages/ui/src/cli/utils/add-plugin.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { addPlugin } from "./add-plugin";
 
 describe("addPlugin", () => {

--- a/packages/ui/src/cli/utils/add-to-config.test.ts
+++ b/packages/ui/src/cli/utils/add-to-config.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "bun:test";
 import * as recast from "recast";
-import { describe, expect, it } from "vitest";
 import { addToConfig } from "./add-to-config";
 
 describe("addToConfig", () => {

--- a/packages/ui/src/cli/utils/compare-nodes.test.ts
+++ b/packages/ui/src/cli/utils/compare-nodes.test.ts
@@ -1,5 +1,5 @@
+import { describe, expect, it } from "bun:test";
 import { parse } from "recast";
-import { describe, expect, it } from "vitest";
 import { compareNodes } from "./compare-nodes";
 
 describe("compareNodes", () => {

--- a/packages/ui/src/cli/utils/create-config.ts
+++ b/packages/ui/src/cli/utils/create-config.ts
@@ -1,0 +1,24 @@
+export interface Config {
+  $schema: string;
+  components: string[];
+  dark: boolean;
+  path: string;
+  prefix: string;
+  rsc: boolean;
+  tsx: boolean;
+  version: 3 | 4;
+}
+
+export function createConfig(input: Partial<Config> = {}): Config {
+  return {
+    $schema: input.$schema ?? "https://unpkg.com/flowbite-react/schema.json",
+    components: input.components ?? [],
+    dark: input.dark ?? true,
+    path: input.path ?? "src/components",
+    // TODO: infer from project
+    prefix: input.prefix ?? "",
+    rsc: input.rsc ?? true,
+    tsx: input.tsx ?? true,
+    version: input.version ?? 4,
+  };
+}

--- a/packages/ui/src/cli/utils/create-init-logger.test.ts
+++ b/packages/ui/src/cli/utils/create-init-logger.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+import { hasThemeInit } from "./create-init-logger";
+
+describe("hasThemeInit", () => {
+  it("should detect self-closing ThemeInit with space", () => {
+    expect(hasThemeInit("<ThemeInit />")).toBe(true);
+  });
+
+  it("should detect self-closing ThemeInit without space", () => {
+    expect(hasThemeInit("<ThemeInit/>")).toBe(true);
+  });
+
+  it("should detect empty ThemeInit tags", () => {
+    expect(hasThemeInit("<ThemeInit></ThemeInit>")).toBe(true);
+  });
+
+  it("should not detect ThemeInit with content", () => {
+    expect(hasThemeInit("<ThemeInit>some content</ThemeInit>")).toBe(false);
+  });
+
+  it("should not detect partial matches", () => {
+    expect(hasThemeInit("ThemeInit")).toBe(false);
+  });
+
+  it("should handle whitespace variations", () => {
+    expect(hasThemeInit("<ThemeInit   />")).toBe(true);
+    expect(hasThemeInit("<ThemeInit   ></ThemeInit>")).toBe(true);
+  });
+
+  it("should return false for empty content", () => {
+    expect(hasThemeInit("")).toBe(false);
+  });
+
+  it("should handle commented out ThemeInit", () => {
+    expect(hasThemeInit("<!-- <ThemeInit /> -->")).toBe(false);
+    expect(hasThemeInit("{/* <ThemeInit /> */}")).toBe(false);
+    expect(hasThemeInit("// <ThemeInit />")).toBe(false);
+  });
+
+  it("should detect ThemeInit in JSX with children", () => {
+    const content = `
+      import type { PropsWithChildren } from "react";
+      import { ThemeInit } from "../.flowbite-react/init";
+
+      export default function RootLayout({ children }: PropsWithChildren) {
+        return (
+          <html lang="en" suppressHydrationWarning>
+            <body className="bg-white text-gray-600 antialiased dark:bg-gray-900 dark:text-gray-400">
+              <ThemeInit />
+              {children}
+            </body>
+          </html>
+        );
+      }
+    `;
+    expect(hasThemeInit(content)).toBe(true);
+  });
+
+  it("should detect ThemeInit in JSX", () => {
+    const content = `
+      import { ThemeInit } from "../.flowbite-react/init";
+      import { App } from "./App";
+
+      export default function App() {
+        return (
+          <>
+            <ThemeInit />
+            <App />
+          </>
+        );
+      }
+    `;
+    expect(hasThemeInit(content)).toBe(true);
+  });
+
+  it("should not detect ThemeInit in JSX", () => {
+    const content = `
+      import { ThemeInit } from "../.flowbite-react/init";
+      import { App } from "./App";
+
+      export default function App() {
+        return (
+          <>
+            <App />
+          </>
+        );
+      }
+    `;
+    expect(hasThemeInit(content)).toBe(false);
+  });
+
+  it("should detect multiple ThemeInit components", () => {
+    const content = `
+      <ThemeInit />
+      <div>Some content</div>
+      <ThemeInit />
+    `;
+    expect(hasThemeInit(content)).toBe(true);
+  });
+
+  it("should detect ThemeInit with attributes/props", () => {
+    expect(hasThemeInit('<ThemeInit data-testid="theme-init" />')).toBe(true);
+    expect(hasThemeInit('<ThemeInit className="my-class" />')).toBe(true);
+    expect(hasThemeInit('<ThemeInit id="theme" custom={true} />')).toBe(true);
+  });
+
+  it("should detect ThemeInit with newlines between tags", () => {
+    expect(
+      hasThemeInit(`<ThemeInit
+    />`),
+    ).toBe(true);
+    expect(
+      hasThemeInit(`<ThemeInit
+
+    ></ThemeInit>`),
+    ).toBe(true);
+  });
+
+  it("should handle more comment variations", () => {
+    expect(hasThemeInit("/* <ThemeInit /> */")).toBe(false);
+    expect(
+      hasThemeInit(`/**
+     * <ThemeInit />
+     */`),
+    ).toBe(false);
+    expect(hasThemeInit("# <ThemeInit />")).toBe(false);
+  });
+
+  it("should not detect case variations of ThemeInit", () => {
+    expect(hasThemeInit("<themeInit />")).toBe(false);
+    expect(hasThemeInit("<Themeinit />")).toBe(false);
+    expect(hasThemeInit("<THEMEINIT />")).toBe(false);
+  });
+
+  it("should detect ThemeInit in template literals", () => {
+    const content = `
+      const template = \`
+        <div>
+          <ThemeInit />
+        </div>
+      \`;
+    `;
+    expect(hasThemeInit(content)).toBe(true);
+  });
+
+  it("should not detect malformed ThemeInit tags", () => {
+    expect(hasThemeInit("< ThemeInit/>")).toBe(false);
+    expect(hasThemeInit("<ThemeInit/ >")).toBe(false);
+    expect(hasThemeInit("<ThemeInit</ThemeInit>")).toBe(false);
+    expect(hasThemeInit("<<ThemeInit />")).toBe(false);
+  });
+});

--- a/packages/ui/src/cli/utils/create-init-logger.ts
+++ b/packages/ui/src/cli/utils/create-init-logger.ts
@@ -1,0 +1,74 @@
+import { configFilePath, initFilePath, initJsxFilePath } from "../consts";
+import { createConfig, type Config } from "./create-config";
+
+/**
+ * Creates a logger to track and warn about `<ThemeInit />` component usage.
+ *
+ * @param {Config} config - The configuration object used to check
+ */
+export function createInitLogger(config: Config) {
+  const defaultConfig = createConfig();
+
+  return {
+    config,
+    checkedMap: new Map<string, boolean>(),
+    get isCustomConfig() {
+      return (
+        this.config.dark !== defaultConfig.dark ||
+        this.config.prefix !== defaultConfig.prefix ||
+        this.config.version !== defaultConfig.version
+      );
+    },
+    get showWarning() {
+      return this.checkedMap.values().find((value) => value) === undefined;
+    },
+    /**
+     * Checks if `<ThemeInit />` component is used in the given file content
+     *
+     * @param path - The path to the file being checked
+     * @param content - The file content to search in
+     */
+    check(path: string, content: string) {
+      if (this.isCustomConfig) {
+        this.checkedMap.set(path, hasThemeInit(content));
+      }
+    },
+    /**
+     * Logs a warning if `<ThemeInit />` component is not used in the project and the configuration `dark`, `prefix` or `version` differs from default values.
+     */
+    log() {
+      if (this.isCustomConfig && this.showWarning) {
+        console.warn(
+          `\n[!] Custom values detected in ${configFilePath}, render '<ThemeInit />' from ${config.tsx ? initFilePath : initJsxFilePath} at root level of your app to sync runtime with node config values.`,
+          `\n[!] Otherwise, your app will use the default values instead of your custom configuration.`,
+          `\n[!] Example: In case of custom 'prefix' or 'version', the app will not display the correct class names.`,
+        );
+      }
+    },
+  };
+}
+
+/**
+ * Checks if `<ThemeInit />` component is used in the given file content
+ *
+ * @param content - The file content to search in
+ * @returns boolean indicating if ThemeInit is used
+ */
+export function hasThemeInit(content: string): boolean {
+  // First check for commented out ThemeInit
+  if (/(\/\/|<!--|{\/\*|\/\*|\*|#)\s*<ThemeInit/.test(content)) {
+    return false;
+  }
+
+  // Check for malformed tags (space after < or before /, or multiple <)
+  if (/(?:< ThemeInit|<ThemeInit\/ |<<ThemeInit)/.test(content)) {
+    return false;
+  }
+
+  // Check for valid ThemeInit tags with optional attributes
+  // This regex matches:
+  // 1. Opening < followed immediately by ThemeInit
+  // 2. Optional attributes (anything that's not > or />)
+  // 3. Self-closing /> or opening/closing tag pair with only whitespace between
+  return /<ThemeInit(?:\s+[^>/]*)?(?:\/>\s*|>\s*<\/ThemeInit>)/.test(content);
+}

--- a/packages/ui/src/cli/utils/extract-component-imports.test.ts
+++ b/packages/ui/src/cli/utils/extract-component-imports.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { extractComponentImports } from "./extract-component-imports";
 
 describe("extractComponentImports", () => {

--- a/packages/ui/src/cli/utils/get-config.ts
+++ b/packages/ui/src/cli/utils/get-config.ts
@@ -1,4 +1,5 @@
-import { setupConfig, type Config } from "../commands/setup-config";
+import { setupConfig } from "../commands/setup-config";
+import type { Config } from "./create-config";
 
 /**
  * Gets the current configuration by reading and validating the config file.

--- a/packages/ui/src/cli/utils/normalize-path.test.ts
+++ b/packages/ui/src/cli/utils/normalize-path.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { joinNormalizedPath, normalizeImportPath } from "./normalize-path";
 
 describe("normalizeImportPath", () => {

--- a/packages/ui/src/cli/utils/update-build-config.test.ts
+++ b/packages/ui/src/cli/utils/update-build-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { updateBuildConfig } from "./update-build-config";
 
 describe("updateBuildConfig", () => {

--- a/packages/ui/src/cli/utils/wrap-default-export.test.ts
+++ b/packages/ui/src/cli/utils/wrap-default-export.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { wrapDefaultExport } from "./wrap-default-export";
 
 describe("wrapDefaultExport", () => {

--- a/packages/ui/src/helpers/apply-prefix-v3.test.ts
+++ b/packages/ui/src/helpers/apply-prefix-v3.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { applyPrefixV3 } from "./apply-prefix-v3";
 
 describe("applyPrefix_v3", () => {

--- a/packages/ui/src/helpers/apply-prefix.test.ts
+++ b/packages/ui/src/helpers/apply-prefix.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { applyPrefix } from "./apply-prefix";
 
 describe("applyPrefix", () => {

--- a/packages/ui/src/helpers/convert-utilities-to-v4.test.ts
+++ b/packages/ui/src/helpers/convert-utilities-to-v4.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { convertUtilitiesToV4 } from "./convert-utilities-to-v4";
 
 describe("convertUtilitiesV4", () => {

--- a/packages/ui/src/helpers/get.test.ts
+++ b/packages/ui/src/helpers/get.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { get } from "./get";
 
 describe("get helper", () => {

--- a/packages/ui/src/helpers/is-equal.test.ts
+++ b/packages/ui/src/helpers/is-equal.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { isEqual } from "./is-equal";
 
 describe("isEqual helper", () => {

--- a/packages/ui/src/helpers/merge-refs.test.ts
+++ b/packages/ui/src/helpers/merge-refs.test.ts
@@ -1,14 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, mock } from "bun:test";
+import type { RefObject } from "react";
 import { mergeRefs } from "./merge-refs";
 
 describe("mergeRefs", () => {
   it("should handle multiple mutable refs", () => {
-    const ref1 = { current: null };
-    const ref2 = { current: null };
+    const ref1: RefObject<string> = { current: null };
+    const ref2: RefObject<string> = { current: null };
     const value = "test";
 
     const mergedRef = mergeRefs([ref1, ref2]);
-    // @ts-expect-error - bypass
     mergedRef(value);
 
     expect(ref1.current).toBe(value);
@@ -16,7 +16,7 @@ describe("mergeRefs", () => {
   });
 
   it("should handle callback refs", () => {
-    const callbackRef = vi.fn();
+    const callbackRef = mock();
     const value = "test";
 
     const mergedRef = mergeRefs([callbackRef]);
@@ -26,8 +26,8 @@ describe("mergeRefs", () => {
   });
 
   it("should handle mixture of mutable and callback refs", () => {
-    const mutableRef = { current: null };
-    const callbackRef = vi.fn();
+    const mutableRef: RefObject<string> = { current: null };
+    const callbackRef = mock();
     const value = "test";
 
     const mergedRef = mergeRefs([mutableRef, callbackRef]);
@@ -38,11 +38,10 @@ describe("mergeRefs", () => {
   });
 
   it("should handle null and undefined refs", () => {
-    const ref1 = { current: null };
+    const ref1: RefObject<string> = { current: null };
     const value = "test";
 
     const mergedRef = mergeRefs([ref1, null, undefined]);
-    // @ts-expect-error - bypass
     mergedRef(value);
 
     expect(ref1.current).toBe(value);

--- a/packages/ui/src/helpers/resolve-props.test.ts
+++ b/packages/ui/src/helpers/resolve-props.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, mock } from "bun:test";
 import { resolveProps } from "./resolve-props";
 import { withoutThemingProps } from "./without-theming-props";
 
-vi.mock("./without-theming-props", () => ({
-  withoutThemingProps: vi.fn((props) => props),
+mock.module("./without-theming-props", () => ({
+  withoutThemingProps: mock((props) => props),
 }));
 
 describe("resolveProps", () => {
@@ -26,6 +26,7 @@ describe("resolveProps", () => {
     expect(result).toEqual({
       foo: "bar",
       baz: "qux",
+      // @ts-expect-error - bypass
       test: "provider",
     });
   });

--- a/packages/ui/src/helpers/resolve-theme.test.ts
+++ b/packages/ui/src/helpers/resolve-theme.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "bun:test";
 import { setStore } from "../store";
 import { resolveTheme } from "./resolve-theme";
 
@@ -13,6 +13,7 @@ describe("resolveTheme", () => {
 
     expect(resolveTheme([base, custom], [])).toEqual({
       color: "text-red-400",
+      // @ts-expect-error - bypass
       background: "text-blue-400",
     });
   });

--- a/packages/ui/src/helpers/strip-dark.test.ts
+++ b/packages/ui/src/helpers/strip-dark.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import { stripDark } from "./strip-dark";
 
 describe("stripDarkClasses", () => {

--- a/packages/ui/src/helpers/without-theming-props.test.ts
+++ b/packages/ui/src/helpers/without-theming-props.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "bun:test";
 import type { ThemingProps } from "../types";
 import { withoutThemingProps } from "./without-theming-props";
 

--- a/packages/ui/vitest.config.js
+++ b/packages/ui/vitest.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
     setupFiles: "./vitest-setup.ts",
     coverage: {
       include: ["src"],
+      exclude: ["src/cli", "src/helpers"],
     },
   },
 });

--- a/packages/ui/vitest.config.js
+++ b/packages/ui/vitest.config.js
@@ -4,7 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [react()],
   test: {
-    exclude: ["scripts"],
+    exclude: ["scripts", "src/cli", "src/helpers"],
     globals: true,
     environment: "jsdom",
     setupFiles: "./vitest-setup.ts",


### PR DESCRIPTION
### Description

Search for `<ThemeInit />` in the project and warn if it's not found instead of warning all the time

### Issue

#1604

### Changes

- [x] during commands `build` and `dev` check files content for custom configuration and display a warning if `<ThemeInit />` is not found
- [x] switch tests in `src/cli` and `src/helpers` from `vitest` -> `bun:test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved warning behavior for the `<ThemeInit />` component, so warnings are only shown if the component is not present when needed.
  * Enhanced logging to help track and notify about missing `<ThemeInit />` usage in projects with custom theme configurations.

* **Chores**
  * Updated test scripts and configuration to use the Bun testing framework instead of Vitest.
  * Refactored configuration utilities for better consistency and maintainability.
  * Added and improved unit tests for new and existing utilities.

* **Documentation**
  * Added detailed test coverage for theme initialization detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->