### PR TITLE
fix(modal): resolve mobile viewport height and centering issues

### DIFF
--- a/.changeset/modal-mobile-viewport.md
+++ b/.changeset/modal-mobile-viewport.md
@@ -1,0 +1,8 @@
+---
+"flowbite-react": patch
+---
+
+fix(modal): resolve mobile viewport height and centering issues
+
+Replace `h-screen` with `h-full` and add `flex flex-col` to modal
+content for proper layout on mobile viewports.

--- a/packages/ui/src/components/Modal/theme.ts
+++ b/packages/ui/src/components/Modal/theme.ts
@@ -3,7 +3,7 @@ import type { ModalTheme } from "./Modal";
 
 export const modalTheme = createTheme<ModalTheme>({
   root: {
-    base: "fixed inset-x-0 top-0 z-50 h-screen overflow-y-auto overflow-x-hidden md:inset-0 md:h-full",
+    base: "fixed inset-x-0 top-0 z-50 h-full overflow-y-auto overflow-x-hidden md:inset-0 md:h-full",
     show: {
       on: "flex bg-gray-900/50 dark:bg-gray-900/80",
       off: "hidden",
@@ -33,7 +33,7 @@ export const modalTheme = createTheme<ModalTheme>({
     },
   },
   content: {
-    base: "relative h-full w-full p-4 md:h-auto",
+    base: "relative h-full w-full p-4 md:h-auto flex flex-col",
     inner: "relative flex max-h-[90dvh] flex-col rounded-lg bg-white shadow dark:bg-gray-700",
   },
   body: {

--- a/packages/ui/src/components/Modal/theme.ts
+++ b/packages/ui/src/components/Modal/theme.ts
@@ -33,7 +33,7 @@ export const modalTheme = createTheme<ModalTheme>({
     },
   },
   content: {
-    base: "relative h-full w-full p-4 md:h-auto flex flex-col",
+    base: "relative flex h-full w-full flex-col p-4 md:h-auto",
     inner: "relative flex max-h-[90dvh] flex-col rounded-lg bg-white shadow dark:bg-gray-700",
   },
   body: {


### PR DESCRIPTION
## Summary
- Replace `h-screen` with `h-full` on modal root to fix mobile browser viewport issues
- Add `flex flex-col` to `content.base` for proper content layout and centering
- On mobile browsers, `100vh` (and even `100dvh`) includes the area behind the toolbar, causing the close button to be cut off and modals to appear misaligned

## Changes
- `packages/ui/src/components/Modal/theme.ts`:
  - `root.base`: `h-screen` → `h-full` (fixes mobile viewport overflow)
  - `content.base`: Added `flex flex-col` (enables proper vertical content distribution)

## Root Cause
Mobile browsers (iOS Safari, Chrome, Firefox) report `100vh` as larger than the visible viewport because it includes the browser chrome (toolbar/address bar). This causes:
1. Modal close button cut off above viewport
2. Modal not vertically centered
3. Bottom padding/rounding disappearing on long content

## Test plan
- [ ] Verify modal displays correctly on iOS Safari
- [ ] Verify modal displays correctly on iOS Chrome
- [ ] Verify modal close button is accessible on mobile
- [ ] Verify modal centers vertically with `position="center"`
- [ ] Verify no regression on desktop browsers
- [ ] Verify long-content modals scroll correctly on mobile

Fixes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Modal layout on mobile now sizes and centers correctly within the viewport by adjusting root height handling.

* **Style**
  * Modal content now uses a column flex layout for more consistent stacking, spacing, and responsive behavior across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->