### PR TITLE
feat(timeline): allow custom point markers

### DIFF
--- a/.changeset/gentle-timelines-share.md
+++ b/.changeset/gentle-timelines-share.md
@@ -1,0 +1,5 @@
+---
+"flowbite-react": patch
+---
+
+Allow `TimelinePoint` to render custom point markers.

--- a/apps/web/content/docs/components/timeline.mdx
+++ b/apps/web/content/docs/components/timeline.mdx
@@ -25,6 +25,12 @@ Use this example to show the timeline component and the child components in a ve
 
 <Example name="timeline.vertical" />
 
+## Activity log
+
+Use a custom point marker such as an avatar to display activity feeds and user events.
+
+<Example name="timeline.activityLog" />
+
 ## Horizontal timeline
 
 Use the `horizontal` prop to show the timeline component and the child components in a horizontal alignment.

--- a/apps/web/examples/timeline/index.ts
+++ b/apps/web/examples/timeline/index.ts
@@ -1,3 +1,4 @@
+export { activityLog } from "./timeline.activityLog";
 export { horizontal } from "./timeline.horizontal";
 export { root } from "./timeline.root";
 export { vertical } from "./timeline.vertical";

--- a/apps/web/examples/timeline/timeline.activityLog.tsx
+++ b/apps/web/examples/timeline/timeline.activityLog.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import {
+  Avatar,
+  Timeline,
+  TimelineBody,
+  TimelineContent,
+  TimelineItem,
+  TimelinePoint,
+  TimelineTime,
+  TimelineTitle,
+} from "flowbite-react";
+import type { CodeData } from "~/components/code-demo";
+
+const code = `
+"use client";
+
+import {
+  Avatar,
+  Timeline,
+  TimelineBody,
+  TimelineContent,
+  TimelineItem,
+  TimelinePoint,
+  TimelineTime,
+  TimelineTitle,
+} from "flowbite-react";
+
+export function Component() {
+  return (
+    <Timeline>
+      <TimelineItem>
+        <TimelinePoint>
+          <Avatar rounded size="xs" img="/images/people/profile-picture-1.jpg" />
+        </TimelinePoint>
+        <TimelineContent>
+          <TimelineTime>just now</TimelineTime>
+          <TimelineTitle>Bonnie Green uploaded a new file</TimelineTitle>
+          <TimelineBody>Flowbite-react.fig was added to the project assets.</TimelineBody>
+        </TimelineContent>
+      </TimelineItem>
+      <TimelineItem>
+        <TimelinePoint>
+          <Avatar rounded size="xs" img="/images/people/profile-picture-2.jpg" />
+        </TimelinePoint>
+        <TimelineContent>
+          <TimelineTime>2 hours ago</TimelineTime>
+          <TimelineTitle>Jese Leos commented on your post</TimelineTitle>
+          <TimelineBody>Looks good to me. The dashboard cards are ready for review.</TimelineBody>
+        </TimelineContent>
+      </TimelineItem>
+    </Timeline>
+  );
+}
+`;
+
+export function Component() {
+  return (
+    <Timeline>
+      <TimelineItem>
+        <TimelinePoint>
+          <Avatar rounded size="xs" img="/images/people/profile-picture-1.jpg" />
+        </TimelinePoint>
+        <TimelineContent>
+          <TimelineTime>just now</TimelineTime>
+          <TimelineTitle>Bonnie Green uploaded a new file</TimelineTitle>
+          <TimelineBody>Flowbite-react.fig was added to the project assets.</TimelineBody>
+        </TimelineContent>
+      </TimelineItem>
+      <TimelineItem>
+        <TimelinePoint>
+          <Avatar rounded size="xs" img="/images/people/profile-picture-2.jpg" />
+        </TimelinePoint>
+        <TimelineContent>
+          <TimelineTime>2 hours ago</TimelineTime>
+          <TimelineTitle>Jese Leos commented on your post</TimelineTitle>
+          <TimelineBody>Looks good to me. The dashboard cards are ready for review.</TimelineBody>
+        </TimelineContent>
+      </TimelineItem>
+    </Timeline>
+  );
+}
+
+export const activityLog: CodeData = {
+  type: "single",
+  code: {
+    fileName: "index",
+    language: "tsx",
+    code,
+  },
+  githubSlug: "timeline/timeline.activityLog.tsx",
+  component: <Component />,
+};

