### PR TITLE
fix: use inline-flex instead of flex in Badge base class

### DIFF
--- a/packages/ui/src/components/Badge/theme.ts
+++ b/packages/ui/src/components/Badge/theme.ts
@@ -3,7 +3,7 @@ import type { BadgeTheme } from "./Badge";
 
 export const badgeTheme = createTheme<BadgeTheme>({
   root: {
-    base: "flex h-fit items-center gap-1 font-semibold",
+    base: "inline-flex h-fit items-center gap-1 font-semibold",
     color: {
       info: "bg-cyan-100 text-cyan-800 hover:bg-cyan-200 dark:bg-cyan-200 dark:text-cyan-800 dark:hover:bg-cyan-300",
       gray: "bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600",


### PR DESCRIPTION
## Summary

Fixed issue #1614: Badge component was using `flex` as the base display class, which caused it to expand to full width when placed inside a normal div. Changed to `inline-flex` to maintain proper inline behavior.

## Changes

- Changed `flex` to `inline-flex` in the Badge theme base class

## Verification

- Built the project successfully
- All existing Badge tests pass

## Related Issue

Closes #1614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Badge component layout behavior to improve rendering and spacing in various contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->