### PR TITLE
fix(deps): replace tailwind-merge aliases with peer dependency

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -274,9 +274,7 @@
     "klona": "2.0.6",
     "magic-string": "0.30.21",
     "oxc-parser": "0.112.0",
-    "package-manager-detector": "1.6.0",
-    "tailwind-merge-v2": "npm:tailwind-merge@2.6.1",
-    "tailwind-merge-v3": "npm:tailwind-merge@3.4.0"
+    "package-manager-detector": "1.6.0"
   },
   "devDependencies": {
     "@farmfe/core": "1.7.11",
@@ -313,6 +311,7 @@
   "peerDependencies": {
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19",
+    "tailwind-merge": "^2 || ^3",
     "tailwindcss": "^3 || ^4"
   },
   "clean-package": {

--- a/packages/ui/src/helpers/tailwind-merge.ts
+++ b/packages/ui/src/helpers/tailwind-merge.ts
@@ -1,21 +1,17 @@
-import { extendTailwindMerge as extendTailwindMerge_v2 } from "tailwind-merge-v2";
-import { extendTailwindMerge as extendTailwindMerge_v3, type ClassNameValue } from "tailwind-merge-v3";
-import { getPrefix, getVersion } from "../store";
+import { extendTailwindMerge, type ClassNameValue } from "tailwind-merge";
+import { getPrefix } from "../store";
 
-const cache = new Map<string | undefined, ReturnType<typeof extendTailwindMerge_v3>>();
+const cache = new Map<string | undefined, ReturnType<typeof extendTailwindMerge>>();
 
 export function twMerge(...classLists: ClassNameValue[]): string {
   const prefix = getPrefix();
-  const version = getVersion();
-
-  const cacheKey = `${prefix}.${version}`;
-  const cacheValue = cache.get(cacheKey);
+  const cacheValue = cache.get(prefix);
 
   if (cacheValue) {
     return cacheValue(...classLists);
   }
 
-  const twMergeFn = (version === 3 ? extendTailwindMerge_v2 : extendTailwindMerge_v3)({
+  const twMergeFn = extendTailwindMerge({
     extend: {
       classGroups: {
         "bg-image": ["bg-arrow-down-icon", "bg-check-icon", "bg-dash-icon", "bg-dot-icon"],
@@ -24,7 +20,7 @@ export function twMerge(...classLists: ClassNameValue[]): string {
     },
     prefix,
   });
-  cache.set(cacheKey, twMergeFn);
+  cache.set(prefix, twMergeFn);
 
   return twMergeFn(...classLists);
 }


### PR DESCRIPTION
## Summary

- Removes `tailwind-merge-v2` and `tailwind-merge-v3` aliased dependencies from `packages/ui/package.json`
- Adds `tailwind-merge` as a peer dependency (`^2 || ^3`)
- Updates `src/helpers/tailwind-merge.ts` to import from `tailwind-merge` directly

## Motivation

`tailwind-merge-v2` and `tailwind-merge-v3` are malicious packages on the npm registry (GHSA-53q4-wj32-3vv9, GHSA-3679-84c2-v5xm). Although npm aliases prevented the malicious packages from ever being installed, security scanners (GitHub Advanced Security, npm audit) read the package names from `package.json` and flag any downstream project that uses flowbite-react — blocking PRs in corporate environments.

Fixes the concern raised in #1665.

## Breaking change

`tailwind-merge` must now be installed explicitly:
- Tailwind CSS v3 users: `npm install tailwind-merge@^2`
- Tailwind CSS v4 users: `npm install tailwind-merge@^3`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `tailwind-merge` dependency structure. The package now requires `tailwind-merge` (v2 or v3) as a peer dependency, giving consumers flexibility in version selection. Simplified internal dependency resolution logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/themesberg/flowbite-react/pull/1675)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->