### PR TITLE
Fix `nextjs` plugin to work on all environments

### DIFF
--- a/.changeset/short-candies-warn.md
+++ b/.changeset/short-candies-warn.md
@@ -1,0 +1,10 @@
+---
+"flowbite-react": patch
+---
+
+Fix `nextjs` plugin to work on all environments
+
+## Changes
+
+- fix(ui): `nextjs` plugin to run properly on `NODE_ENV` environments: `production`, `development` and `test`
+- log file writes in `dev`

--- a/.changeset/short-candies-warn.md
+++ b/.changeset/short-candies-warn.md
@@ -8,3 +8,15 @@ Fix `nextjs` plugin to work on all environments
 
 - fix(ui): `nextjs` plugin to run properly on `NODE_ENV` environments: `production`, `development` and `test`
 - log file writes in `dev`
+
+## Breaking changes
+
+`withFlowbiteReact` now always returns async configuration (see: [Async Configuration](https://nextjs.org/docs/app/api-reference/config/next-config-js#async-configuration)) so make sure to wrap any other HOC (higher-order-functions) such as `withContentlayer` because most of them do not forward pass async config arguments (eg: `phase, options`)
+
+```tsx
+// ❌ not working
+export default withContentlayer(withFlowbiteReact(nextConfig));
+
+// ✅ working
+export default withFlowbiteReact(withContentlayer(nextConfig));
+```

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -158,4 +158,4 @@ const nextConfig = {
   },
 };
 
-export default withContentlayer(withFlowbiteReact(nextConfig));
+export default withFlowbiteReact(withContentlayer(nextConfig));

--- a/packages/ui/src/cli/commands/dev.ts
+++ b/packages/ui/src/cli/commands/dev.ts
@@ -63,6 +63,7 @@ export async function dev() {
 
   if (!isEqual(classList, newClassList)) {
     classList = newClassList;
+    console.log(`Generating ${classListFilePath} file...`);
     await fs.writeFile(classListFilePath, JSON.stringify(classList, null, 2));
   }
 
@@ -106,6 +107,7 @@ export async function dev() {
 
     if (!isEqual(classList, newClassList)) {
       classList = newClassList;
+      console.log(`Generating ${classListFilePath} file...`);
       await fs.writeFile(classListFilePath, JSON.stringify(classList, null, 2));
     }
   }


### PR DESCRIPTION
Fix `nextjs` plugin to work on all environments

## Changes

- fix(ui): `nextjs` plugin to run properly on `NODE_ENV` environments: `production`, `development` and `test`
- log file writes in `dev`

## Breaking changes

`withFlowbiteReact` now always returns async configuration (see: [Async Configuration](https://nextjs.org/docs/app/api-reference/config/next-config-js#async-configuration)) so make sure to wrap any other HOC (higher-order-functions) such as `withContentlayer` because most of them do not forward pass async config arguments (eg: `phase, options`)

```tsx
// ❌ not working
export default withContentlayer(withFlowbiteReact(nextConfig));

// ✅ working
export default withFlowbiteReact(withContentlayer(nextConfig));
```
