### PR TITLE
fix: hide modal close button when not dismissible

### DIFF
--- a/.changeset/social-kings-cut.md
+++ b/.changeset/social-kings-cut.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+Ensure modal close button respects dismissible prop

--- a/packages/ui/src/components/Modal/Modal.test.tsx
+++ b/packages/ui/src/components/Modal/Modal.test.tsx
@@ -26,6 +26,34 @@ describe("Components / Modal", () => {
     expect(modal).not.toBeInTheDocument();
   });
 
+  it("should not render close button when modal is not dismissible", async () => {
+    const user = userEvent.setup();
+
+    render(<TestModal />);
+
+    await user.click(triggerButton());
+
+    const modal = dialog();
+    expect(modal).toBeInTheDocument();
+
+    const closeButton = screen.queryByLabelText("Close");
+    expect(closeButton).not.toBeInTheDocument();
+  });
+
+  it("should render close button when modal is dismissible", async () => {
+    const user = userEvent.setup();
+
+    render(<TestModal dismissible />);
+
+    await user.click(triggerButton());
+
+    const modal = dialog();
+    expect(modal).toBeInTheDocument();
+
+    const closeButton = screen.queryByLabelText("Close");
+    expect(closeButton).toBeInTheDocument();
+  });
+
   it("should append to root element when root prop is provided", async () => {
     const root = document.createElement("div");
     const user = userEvent.setup();
@@ -82,7 +110,7 @@ describe("Components / Modal", () => {
     it("should close `Modal` when `Space` is pressed on any of its buttons", async () => {
       const user = userEvent.setup();
 
-      render(<TestModal />);
+      render(<TestModal dismissible />);
 
       const openButton = triggerButton();
 

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -117,6 +117,7 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>((props, ref) => {
         clearTheme: props.clearTheme,
         applyTheme: props.applyTheme,
         popup,
+        dismissible,
         onClose,
         setHeaderId,
       }}

--- a/packages/ui/src/components/Modal/ModalContext.tsx
+++ b/packages/ui/src/components/Modal/ModalContext.tsx
@@ -6,6 +6,7 @@ import type { ModalTheme } from "./Modal";
 
 export interface ModalContextValue extends ThemingProps<ModalTheme> {
   popup?: boolean;
+  dismissible?: boolean;
   setHeaderId: (id: string | undefined) => void;
   onClose?: () => void;
 }

--- a/packages/ui/src/components/Modal/ModalHeader.tsx
+++ b/packages/ui/src/components/Modal/ModalHeader.tsx
@@ -31,6 +31,7 @@ export const ModalHeader = forwardRef<HTMLDivElement, ModalHeaderProps>((props, 
     clearTheme: rootClearTheme,
     applyTheme: rootApplyTheme,
     popup,
+    dismissible,
     onClose,
     setHeaderId,
   } = useModalContext();
@@ -64,9 +65,11 @@ export const ModalHeader = forwardRef<HTMLDivElement, ModalHeaderProps>((props, 
       <Component id={headerId} className={theme.title}>
         {children}
       </Component>
-      <button aria-label="Close" className={theme.close.base} type="button" onClick={onClose}>
-        <OutlineXIcon aria-hidden className={theme.close.icon} />
-      </button>
+      {dismissible && (
+        <button aria-label="Close" className={theme.close.base} type="button" onClick={onClose}>
+          <OutlineXIcon aria-hidden className={theme.close.icon} />
+        </button>
+      )}
     </div>
   );
 });


### PR DESCRIPTION
## Summary
Fixes the modal close button to only render when the modal is dismissible. Previously, the X button in the modal header would always display, even when `dismissible={false}`, which created a confusing UX where the button appeared but had no effect.

## Changes
- Added `dismissible` prop to `ModalContext` interface
- Updated `Modal` component to pass `dismissible` through context
- Modified `ModalHeader` to conditionally render the close button based on `dismissible` prop
- Added 2 new tests to verify the close button visibility behavior
- Updated existing test to pass `dismissible` prop where needed

## Behavior
- **Before**: Close button always visible in modal header
- **After**: Close button only visible when `dismissible={true}`

## Test Plan
- [x] All existing tests pass (11/11 Modal tests)
- [x] Added test: close button should not render when modal is not dismissible
- [x] Added test: close button should render when modal is dismissible
- [x] Manually verified: modal without `dismissible` prop shows no close button
- [x] Manually verified: modal with `dismissible={true}` shows close button

## Screenshots
N/A - behavioral change only

These follow the project's conventions from the contributing guide, including the commitizen-style prefix and the Claude Code attribution footer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal now supports a dismissible option so the close button is shown or hidden based on configuration.

* **Tests**
  * Added tests to verify the close button is present only when the modal is dismissible and that dismissal via the button behaves correctly.

* **Chores**
  * Added a changelog entry noting the close-button behavior update.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->