### PR TITLE
fix(Pagination): single-page pagination bug

### DIFF
--- a/packages/ui/src/components/Pagination/Pagination.test.tsx
+++ b/packages/ui/src/components/Pagination/Pagination.test.tsx
@@ -182,7 +182,6 @@ describe("Pagination", () => {
       expect(pages()[0]).toBe(1);
     });
 
-
     it("should change previous and next text when provided", () => {
       render(
         <Pagination

--- a/packages/ui/src/components/Pagination/Pagination.test.tsx
+++ b/packages/ui/src/components/Pagination/Pagination.test.tsx
@@ -176,6 +176,12 @@ describe("Pagination", () => {
 
       expect(pages()).toHaveLength(0);
     });
+    it("should render page 1 when totalPages is 1", () => {
+      render(<Pagination currentPage={1} totalPages={1} onPageChange={() => undefined} />);
+      expect(pages()).toHaveLength(1);
+      expect(pages()[0]).toBe(1);
+    });
+
 
     it("should change previous and next text when provided", () => {
       render(

--- a/packages/ui/src/components/Pagination/Pagination.tsx
+++ b/packages/ui/src/components/Pagination/Pagination.tsx
@@ -66,6 +66,13 @@ export interface TablePaginationProps extends BasePaginationProps {
 
 export type PaginationProps = DefaultPaginationProps | TablePaginationProps;
 
+/**
+ * Top-level Pagination component. Switches between Default and Table variants
+ * based on the `layout` prop.
+ * @param props - Discriminated union of DefaultPaginationProps and TablePaginationProps.
+ * @param ref - Ref forwarded to the underlying nav element.
+ * @returns The rendered pagination navigation.
+ */
 export const Pagination = forwardRef<HTMLElement, PaginationProps>((props, ref) => {
   if (props.layout === "table") return <TablePagination {...props} ref={ref} />;
   return <DefaultPagination {...props} ref={ref} />;

--- a/packages/ui/src/components/Pagination/Pagination.tsx
+++ b/packages/ui/src/components/Pagination/Pagination.tsx
@@ -71,6 +71,12 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>((props, ref) 
   return <DefaultPagination {...props} ref={ref} />;
 });
 
+/**
+ * Default pagination component.
+ * @param props - Pagination props (currentPage, totalPages, layout, etc.)
+ * @param ref - Ref to the nav element.
+ * @returns The rendered navigation component.
+ */
 const DefaultPagination = forwardRef<HTMLElement, DefaultPaginationProps>((props, ref) => {
   const provider = useThemeProvider();
   const theme = useResolveTheme(
@@ -162,6 +168,12 @@ const DefaultPagination = forwardRef<HTMLElement, DefaultPaginationProps>((props
   );
 });
 
+/**
+ * Table pagination component.
+ * @param props - Pagination props (currentPage, itemsPerPage, totalItems, etc.)
+ * @param ref - Ref to the nav element.
+ * @returns The rendered navigation component.
+ */
 const TablePagination = forwardRef<HTMLElement, TablePaginationProps>((props, ref) => {
   const provider = useThemeProvider();
   const theme = useResolveTheme(

--- a/packages/ui/src/components/Pagination/Pagination.tsx
+++ b/packages/ui/src/components/Pagination/Pagination.tsx
@@ -102,6 +102,7 @@ const DefaultPagination = forwardRef<HTMLElement, DefaultPaginationProps>((props
 
   const lastPage = Math.min(Math.max(layout === "pagination" ? currentPage + 2 : currentPage + 4, 5), totalPages);
   const firstPage = Math.max(1, lastPage - 4);
+  const lastPageInRange = Math.max(lastPage, firstPage);
 
   function goToNextPage() {
     onPageChange(Math.min(currentPage + 1, totalPages));
@@ -125,16 +126,27 @@ const DefaultPagination = forwardRef<HTMLElement, DefaultPaginationProps>((props
           </PaginationNavigation>
         </li>
         {layout === "pagination" &&
-          range(firstPage, lastPage).map((page: number) => (
-            <li aria-current={page === currentPage ? "page" : undefined} key={page}>
-              {renderPaginationButton({
-                className: twMerge(theme.pages.selector.base, currentPage === page && theme.pages.selector.active),
-                active: page === currentPage,
-                onClick: () => onPageChange(page),
-                children: page,
-              })}
-            </li>
-          ))}
+          (totalPages <= 5
+            ? Array.from({ length: totalPages }, (_, i) => i + 1).map((page: number) => (
+                <li aria-current={page === currentPage ? "page" : undefined} key={page}>
+                  {renderPaginationButton({
+                    className: twMerge(theme.pages.selector.base, currentPage === page && theme.pages.selector.active),
+                    active: page === currentPage,
+                    onClick: () => onPageChange(page),
+                    children: page,
+                  })}
+                </li>
+              ))
+            : range(firstPage, lastPageInRange).map((page: number) => (
+                <li aria-current={page === currentPage ? "page" : undefined} key={page}>
+                  {renderPaginationButton({
+                    className: twMerge(theme.pages.selector.base, currentPage === page && theme.pages.selector.active),
+                    active: page === currentPage,
+                    onClick: () => onPageChange(page),
+                    children: page,
+                  })}
+                </li>
+              )))}
         <li>
           <PaginationNavigation
             className={twMerge(theme.pages.next.base, showIcon && theme.pages.showIcon)}


### PR DESCRIPTION
Fixes issue #1048 where pagination failed to render a single page. Includes regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination rendering to prevent empty/invalid page lists in edge cases by clamping the rendered range.
  * Improved page-button generation so totals of 5 or fewer display all pages, while larger totals use a bounded range.
* **Tests**
  * Added coverage for the single-page scenario to ensure exactly one page item renders and shows `1`.
* **Documentation**
  * Added/updated JSDoc comments for the pagination components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->