### PR TITLE
Fix CLI crash when using custom config (dark: false)

### DIFF
--- a/.changeset/twelve-dogs-refuse.md
+++ b/.changeset/twelve-dogs-refuse.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+Fix CLI crash by safely iterating over Map values in init logger

--- a/packages/ui/src/cli/utils/create-init-logger.ts
+++ b/packages/ui/src/cli/utils/create-init-logger.ts
@@ -20,8 +20,16 @@ export function createInitLogger(config: Config) {
       );
     },
     get showWarning() {
-      return this.checkedMap.size > 0 &&
-         !Array.from(this.checkedMap.values()).some(Boolean);
+      let hasChecked = false;
+
+      for (const value of this.checkedMap.values()) {
+        if (value) {
+          hasChecked = true;
+          break;
+        }
+      }
+
+      return !hasChecked;
     },
     /**
      * Checks if `<ThemeInit />` component is used in the given file content


### PR DESCRIPTION
### Summary

The Flowbite React CLI could crash at runtime when a custom configuration
was used (e.g. `dark: false`). This triggers the CLI to evaluate the
`<ThemeInit />` warning logic, where an array method was incorrectly called
on a `MapIterator`.

### Fix

- Safely evaluate `checkedMap` values without calling array methods on a `MapIterator`
- Only run the warning logic after at least one file has been checked

```js
this.checkedMap.size > 0 &&
!Array.from(this.checkedMap.values()).some(Boolean)
```

### Verification
Built the package and tested it in a Next.js project where the CLI previously
crashed with `dark: false`. The issue no longer occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a CLI crash and improved warning display so warnings appear only when appropriate.

* **Documentation**
  * Added a changelog entry and a small patch version update for a UI dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->