### PR TITLE
fix(ui/cli/plugins): `setup-plugin-bun` also detect `Bun.build`

### DIFF
--- a/.changeset/many-nights-nail.md
+++ b/.changeset/many-nights-nail.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+fix(ui/cli/plugins): `setup-plugin-bun` also detect `Bun.build`

--- a/apps/web/content/docs/guides/bun.mdx
+++ b/apps/web/content/docs/guides/bun.mdx
@@ -55,13 +55,8 @@ Create a new Bun project with React and Tailwind CSS:
 
 ```bash
 mkdir my-app && cd my-app
-bun init
+bun init --react=tailwind
 ```
-
-When prompted:
-
-- Select "React" for the project template
-- Select "TailwindCSS" for the React template
 
 ### 2. Install Flowbite React
 

--- a/packages/ui/src/cli/utils/update-build-config.test.ts
+++ b/packages/ui/src/cli/utils/update-build-config.test.ts
@@ -90,4 +90,32 @@ describe("updateBuildConfig", () => {
     expect(result).toContain('import customPlugin from "@custom/plugin"');
     expect(result).toMatch(/plugins:\s*\[\s*customPlugin\s*\]/);
   });
+
+  it("should handle config with Bun.build", () => {
+    const input = `
+      import { plugin } from './plugins';
+
+      const result = await Bun.build({
+        entrypoints,
+        outdir,
+        plugins: [plugin],
+        minify: true,
+        target: "browser",
+        sourcemap: "linked",
+        define: {
+          "process.env.NODE_ENV": JSON.stringify("production"),
+        },
+        ...cliConfig,
+      });
+    `;
+
+    const result = updateBuildConfig({
+      content: input,
+      pluginName: "flowbiteReact",
+      pluginImportPath: "flowbite-react/plugin/bun",
+    });
+
+    expect(result).toContain('import flowbiteReact from "flowbite-react/plugin/bun"');
+    expect(result).toMatch(/plugins:\s*\[\s*plugin,\s*flowbiteReact\s*\]/);
+  });
 });

--- a/packages/ui/src/cli/utils/update-build-config.ts
+++ b/packages/ui/src/cli/utils/update-build-config.ts
@@ -40,10 +40,14 @@ export function updateBuildConfig({
     visitCallExpression(path) {
       const { node } = path;
 
-      // Check if this is a build() call
+      // Check if this is a build() or Bun.build() call
       if (
-        node.callee.type === "Identifier" &&
-        node.callee.name === "build" &&
+        ((node.callee.type === "Identifier" && node.callee.name === "build") ||
+          (node.callee.type === "MemberExpression" &&
+            node.callee.object.type === "Identifier" &&
+            node.callee.object.name === "Bun" &&
+            node.callee.property.type === "Identifier" &&
+            node.callee.property.name === "build")) &&
         node.arguments.length > 0 &&
         node.arguments[0].type === "ObjectExpression"
       ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - CLI plugin setup now correctly detects Bun.build configurations, ensuring the Flowbite React Bun plugin is imported and added to the plugins list as expected.

- Tests
  - Added unit tests covering Bun.build-style configurations to validate plugin injection and integration.

- Chores
  - Prepared a patch release entry for Flowbite React, noting improved Bun setup detection in the UI CLI plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->