### PR TITLE
Fixes layout where title and close button overlap in RTL mode

### DIFF
--- a/.changeset/smooth-points-smile.md
+++ b/.changeset/smooth-points-smile.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+Improve RTL support in the modal component

--- a/packages/ui/src/components/Modal/theme.ts
+++ b/packages/ui/src/components/Modal/theme.ts
@@ -50,7 +50,7 @@ export const modalTheme = createTheme<ModalTheme>({
     },
   },
   footer: {
-    base: "flex items-center space-x-2 rounded-b border-gray-200 p-6 dark:border-gray-600",
+    base: "flex items-center gap-2 rounded-b border-gray-200 p-6 dark:border-gray-600",
     popup: "border-t",
   },
 });


### PR DESCRIPTION
Fixes layout where title and close button overlap in RTL mode
Uses logical CSS property for text direction

<img width="1680" height="1050" alt="Screenshot 2025-12-16 at 11 16 02 PM" src="https://github.com/user-attachments/assets/4c1deea7-47db-42a9-ae98-a150976d7b99" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted modal header close button alignment and footer spacing for more consistent layout.
* **Bug Fixes**
  * Improved RTL support in the modal for better behavior in right-to-left languages.
* **Chores**
  * Added a changeset marking a patch release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->