### PR TITLE
fix: show page number when totalPages equals 1 in Pagination

### DIFF
--- a/packages/ui/src/components/Pagination/helpers.test.ts
+++ b/packages/ui/src/components/Pagination/helpers.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 import { range } from "./helpers";
 
 describe("Helpers / Range", () => {
-  it("should return the empty list, given start >= end", () => {
+  it("should return the empty list, given start > end", () => {
     expect(range(20, 10)).toEqual([]);
-    expect(range(10, 10)).toEqual([]);
+  });
+
+  it("should return a single element when start equals end", () => {
+    expect(range(10, 10)).toEqual([10]);
   });
 
   it("should return every number from start to end, inclusive, given start < end", () => {

--- a/packages/ui/src/components/Pagination/helpers.ts
+++ b/packages/ui/src/components/Pagination/helpers.ts
@@ -10,7 +10,7 @@
  * ```
  */
 export function range(start: number, end: number): number[] {
-  if (start >= end) {
+  if (start > end) {
     return [];
   }
 


### PR DESCRIPTION
## Summary

Fixes issue #1048 - "Pagination is broken if there is only one page".

The `range()` helper was returning an empty array when `start >= end`, but it should return a single element when `start === end` (i.e., when `totalPages = 1`).

## Changes

- Modified `helpers.ts`: Changed condition from `start >= end` to `start > end`
- Updated test to verify edge case behavior

## Verification

Tested manually:
- `range(1, 1)` returns `[1]` (single page) ✓
- `range(1, 5)` returns `[1, 2, 3, 4, 5]` (normal case) ✓
- `range(20, 10)` returns `[]` (invalid range) ✓

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pagination range calculation to properly handle boundary conditions where start and end values are equal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->