--- a/packages/ui/src/components/Timeline/Timeline.test.tsx
+++ b/packages/ui/src/components/Timeline/Timeline.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ThemeProvider } from "../../theme/provider";
 import type { CustomFlowbiteTheme } from "../../types";
+import { Avatar } from "../Avatar";
 import type { TimelineProps } from "./Timeline";
 import { Timeline } from "./Timeline";
 import { TimelineBody } from "./TimelineBody";
@@ -60,6 +61,14 @@ describe("Components / Timeline", () => {
 
       expect(timelinePoint()).toBeInTheDocument();
       expect(timelinePoint().childNodes[0]).toContainHTML("svg");
+    });
+
+    it("should render children as the point marker", () => {
+      render(<TestTimelineWithCustomPoint />);
+
+      expect(timelinePoint()).toBeInTheDocument();
+      expect(timelinePoint().childNodes).toHaveLength(1);
+      expect(screen.getByTestId("flowbite-avatar")).toBeInTheDocument();
     });
 
     it("should use `vertical` classes of content if provided", () => {
@@ -128,6 +137,26 @@ function TestTimelineWithIcon({ horizontal, className }: TimelineProps): JSX.Ele
     <Timeline horizontal={horizontal} className={className}>
       <TimelineItem>
         <TimelinePoint icon={IconSVG} />
+        <TimelineContent>
+          <TimelineTime>February 2022</TimelineTime>
+          <TimelineTitle>Application UI code in Tailwind CSS</TimelineTitle>
+          <TimelineBody>
+            Get access to over 20+ pages including a dashboard layout, charts, kanban board, calendar, and pre-order
+            E-commerce & Marketing pages.
+          </TimelineBody>
+        </TimelineContent>
+      </TimelineItem>
+    </Timeline>
+  );
+}
+
+function TestTimelineWithCustomPoint(): JSX.Element {
+  return (
+    <Timeline>
+      <TimelineItem>
+        <TimelinePoint>
+          <Avatar rounded size="xs" img="/images/people/profile-picture-1.jpg" />
+        </TimelinePoint>
         <TimelineContent>
           <TimelineTime>February 2022</TimelineTime>
           <TimelineTitle>Application UI code in Tailwind CSS</TimelineTitle>

--- a/packages/ui/src/components/Timeline/TimelinePoint.tsx
+++ b/packages/ui/src/components/Timeline/TimelinePoint.tsx
@@ -67,8 +67,9 @@ export const TimelinePoint = forwardRef<HTMLDivElement, TimelinePointProps>((pro
       className={twMerge(horizontal && theme.horizontal, !horizontal && theme.vertical, className)}
       {...restProps}
     >
-      {children}
-      {Icon ? (
+      {children ? (
+        <span className={twMerge(theme.marker.icon.wrapper)}>{children}</span>
+      ) : Icon ? (
         <span className={twMerge(theme.marker.icon.wrapper)}>
           <Icon aria-hidden className={twMerge(theme.marker.icon.base)} />
         </span>


### PR DESCRIPTION
## Summary

- Allow `TimelinePoint` to render custom children as the point marker
- Add a test covering Avatar usage inside `TimelinePoint`
- Add an activity log example to the Timeline docs

Closes #1276

## Tests

- `vitest run src/components/Timeline/Timeline.test.tsx`
- `bun run build:ui`
- `prettier --check ...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeline now supports rendering custom point markers (e.g., avatars) in place of icons.

* **Documentation**
  * Added an "Activity log" section to the Timeline docs with a usage example.

* **Examples**
  * Added an Activity Log example to the Timeline examples export.

* **Tests**
  * Added test coverage verifying custom point marker rendering in Timeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/themesberg/flowbite-react/pull/1676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->