### PR TITLE
fix(datepicker): display raw day numbers for all locales

### DIFF
--- a/.changeset/datepicker-day-locale.md
+++ b/.changeset/datepicker-day-locale.md
@@ -1,0 +1,8 @@
+---
+"flowbite-react": patch
+---
+
+fix(datepicker): display raw day numbers for all locales
+
+Replace locale-formatted day labels with `Date.getDate()` to avoid
+language-specific suffixes (e.g. "日" in Japanese) in calendar cells.

--- a/packages/ui/src/components/Datepicker/Views/Days.tsx
+++ b/packages/ui/src/components/Datepicker/Views/Days.tsx
@@ -5,7 +5,6 @@ import { useDatePickerContext } from "../DatepickerContext";
 import {
   addDays,
   getFirstDayOfTheMonth,
-  getFormattedDate,
   getWeekDays,
   isDateEqual,
   isDateInRange,
@@ -59,7 +58,7 @@ export function DatepickerViewsDays() {
       <div className={theme.items.base}>
         {[...Array(42)].map((_date, index) => {
           const currentDate = addDays(startDate, index);
-          const day = getFormattedDate(language, currentDate, { day: "numeric" });
+          const day = currentDate.getDate();
 
           const isSelected = selectedDate && isDateEqual(selectedDate, currentDate);
           const isDisabled =


### PR DESCRIPTION
## Summary
- Use `Date.getDate()` instead of `Intl.DateTimeFormat({ day: "numeric" })` for calendar day cells
- Fixes locale suffixes appearing in day numbers (e.g. "1日" in ja-JP, "1일" in ko-KR)
- Calendar UIs universally display bare numbers — this matches standard datepicker behavior

## Changes
- `packages/ui/src/components/Datepicker/Views/Days.tsx`: Replace `getFormattedDate()` call with `currentDate.getDate()`
- Remove unused `getFormattedDate` import

## Test plan
- [ ] Verify datepicker renders bare numbers (1-31) for default locale
- [ ] Verify datepicker renders bare numbers for ja-JP, zh-CN, ko-KR locales
- [ ] Verify no visual regression on other datepicker views (months, years)

Fixes #1453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Datepicker calendar cells now display plain numeric day values (e.g., "1", "2") instead of locale-formatted day labels that could include language-specific suffixes.

* **Chores**
  * Added a patch release entry to mark this Datepicker day-label change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->