### PR TITLE
fix: (node:50743) [DEP0190] DeprecationWarning

### DIFF
--- a/.changeset/plenty-apes-give.md
+++ b/.changeset/plenty-apes-give.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+fix: (node:50743) [DEP0190] DeprecationWarning

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
     "packages/ui": {
       "name": "flowbite-react",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "bin": {
         "flowbite-react": "./dist/cli/bin.js",
       },

--- a/packages/ui/src/cli/utils/exec-command.ts
+++ b/packages/ui/src/cli/utils/exec-command.ts
@@ -1,7 +1,7 @@
 import { spawn, type SpawnOptions } from "child_process";
 
 /**
- * Runs a shell command asynchronously and captures its output.
+ * Runs a command asynchronously and captures its output.
  *
  * @param {string} command - The command to execute (e.g., "npm").
  * @param {string[]} [args=[]] - Arguments for the command (e.g., ["install", "package-name"]).
@@ -15,7 +15,7 @@ export function execCommand(
   options: SpawnOptions = {},
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { ...options, shell: true });
+    const child = spawn(command, args, options);
 
     let stdout = "";
     let stderr = "";

--- a/packages/ui/src/components/Datepicker/Datepicker.test.tsx
+++ b/packages/ui/src/components/Datepicker/Datepicker.test.tsx
@@ -200,7 +200,10 @@ describe("Components / Datepicker", () => {
 
     await userEvent.click(screen.getByRole("textbox"));
 
-    expect(screen.getByText(tomorrow.getDate())).toBeDisabled();
+    const dateButtons = screen.getAllByText(tomorrow.getDate().toString());
+    const disabledButton = dateButtons.find((button) => button.hasAttribute("disabled"));
+    expect(disabledButton).toBeInTheDocument();
+    expect(disabledButton).toBeDisabled();
   });
 
   it("should focus the input when ref.current.focus is called", () => {


### PR DESCRIPTION
### Error

```bash
(node:50743) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

### Changes

- [x] remove `shell: true`
- [x] fix `Datepicker ` test

### Result

**Before**

<img width="833" height="205" alt="Screenshot 2025-07-28 at 11 38 57" src="https://github.com/user-attachments/assets/7dc9bbc0-4603-4302-bd6f-8da072836998" />

**After**

No error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a patch update addressing a Node.js deprecation warning.
  * Updated documentation to clarify command execution behavior.

* **Refactor**
  * Improved command execution utility to allow flexible command running without forced shell usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->