### PR TITLE
fix: point PR template contributing link at .github/CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-- [ ] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/CONTRIBUTING.md#your-first-code-contribution)
+- [ ] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/.github/CONTRIBUTING.md#your-first-code-contribution)
 
 Summarize the changes made and the motivation behind them.
 


### PR DESCRIPTION
- [x] I have followed the [Your First Code Contribution section of the Contributing guide](https://github.com/themesberg/flowbite-react/blob/main/.github/CONTRIBUTING.md#your-first-code-contribution)

The PR template's first checkbox links to `CONTRIBUTING.md#your-first-code-contribution`, which 404s because the contributing guide lives at `.github/CONTRIBUTING.md` (GitHub does not redirect the root path to `.github/`). This fixes the link path so the checkbox resolves to the existing guide.

No related issue. No breaking API changes.

Verified: `https://github.com/themesberg/flowbite-react/blob/main/.github/CONTRIBUTING.md#your-first-code-contribution` returns 200; the old root path returns 404.
