### PR TITLE
feat(Datepicker): add outOfMonth styling for days outside current month

### DIFF
--- a/packages/ui/src/components/Datepicker/Views/Days.tsx
+++ b/packages/ui/src/components/Datepicker/Views/Days.tsx
@@ -25,6 +25,7 @@ export interface DatepickerViewsDaysTheme {
       selected: string;
       disabled: string;
       today: string;
+      outOfMonth: string;
     };
   };
 }
@@ -65,6 +66,7 @@ export function DatepickerViewsDays() {
           const isDisabled =
             !isDateInRange(currentDate, minDate, maxDate) || (filterDate && !filterDate(currentDate, Views.Days));
           const isToday = isDateToday(currentDate);
+          const isOutOfMonth = currentDate.getMonth() !== viewDate.getMonth();
 
           return (
             <button
@@ -73,6 +75,7 @@ export function DatepickerViewsDays() {
               type="button"
               className={twMerge(
                 theme.items.item.base,
+                isOutOfMonth && theme.items.item.outOfMonth,
                 isToday && theme.items.item.today,
                 isSelected && theme.items.item.selected,
                 isDisabled && theme.items.item.disabled,

--- a/packages/ui/src/components/Datepicker/theme.ts
+++ b/packages/ui/src/components/Datepicker/theme.ts
@@ -50,9 +50,11 @@ export const datePickerTheme = createTheme<DatepickerTheme>({
           selected: "bg-primary-700 text-white hover:bg-primary-600",
           disabled: "text-gray-500",
           today: "",
+          outOfMonth: "text-gray-400 hover:bg-gray-100 dark:text-gray-500 dark:hover:bg-gray-600",   
         },
       },
     },
+    
     months: {
       items: {
         base: "grid w-64 grid-cols-4",


### PR DESCRIPTION


Changes

- Added `outOfMonth` class support in `DatepickerViewsDaysTheme`
- Added logic to detect `isOutOfMonth` in `Days.tsx`
- Added default styling for out-of-month days (lighter color, consistent with Flowbite design)

This allows users to easily distinguish days from the previous/next month in the calendar grid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Out-of-month dates in the datepicker are now visually distinguished with muted styling to improve calendar readability and navigation clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->