### PR TITLE
fix(wrapDefaultExport): handle complex multiline exports

### DIFF
--- a/.changeset/better-kings-fail.md
+++ b/.changeset/better-kings-fail.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+fix(wrapDefaultExport): handle complex multiline exports

--- a/packages/ui/src/cli/utils/wrap-default-export.test.ts
+++ b/packages/ui/src/cli/utils/wrap-default-export.test.ts
@@ -105,4 +105,90 @@ export const a = 1;
 module.exports = wrapper(myFunction);`;
     expect(wrapDefaultExport(input, "wrapper").trim()).toBe(expected.trim());
   });
+
+  it("handles complex multiline exports with nested function calls and objects", () => {
+    const input = `import { withHOC } from "./utils";
+import type { Config } from "./types";
+
+const config: Config = {
+  /* config options here */
+};
+
+export default withHOC(config, {
+  feature1: true,
+  feature2: "enabled",
+  callbacks: {
+    onInit: () => console.log("initialized"),
+    onUpdate: (data) => console.log("updated:", data)
+  },
+  options: [
+    { id: 1, value: "first" },
+    { id: 2, value: "second" }
+  ]
+});`;
+
+    const expected = `import { withHOC } from "./utils";
+import type { Config } from "./types";
+
+const config: Config = {
+  /* config options here */
+};
+
+export default wrapper(withHOC(config, {
+  feature1: true,
+  feature2: "enabled",
+  callbacks: {
+    onInit: () => console.log("initialized"),
+    onUpdate: (data) => console.log("updated:", data)
+  },
+  options: [
+    { id: 1, value: "first" },
+    { id: 2, value: "second" }
+  ]
+}));`;
+
+    expect(wrapDefaultExport(input, "wrapper")).toBe(expected);
+  });
+
+  it("handles complex multiline CJS exports with nested function calls and objects", () => {
+    const input = `const { withHOC } = require("./utils");
+
+const config = {
+  /* config options here */
+};
+
+module.exports = withHOC(config, {
+  feature1: true,
+  feature2: "enabled",
+  callbacks: {
+    onInit: () => console.log("initialized"),
+    onUpdate: (data) => console.log("updated:", data)
+  },
+  options: [
+    { id: 1, value: "first" },
+    { id: 2, value: "second" }
+  ]
+});`;
+
+    const expected = `const { withHOC } = require("./utils");
+
+const config = {
+  /* config options here */
+};
+
+module.exports = wrapper(withHOC(config, {
+  feature1: true,
+  feature2: "enabled",
+  callbacks: {
+    onInit: () => console.log("initialized"),
+    onUpdate: (data) => console.log("updated:", data)
+  },
+  options: [
+    { id: 1, value: "first" },
+    { id: 2, value: "second" }
+  ]
+}));`;
+
+    expect(wrapDefaultExport(input, "wrapper")).toBe(expected);
+  });
 });

--- a/packages/ui/src/cli/utils/wrap-default-export.ts
+++ b/packages/ui/src/cli/utils/wrap-default-export.ts
@@ -16,33 +16,75 @@ export function wrapDefaultExport(content: string, withFunction: string): string
 
   let wrappedContent = content;
 
-  // Handle ESM exports
-  if (isESM) {
-    const esmMatch = content.match(/export\s+default\s+(?:class|interface|abstract\s+class)\s+/);
-    if (!esmMatch) {
-      wrappedContent = wrappedContent.replace(
-        /(export\s+default\s+)([^;\n]+(?:{[^}]*})?[^;\n]*)(;?\s*)$/gm,
-        (_, prefix, exportValue, semicolon) => {
-          const trimmedValue = exportValue.trim();
-          return `${prefix}${withFunction}(${trimmedValue})${semicolon}`;
-        },
-      );
-    }
-  }
+  const config = isCJS ? EXPORT_CONFIGS.cjs : EXPORT_CONFIGS.esm;
 
-  // Handle CJS exports
-  if (isCJS) {
-    const cjsMatch = content.match(/module\.exports\s*=\s*(?:class|interface|abstract\s+class)\s+/);
-    if (!cjsMatch) {
-      wrappedContent = wrappedContent.replace(
-        /(module\.exports\s*=\s*)([^;\n]+(?:{[^}]*})?[^;\n]*)(;?\s*)$/gm,
-        (_, prefix, exportValue, semicolon) => {
-          const trimmedValue = exportValue.trim();
-          return `${prefix}${withFunction}(${trimmedValue})${semicolon}`;
-        },
-      );
+  // Skip if it's a class/interface export
+  if (!content.match(config.skipPattern)) {
+    const lastExportMatch = wrappedContent.match(config.matchPattern);
+    if (lastExportMatch) {
+      const [fullMatch, prefix, rest] = lastExportMatch;
+      const { exportValue, restContent } = extractExportValue(rest);
+      const replacement = createWrappedReplacement(prefix, exportValue, withFunction, restContent);
+
+      // Replace only the last occurrence
+      const index = wrappedContent.lastIndexOf(fullMatch);
+      wrappedContent = wrappedContent.slice(0, index) + replacement + wrappedContent.slice(index + fullMatch.length);
     }
   }
 
   return wrappedContent;
+}
+
+const EXPORT_CONFIGS = {
+  esm: {
+    skipPattern: /export\s+default\s+(?:class|interface|abstract\s+class)\s+/,
+    matchPattern: /(export\s+default\s+)([\s\S]*$)/m,
+  },
+  cjs: {
+    skipPattern: /module\.exports\s*=\s*(?:class|interface|abstract\s+class)\s+/,
+    matchPattern: /(module\.exports\s*=\s*)([\s\S]*$)/m,
+  },
+};
+
+/**
+ * Extracts the export value from a string, handling nested structures
+ */
+function extractExportValue(rest: string): { exportValue: string; restContent: string } {
+  let depth = 0;
+  let i = 0;
+
+  // Parse the export value handling nested parentheses and braces
+  for (i = 0; i < rest.length; i++) {
+    const char = rest[i];
+    if (char === "(" || char === "{") depth++;
+    if (char === ")" || char === "}") depth--;
+
+    // Break on semicolon or newline if we're not inside parentheses/braces
+    if (depth === 0 && (char === ";" || char === "\n")) {
+      return {
+        exportValue: rest.slice(0, char === ";" ? i + 1 : i),
+        restContent: rest.slice(char === ";" ? i + 1 : i),
+      };
+    }
+  }
+
+  // If we didn't find a terminator, use the whole rest
+  return {
+    exportValue: rest,
+    restContent: "",
+  };
+}
+
+/**
+ * Creates a wrapped replacement for an export statement
+ */
+function createWrappedReplacement(
+  prefix: string,
+  exportValue: string,
+  withFunction: string,
+  restContent: string,
+): string {
+  const trimmedValue = exportValue.trim();
+  const hasTrailingSemi = trimmedValue.endsWith(";");
+  return `${prefix}${withFunction}(${trimmedValue.replace(/;$/, "")})${hasTrailingSemi ? ";" : ""}${restContent}`;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correct handling of complex multiline default exports across ESM and CommonJS, ensuring proper wrapping without affecting classes or interfaces and preserving surrounding formatting.
* **Tests**
  * Added test coverage for multiline export scenarios in both ESM and CommonJS to prevent regressions.
* **Chores**
  * Added a patch release entry for flowbite-react.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->